### PR TITLE
Add AGENTS.md and improve hub seed fallbacks and empty-state copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+## Project
+This repository is the KlarLyd / VOX web MVP.
+KlarLyd is an AI-assisted service for hearing-aid users, built around helpful content, hub-and-spoke IA, and a CES/RAG-based assistant.
+The product should feel warm, premium, technically strong, and useful in everyday life. Avoid clinical or hospital-like expression unless explicitly requested.
+
+## Stack
+- Astro 5
+- Tailwind CSS v4
+- CSS tokens/custom properties
+- Storyblok for selected content flows
+- Vercel deployment
+- GitHub issues/PRs as task bus
+
+## Working role
+Codex is an implementation agent.
+Use GitHub and the repository as source of truth for code, project docs, issues, branches and PRs.
+Do not assume access to ChatGPT project memory. Read repo context before coding.
+
+## Before coding
+For non-trivial tasks, first inspect relevant project docs and files.
+Prefer reading:
+- README.md
+- docs/project/00_STATE.md
+- docs/project/03_DECISIONS.md
+- docs/project/07_GITHUB_TASK_FLOW.md
+- files directly related to the requested route/component
+
+For ambiguous or larger tasks:
+- propose a short plan first
+- wait for approval before large changes
+
+## Rules
+- Keep changes small and reviewable.
+- Prefer existing components, tokens, CSS patterns and Astro structure.
+- Preserve IA, routes and content model unless explicitly asked.
+- Do not introduce new dependencies without approval.
+- Do not rewrite working areas unnecessarily.
+- Avoid broad refactors unless the task explicitly asks for it.
+- Do not make visual redesigns without a clear brief.
+- Commit messages, branch names, code and filenames may be in English.
+- User-facing summaries and QA should be in Norwegian.
+
+## Verification
+Run relevant checks before finishing.
+Default check:
+- npm run build
+
+If a check cannot be run, explain why.
+
+## Return ticket
+End every task with a Norwegian return ticket:
+
+- Status
+- Hva ble gjort
+- Filer endret
+- Tester kjørt
+- Hva Thomas bør verifisere
+- Eventuelle risikoer eller åpne punkter

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -159,14 +159,20 @@ const spokeEntries = [
                     <p class="text-sm font-semibold text-[rgb(var(--text))]">{sanitizeHubCopy(seed.question)}</p>
                     {seed.shortAnswer ? (
                       <p class="mt-1.5 text-sm text-[rgb(var(--muted))]">{sanitizeHubCopy(seed.shortAnswer)}</p>
-                    ) : null}
+                    ) : (
+                      <p class="mt-1.5 text-sm text-[rgb(var(--muted))]">Trykk for forslag til neste steg i chat.</p>
+                    )}
                   </a>
                 </li>
               ))}
             </ul>
           ) : (
             <p class="mt-4 text-sm text-[rgb(var(--muted))]">
-              Samtaleforslag fylles på fortløpende. Du kan åpne Hørehjelpen direkte via chat.
+              Vi har ingen forslag klare akkurat nå. Du kan fortsatt{" "}
+              <a href="/no/chat" class="font-medium text-[rgb(var(--text-secondary))] underline underline-offset-2 hover:text-[rgb(var(--text))]">
+                åpne Hørehjelpen
+              </a>{" "}
+              og skrive spørsmålet ditt med egne ord.
             </p>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- Provide project-level implementation guidance and agent rules by adding an `AGENTS.md` to the repo. 
- Improve the user experience on the Norwegian hub page by showing a helpful fallback when seed answers are missing and clarifying the empty-state with a direct chat CTA.

### Description
- Add `AGENTS.md` containing project stack, working role, rules, verification steps, and a required Norwegian return ticket format. 
- Update `src/pages/no/hub.astro` to render a fallback line when a seed has no `shortAnswer` and to replace the empty-state paragraph with clearer Norwegian copy linking to `/no/chat`. 
- Keep existing helpers (`buildChatShellHref` and `sanitizeHubCopy`) and markup while only altering the copy and conditional rendering.

### Testing
- Run `npm run build` and the site build completed successfully. 
- Return ticket: Status: Klar for gjennomgang; Hva ble gjort: Lagt til `AGENTS.md` og forbedret fallback-tekst og tom-tilstand på `src/pages/no/hub.astro`; Filer endret: `AGENTS.md`, `src/pages/no/hub.astro`; Tester kjørt: `npm run build` (lyktes); Hva Thomas bør verifisere: Norsk tekst og lenke til chat på hub-siden; Eventuelle risikoer eller åpne punkter: Ingen kjente risikoer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec560c4e9883329ea2dfc78ebec55a)