### PR TITLE
Mobilfix: wrap for seed-knapper i «Fortsett i Hørehjelpen»

### DIFF
--- a/src/styles/article-system.css
+++ b/src/styles/article-system.css
@@ -368,6 +368,17 @@ html[data-inspect-components="true"] :where([data-article-system],[data-article-
   transition: background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
+@media (max-width: 639px) {
+  :where([data-article-system],[data-article-master-sandbox]) .prompt-group--ghost-pill .prompt-group__link {
+    max-width: 100%;
+    height: auto;
+    min-height: 40px;
+    white-space: normal;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+  }
+}
+
 :where([data-article-system],[data-article-master-sandbox]) .prompt-group--ghost-pill .prompt-group__link:hover {
   background: rgb(var(--article-system-pill-hover-light));
   box-shadow: none;


### PR DESCRIPTION
### Motivation
- Rettet et mobil-layoutproblem der ghost-pill seed-knapper i artikkelens «Fortsett i Hørehjelpen» ble for brede og skapte horisontal overflow; målet var å la knappetekst wrappe på små skjermer uten å endre chat-/seed-logikk eller desktop-oppsett.

### Description
- La til en begrenset mobilmediaquery i `src/styles/article-system.css` som endrer `.prompt-group--ghost-pill .prompt-group__link` til `max-width: 100%`, `height: auto`, `min-height: 40px`, `white-space: normal`, `line-height: 1.35` og `overflow-wrap: anywhere` for skjermer <=639px for å tillate multiline-knapper og forhindre horisontal scrolling.

### Testing
- Kjørt `npm run build` og bygget ferdig uten feil (suksess).
- Kjørt `git diff --name-only` og bekreftet at diffen kun inneholder `src/styles/article-system.css` (suksess).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc15ec7b48332992587f3e150eba3)