### PR TITLE
Add progressive activation mode to ArticleInlineChatShell and R1 test page

### DIFF
--- a/src/components/article/ArticleInlineChatShell.astro
+++ b/src/components/article/ArticleInlineChatShell.astro
@@ -10,6 +10,8 @@ export interface Props {
   headingId: string;
   items: PromptItem[];
   sourceLabel?: string;
+  mode?: "inline" | "progressive";
+  freeChatLabel?: string;
 }
 
 const {
@@ -18,36 +20,87 @@ const {
   headingId,
   items,
   sourceLabel = "artikkel",
+  mode = "inline",
+  freeChatLabel = "Start fri samtale",
 } = Astro.props;
 ---
 
-<section class="inline-chat-shell ams-zone" aria-labelledby={headingId} data-component="ArticleInlineChatShell">
+<section
+  class="inline-chat-shell ams-zone"
+  aria-labelledby={headingId}
+  data-component="ArticleInlineChatShell"
+  data-inline-chat-mode={mode}
+  data-inline-chat-state={mode === "progressive" ? "idle" : "active"}
+>
   <header class="inline-chat-shell__header">
     <h2 id={headingId} class="inline-chat-shell__title">{title}</h2>
     <p class="inline-chat-shell__intro">{intro}</p>
   </header>
 
-  <ul class="inline-chat-shell__seed-list" role="list">
+  {mode === "progressive" ? (
+    <p
+      class="inline-chat-shell__affordance text-xs font-medium uppercase tracking-[0.12em] text-[rgb(var(--reading-ink-secondary))]"
+      data-inline-chat-affordance
+    >
+      Dialog med Hørehjelpen
+    </p>
+  ) : null}
+
+  <ul
+    class:list={[
+      "inline-chat-shell__seed-list",
+      mode === "progressive" && "prompt-group__list prompt-group--ghost-pill",
+    ]}
+    role="list"
+  >
     {
       items.map((item) => (
         <li>
           <button
             type="button"
-            class="inline-chat-shell__seed-btn"
+            class:list={[
+              "inline-chat-shell__seed-btn",
+              mode === "progressive" && "prompt-group__link",
+            ]}
             data-inline-chat-seed={item.question}
           >
-            {item.question}
+            <span class={mode === "progressive" ? "prompt-group__question" : undefined}>{item.question}</span>
+            {mode === "progressive" ? (
+              <span class="prompt-group__hint" aria-hidden="true">
+                <svg class="prompt-group__hint-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M6 3l5 5-5 5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+            ) : null}
           </button>
         </li>
       ))
     }
   </ul>
 
+  {mode === "progressive" ? (
+    <button type="button" class="prompt-group__cta inline-chat-shell__free-chat" data-inline-chat-free-trigger>
+      {freeChatLabel}
+    </button>
+  ) : null}
+
   <p class="inline-chat-shell__source text-[11px] text-[rgb(var(--muted))]">
-    Kontekst: {sourceLabel}. Velg et startsporsmal eller skriv fritt i feltet under.
+    Kontekst: {sourceLabel}. Velg et startspørsmål{mode === "progressive" ? " for å åpne samtalen." : " eller skriv fritt i feltet under."}
   </p>
 
-  <div class="vox-surface-embedded-app mt-3" data-kl-surface="embedded-app">
+  <div class="inline-chat-shell__selected mt-3 hidden rounded-[10px] border border-[rgb(var(--border))/0.35] bg-[rgb(var(--surface-subtle))] px-3 py-2.5" data-inline-chat-selected>
+    <p class="text-[11px] font-semibold uppercase tracking-[0.12em] text-[rgb(var(--reading-ink-secondary))]">Valgt start</p>
+    <p class="mt-1 text-sm leading-relaxed text-[rgb(var(--reading-ink))]" data-inline-chat-selected-text></p>
+  </div>
+
+  <div
+    class:list={[
+      "vox-surface-embedded-app mt-3",
+      mode === "progressive" && "hidden",
+    ]}
+    data-kl-surface="embedded-app"
+    data-inline-chat-surface
+  >
     <chat-messenger
       id="article-inline-chat-widget"
       url-allowlist="*"
@@ -62,10 +115,23 @@ const {
   </div>
 </section>
 
-<script is:inline define:vars={{ sourceLabel }}>
+<script is:inline define:vars={{ sourceLabel, mode }}>
   (() => {
-    const widget = document.getElementById("article-inline-chat-widget");
+    const shell = document.querySelector('[data-component="ArticleInlineChatShell"][data-inline-chat-mode]');
+    const widget = shell?.querySelector("#article-inline-chat-widget");
     if (!widget) return;
+    const progressive = mode === "progressive";
+    const selectedBox = shell?.querySelector("[data-inline-chat-selected]");
+    const selectedText = shell?.querySelector("[data-inline-chat-selected-text]");
+    const surface = shell?.querySelector("[data-inline-chat-surface]");
+    const setState = (next) => {
+      if (!shell) return;
+      shell.setAttribute("data-inline-chat-state", next);
+    };
+    const revealSurface = () => {
+      if (selectedBox) selectedBox.classList.remove("hidden");
+      if (surface) surface.classList.remove("hidden");
+    };
 
     const pushToWidget = (prompt) => {
       const seed = (prompt || "").trim();
@@ -83,7 +149,29 @@ const {
       return true;
     };
 
-    let bridgeReady = pushToWidget("");
+    const startFreeChat = () => {
+      revealSurface();
+      if (selectedText) selectedText.textContent = "Fri samtale";
+      setState("started");
+      widget.open?.();
+      widget.show?.();
+      if (typeof widget.sessionInput === "function") {
+        setState("active");
+        return;
+      }
+      let retry = 0;
+      const freeRetryTimer = setInterval(() => {
+        retry += 1;
+        widget.open?.();
+        widget.show?.();
+        if (typeof widget.sessionInput === "function" || retry > 20) {
+          if (typeof widget.sessionInput === "function") setState("active");
+          clearInterval(freeRetryTimer);
+        }
+      }, 250);
+    };
+
+    let bridgeReady = !progressive && pushToWidget("");
     let tries = 0;
     const timer = setInterval(() => {
       tries += 1;
@@ -91,16 +179,33 @@ const {
       if (bridgeReady || tries > 40) clearInterval(timer);
     }, 250);
 
-    document.querySelectorAll("[data-inline-chat-seed]").forEach((btn) => {
+    shell?.querySelectorAll("[data-inline-chat-seed]").forEach((btn) => {
       btn.addEventListener("click", () => {
         const seed = btn.getAttribute("data-inline-chat-seed") || "";
-        if (pushToWidget(seed)) return;
+        if (progressive) {
+          if (selectedText) selectedText.textContent = seed;
+          revealSurface();
+          setState("started");
+        }
+        if (pushToWidget(seed)) {
+          if (progressive) setState("active");
+          return;
+        }
         let retry = 0;
         const retryTimer = setInterval(() => {
           retry += 1;
-          if (pushToWidget(seed) || retry > 20) clearInterval(retryTimer);
+          const pushed = pushToWidget(seed);
+          if (pushed || retry > 20) {
+            if (pushed && progressive) setState("active");
+            clearInterval(retryTimer);
+          }
         }, 250);
       });
     });
+
+    const freeTrigger = shell?.querySelector("[data-inline-chat-free-trigger]");
+    if (freeTrigger) {
+      freeTrigger.addEventListener("click", startFreeChat);
+    }
   })();
 </script>

--- a/src/pages/no/artikkel/r1-spoke-v03.astro
+++ b/src/pages/no/artikkel/r1-spoke-v03.astro
@@ -1,0 +1,326 @@
+---
+/* CONTRACT: R1 spoke v0.3 progressive AI bridge test with inline shell activation after user intent. */
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import Footer from "../../../components/nav/Footer.astro";
+import ArticleTemplateV01 from "../../../components/article/ArticleTemplateV01.astro";
+import ArticleInlineChatShell from "../../../components/article/ArticleInlineChatShell.astro";
+import "../../../styles/article-system.css";
+
+Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
+const r1Article = {
+  title: "Når hørselen endrer samtalen, og hvordan du kan møte det med mer overskudd",
+  ingress:
+    "Når hørselen blir mer krevende i hverdagen, kan samtaler føles tyngre enn før. Her får du en rolig oversikt over hvorfor det skjer, og små grep som kan gjøre det lettere.",
+  preset: "standard" as const,
+  articleType: "spoke",
+  hub: "Bedre lyd i hverdagen",
+  sourceTrustType: "redaksjonelt kvalitetssjekket med faglig orientering",
+  relatedTopics: ["Samtaletips", "Høreliv", "Hverdagskommunikasjon"],
+  aiSeedGroup: "hearing-conversation-v1",
+  body: [
+    "Hørsel handler ikke bare om volum. Det handler også om hvor mye energi du bruker på å fylle inn det du ikke fikk med deg, og hvor raskt du blir sliten av støy, flere stemmer eller dårlig akustikk.",
+    "For pårørende kan dette se ut som manglende interesse. For den som strever med å høre, kan det føles som skam eller frustrasjon over å måtte spørre om igjen.",
+    "Et nyttig perspektiv er å skille mellom intensjon og effekt: du kan ønske å være til stede, men likevel oppleves som distansert fordi du bruker mye kapasitet på å følge med.",
+    "Små grep hjelper ofte: senk tempoet, del opp setninger, flytt samtalen til et roligere sted og vær tydelig på hva du trenger i øyeblikket.",
+    "Pause er ikke det samme som å gi opp. En kort avtale om å fortsette samtalen senere kan være mer omsorgsfullt enn å presse alt gjennom når begge er slitne.",
+    "Når samtalen blir tydeligere og tempoet roligere, blir det ofte lettere å forstå hverandre uten at noen må «holde maska».",
+  ],
+  footerTitle: "Kort oppsummert",
+  footerText:
+    "Små justeringer i tempo, plassering og forventninger kan gjøre samtaler mer skånsomme. Start med ett grep om gangen, og bygg videre derfra.",
+  trustAuthors: [
+    { name: "Nora Lysvik", role: "faglig rådgiver", href: "#" },
+    { name: "KlarLyd Redaksjon", role: "redaksjonell fagjournalist", href: "#" },
+  ],
+  trustPublished: "03. feb 2026, 06:30",
+  trustUpdated: "25. mar 2026, 16:04",
+  trustShowActions: true,
+  trustActionLinks: [
+    { label: "Forside", href: "/no" },
+    { label: "Emnehuber", href: "/no/hubs" },
+    { label: "R1 artikkel v03" },
+  ],
+  trustAvatarSrc: "/images/klarlyd/r1-byline-profile.png",
+  trustAvatarAlt: "Redaksjonell avatar",
+  figureAfterTrust: true,
+  ingressAfterFigure: true,
+  figureImage: {
+    src: "/images/klarlyd/r1-storlom-test.png",
+    alt: "Storlom i disig fjordlandskap som visualiserer stillhet, fokus og ettertanke.",
+    caption: "Testbilde i editorial layer: storlom i fjordlandskap, brukt for å validere bildeplassering i leserommet.",
+  },
+};
+
+const bridgeQuestions = [
+  {
+    question:
+      "Hvordan kan jeg forklare mine behov i en samtale uten at det blir konflikt eller misforståelser?",
+  },
+  {
+    question:
+      "Hvilket første grep bør vi teste hjemme denne uken for å få roligere og tydeligere samtaler?",
+  },
+  {
+    question:
+      "Kan du hjelpe meg lage en kort plan for hva vi gjør når samtalen låser seg i støy eller stress?",
+  },
+];
+---
+
+<BaseLayout title="VOX - R1 spoke v0.3" currentPath="/no/hubs" shellVariant="article">
+  <meta slot="head" name="robots" content="noindex,follow" />
+  <main class="bg-[rgb(var(--article-page-canvas))] py-2 sm:py-3" data-article-system data-r1-editorial>
+    <span class="article-component-label mb-2 inline-flex rounded border border-yellow-700/70 bg-yellow-100/95 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-950" data-component-label>
+      R1PageMain
+    </span>
+    <div class="px-4 sm:px-6">
+      <section class="r1-orientation mx-auto mb-7 max-w-[min(100%,46rem)] px-0.5 py-1">
+        <span class="article-component-label mb-2 inline-flex rounded border border-yellow-700/70 bg-yellow-100/95 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-950" data-component-label>
+          OrientationBlock
+        </span>
+        <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[rgb(var(--reading-ink-secondary))]">Produktanatomi v0.3 test</p>
+        <p class="mt-2 text-sm leading-relaxed text-[rgb(var(--reading-ink-secondary))]">
+          Les artikkelen først. Når du velger et spørsmål (eller fri samtale), åpnes chatten direkte under i samme kontekst.
+        </p>
+      </section>
+
+      <ArticleTemplateV01 {...r1Article}>
+        <section slot="before-summary" class="r1-ai-bridge ams-zone px-0.5 py-1" data-component="PromptBridgeInArticle">
+          <span class="article-component-label mb-2 inline-flex rounded border border-yellow-700/70 bg-yellow-100/95 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-950" data-component-label>
+            PromptBridge
+          </span>
+          <ArticleInlineChatShell
+            title="Fortsett i Hørehjelpen"
+            intro="Velg et predefinert spørsmål for å starte dialogen i samme artikkelkontekst. Chatten åpnes først etter handling."
+            headingId="r1-continue-v03"
+            items={bridgeQuestions}
+            sourceLabel="r1-spoke-v03"
+            mode="progressive"
+            freeChatLabel="Start fri samtale"
+          />
+        </section>
+      </ArticleTemplateV01>
+
+      <aside class="r1-component-inventory mx-auto mt-6 max-w-[min(100%,46rem)]" data-component="ComponentInventory">
+        <span class="article-component-label mb-2 inline-flex rounded border border-yellow-700/70 bg-yellow-100/95 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-950" data-component-label>
+          ComponentInventory
+        </span>
+        <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[rgb(var(--reading-ink-secondary))]">Komponenter i bruk</p>
+        <ul class="mt-2 flex flex-wrap gap-1.5 text-[11px] text-[rgb(var(--reading-ink-secondary))]">
+          <li>ArticleTemplate</li><li>ArticleHeader</li><li>ArticleTrustBlock</li><li>ArticleFigurePlaceholder</li>
+          <li>ArticleIngress</li><li>ArticleBody</li><li>ArticleSummary</li><li>ArticleInlineChatShell</li><li>InlineChatSeeds</li>
+          <li>InlineChatProgressiveState</li><li>InlineChatMessenger</li><li>BreadcrumbNav</li><li>OrientationBlock</li><li>PromptBridge</li>
+        </ul>
+      </aside>
+    </div>
+  </main>
+  <style is:global>
+    [data-r1-editorial] [data-component="ArticleContent"] {
+      background: #fff;
+      border-radius: 0;
+    }
+
+    [data-r1-editorial] [data-component="ArticleHeader"] > div:first-of-type {
+      margin-bottom: 0.1rem;
+    }
+
+    [data-r1-editorial] [data-component="ArticleHeader"] {
+      padding-bottom: 0.2rem !important;
+      margin-top: 20px !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleHeader"] > div:first-of-type .ams-kicker {
+      font-size: 10px;
+      letter-spacing: 0.14em;
+    }
+
+    [data-r1-editorial] [data-component="ArticleTrustBlock"] {
+      background: transparent;
+      border-radius: 0;
+      padding: 0;
+      margin: 0 0 0.22rem !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleContent"] > [data-component="ArticleTrustBlock"] {
+      margin-top: -1.74rem !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleTrustBlock"] > div {
+      margin-top: 0 !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleTrustBlock"] > p {
+      margin-top: 0.08rem !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleTrustBlock"] .ams-kicker {
+      font-size: 10px;
+      letter-spacing: 0.14em;
+      color: rgb(var(--reading-ink-secondary));
+    }
+
+    [data-r1-editorial] [data-component="ArticleTrustBlock"] p:last-child {
+      margin-top: 0.22rem;
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
+    [data-r1-editorial] [data-component="ArticleTrustBlock"] a {
+      color: rgb(var(--reading-ink));
+    }
+
+    [data-r1-editorial] .ams-plate {
+      background: transparent;
+      border-radius: 0;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      box-shadow: none;
+    }
+
+    [data-r1-editorial] [data-component="ArticleFigurePlaceholder"] {
+      margin-top: 0.32rem !important;
+      border-top: 0;
+      padding-top: 0;
+    }
+
+    [data-r1-editorial] [data-component="ArticleFigurePlaceholder"] figcaption {
+      margin-top: 0.28rem !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleContent"] > [data-component="ArticleIngress"] {
+      margin-top: -2.1rem !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleTrustBlock"] hr {
+      margin-top: 0.38rem !important;
+      border-top-color: rgb(var(--border) / 0.42) !important;
+      opacity: 1 !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleTrustBlock"] hr + div {
+      margin-top: 0.15rem !important;
+    }
+
+    [data-r1-editorial] [data-component="ArticleSummary"] {
+      margin-top: 1.25rem;
+      border-top: 1px solid rgb(var(--border) / 0.4);
+      padding-top: 1.15rem;
+      padding-bottom: 0;
+    }
+
+    [data-r1-editorial] [data-component="ArticleSummary"] ul li {
+      border: 1px solid rgb(var(--border) / 0.5);
+      border-radius: 0 !important;
+      padding: 0.18rem 0.44rem;
+      font-size: 11px;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+      color: rgb(var(--reading-ink-secondary));
+      background: transparent;
+    }
+
+    [data-r1-editorial] [data-component="ArticleSummary"] ul li + li::before {
+      content: none;
+      margin-right: 0;
+      color: transparent;
+    }
+
+    [data-r1-editorial] .r1-orientation {
+      display: none;
+      border-top: 1px solid rgb(var(--border) / 0.22);
+      padding-top: 0.95rem;
+      margin-bottom: 2rem;
+    }
+
+    html[data-inspect-testinfo="true"] [data-r1-editorial] .r1-orientation {
+      display: block;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge {
+      border-top: 0;
+      padding-top: 0.35rem;
+      margin-top: 0.55rem;
+      margin-bottom: 0.7rem;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge .inline-chat-shell__header {
+      margin-bottom: 0.6rem;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge .inline-chat-shell__title {
+      font-size: 1.08rem;
+      letter-spacing: -0.01em;
+      line-height: 1.3;
+      font-weight: 600;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge .inline-chat-shell__intro {
+      margin-top: 0.28rem;
+      font-size: 0.94rem;
+      line-height: 1.48;
+      color: rgb(var(--reading-ink-secondary));
+    }
+
+    [data-r1-editorial] .r1-ai-bridge [data-inline-chat-mode="inline"] .inline-chat-shell__seed-list {
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.42rem;
+      padding: 0;
+      list-style: none;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge [data-inline-chat-mode="inline"] .inline-chat-shell__seed-btn {
+      width: 100%;
+      border: 1px solid rgb(var(--border) / 0.52);
+      border-radius: 999px;
+      background: rgb(var(--surface) / 0.9);
+      padding: 0.52rem 0.84rem;
+      text-align: left;
+      font-size: 0.88rem;
+      line-height: 1.4;
+      transition: background-color 120ms ease, border-color 120ms ease;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge [data-inline-chat-mode="inline"] .inline-chat-shell__seed-btn:hover {
+      background: rgb(var(--surface-subtle) / 0.95);
+      border-color: rgb(var(--border) / 0.72);
+    }
+
+    [data-r1-editorial] .r1-ai-bridge [data-inline-chat-mode="progressive"] .inline-chat-shell__affordance {
+      margin-top: 0.1rem;
+      margin-bottom: 0.55rem;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge [data-inline-chat-mode="progressive"] .inline-chat-shell__seed-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge [data-inline-chat-mode="progressive"] .inline-chat-shell__seed-btn {
+      border: 0;
+      background: transparent;
+      cursor: pointer;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge [data-inline-chat-mode="progressive"] .inline-chat-shell__free-chat {
+      margin-top: 1rem;
+    }
+
+    [data-r1-editorial] .r1-ai-bridge .inline-chat-shell__source {
+      margin-top: 0.6rem;
+    }
+
+    [data-r1-editorial] .r1-component-inventory {
+      display: none;
+      border-top: 1px solid rgb(var(--border) / 0.3);
+      padding-top: 0.9rem;
+    }
+
+    html[data-inspect-components="true"] [data-r1-editorial] .r1-component-inventory {
+      display: block;
+    }
+  </style>
+  <Footer variant="article" />
+</BaseLayout>


### PR DESCRIPTION
### Motivation
- Introduce a progressive activation mode for the inline chat shell so the messenger stays hidden until the user explicitly expresses intent, reducing visual noise and enabling an intent-driven flow. 
- Provide a concrete editorial test page to exercise the new progressive behavior and styling in context. 

### Description
- Add `mode` (`"inline" | "progressive"`) and `freeChatLabel` props to `ArticleInlineChatShell.astro` and expose the mode via `data-inline-chat-mode` and `data-inline-chat-state` attributes. 
- Implement conditional UI for progressive mode: affordance text, ghost-pill seed list styling, hint icon, a selected-start box, a free-chat CTA, and hide the embedded `chat-messenger` surface until triggered. 
- Update the inline script to support progressive behavior by managing shell state, revealing the surface on user intent, starting a free chat (`startFreeChat`), and retrying until the widget bridge (`widget.sessionInput`) is available. 
- Add a new page `src/pages/no/artikkel/r1-spoke-v03.astro` as an editorial test fixture that uses the new `mode="progressive"` with sample content, style overrides, and seed questions. 

### Testing
- Built the site with `npm run build` and the build completed successfully. 
- Started a local dev server with `npm run dev` and verified the page renders and the progressive UI elements are present with no runtime errors. 
- Ran lint/type checks with `npm run lint` and `npm run typecheck` and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc15ec7b48332992587f3e150eba3)