### PR TITLE
feat(#131A/#131B): VIS inventory doc + stakeholder review entry

### DIFF
--- a/docs/project/tasks/ISSUE_131A_VIS_INVENTORY_ACCESS_MAP.md
+++ b/docs/project/tasks/ISSUE_131A_VIS_INVENTORY_ACCESS_MAP.md
@@ -1,0 +1,235 @@
+# Issue #131A — VIS inventory & access map
+
+**Epic:** #131 VIS as Review Surface v1  
+**Dato:** 2026-05-21  
+**Status:** Safe-read / kartlegging — ingen flytting, sletting eller domeneendring i denne runden
+
+---
+
+## Formål
+
+Gi Thomas (og senere Vibeke) et klart bilde av **hva som finnes i VIS**, **hvordan det åpnes**, og **hva som er trygt å vise** — før #131B–E rydder access, entry og navngiving.
+
+---
+
+## Nåværende VIS access model
+
+| Kanal | URL-mønster | Tilgang i praksis | Anbefalt for QA |
+|-------|-------------|-------------------|-----------------|
+| **Produksjon (main deploy)** | `https://vox.raddum.no/vis/...` | Offentlig HTTP 200 (ingen SSO) | **Ja — primær i dag** |
+| **Branch preview (Vercel)** | `https://vox-web-git-<branch>-raddum-5965s-projects.vercel.app/vis/...` | **401** — Vercel Deployment Protection / team SSO | Nei uten Vercel-innlogging |
+| **Lokal dev** | `http://localhost:4321/vis/...` | Alltid tilgjengelig for utvikler | Ja (agent/dev) |
+| **GitHub Pages workflow** | Nevnt i `docs/project/20_*` | Ikke bekreftet som aktiv prod-host; **faktisk prod = vox.raddum.no** | Avklares i #131D |
+
+### Læring fra #125C (2026-05-21)
+
+- Cursor-leveranser uten merge til `main` er **ikke** synlige for Thomas på `vox.raddum.no`.
+- Branch preview-URL fra Vercel-bot i PR **ser riktig ut**, men returnerer **401** uten innlogging i Vercel-team `raddum-5965s-projects`.
+- **Minste trygge QA-løp i dag:** merge til `main` → verifiser `https://vox.raddum.no/vis/...` (som #124D, #125C).
+
+### Robots / synlighet
+
+- VIS bruker `PrototypeLayout` med `<meta name="robots" content="noindex, nofollow">`.
+- VIS er ment som intern review — ikke SEO-produkt.
+
+---
+
+## Hvor VIS bygges i repoet
+
+| Ansvar | Fil(er) |
+|--------|---------|
+| **VIS-index (operativ oversikt)** | `src/pages/vis/index.astro` |
+| **Raw wireframe-liste / metadata** | `src/lib/vis-wireframes.ts` |
+| **Raw HTML-artefakter** | `public/vis/raw/*.html` |
+| **Wireframe viewer (iframe)** | `src/pages/vis/[slug].astro` |
+| **VIS shell (chrome, «VIS»-label)** | `src/layouts/PrototypeLayout.astro` |
+| **Sprint preview W21** | `src/pages/vis/sprints/2026-w21/index.astro` |
+| **Primitives lab** | `src/pages/vis/sprints/2026-w21/primitives/` + `_data.ts` |
+| **Systemreferanse** | `src/pages/vis/system/` |
+| **Runtime markdown (ikke Astro-side)** | `public/vis/runtime/00_GITHUB_RUNTIME_STATUS.md` |
+
+---
+
+## Anbefalt ny URL-struktur (forslag — ikke implementert)
+
+Mål: én forutsigbar inngang, skilt active/reference/archive.
+
+| Lag | Forslag domene | Forslag path | Merknad |
+|-----|----------------|--------------|---------|
+| **Primær review** | `vis.viddel.no` | `/` | Stakeholder-safe entry (#131B) |
+| **Aktiv sprint** | `vis.viddel.no` | `/sprints/2026-w21/` | Erstatter lang `/vis/sprints/...` i kommunikasjon |
+| **System/reference** | `vis.viddel.no` | `/system/` | Design lock, article system, roadmap |
+| **Archive** | `vis.viddel.no` | `/archive/` | Raw KlarLyd-wireframes, pensjonerte ruter |
+| **Redirect legacy** | `vox.raddum.no/vis/*` | 301 → `vis.viddel.no` | Overgangsfase (#131D) |
+
+Inntil domene er klart: **`https://vox.raddum.no/vis/sprints/2026-w21/`** er canonical entry for W21-design review.
+
+---
+
+## Domene- og navneproblem
+
+| Problem | Eksempler | Risiko for Vibeke |
+|---------|-----------|-------------------|
+| **VOX-produksjonsdomene hoster VIS** | `vox.raddum.no/vis/` | Forvirring: «er dette produktet?» |
+| **KlarLyd i URL-slugs** | `/vis/KlarLyd_Forside_Variant_A` | Historisk merke, ikke Viddel |
+| **KlarLyd i filnavn/titler** | `public/vis/raw/KlarLyd_*.html` | Vises i index og wireframe chrome |
+| **VOX CSS-klasser i system-doc** | `.vox-surface-*`, `--vox-brand-*` i design-system VIS | OK som teknisk referanse; ikke stakeholder-entry |
+| **Repo-navn vox-web** | GitHub, Vercel preview URLs | `vox-web-git-...vercel.app` signal |
+| **PrototypeLayout tittel** | `VIS Wireframe - {title}` | Greit internt; kan forenkles i #131B |
+| **Blandet kuratering** | `/vis/` lister alle raw HTML + lenker til system | Mye støy uten «safe entry» |
+
+---
+
+## VIS-ruter — full liste
+
+**Base URL i prod:** `https://vox.raddum.no`  
+**Path-prefix:** `/vis`
+
+### A. Entry & navigasjon
+
+| Route | Kilde | Status | Stakeholder-safe | Merknad |
+|-------|-------|--------|------------------|---------|
+| `/vis/` | `index.astro` | **Active** | **Needs cleanup** | Kuratert oversikt, men lister også all raw HTML |
+| `/vis/hub` | `hub.astro` | Deprecated | No | Placeholder — peker til index |
+| `/vis/artikkel` | `artikkel.astro` | Deprecated | No | Placeholder |
+
+### B. Sprint 2026-W21 (MVP Design Lock — aktiv review)
+
+| Route | Status | Stakeholder-safe | Merknad |
+|-------|--------|------------------|---------|
+| `/vis/sprints/2026-w21/` | **Active** | **Yes** | **Primær inngang W21** — lenker til labs |
+| `/vis/sprints/2026-w21/color/` | **Active** | Yes | #122 color tokens lab |
+| `/vis/sprints/2026-w21/typography/` | **Active** | Yes | #123 typography lab |
+| `/vis/sprints/2026-w21/hub-types/` | **Active** | Yes | #125C utility vs editorial |
+| `/vis/sprints/2026-w21/primitives/` | **Active** | Yes | #124 primitives catalog |
+| `/vis/sprints/2026-w21/primitives/surfaces/` | **Active** | Yes | #127 candidate |
+| `/vis/sprints/2026-w21/primitives/radius/` | Reference | Yes | Primitive slice |
+| `/vis/sprints/2026-w21/primitives/strokes/` | Reference | Yes | Primitive slice |
+| `/vis/sprints/2026-w21/primitives/elevation/` | Reference | Yes | Primitive slice |
+| `/vis/sprints/2026-w21/primitives/layering/` | Reference | Yes | Primitive slice |
+| `/vis/sprints/2026-w21/primitives/buttons/` | **Active** | Yes | #128 — lenke til context |
+| `/vis/sprints/2026-w21/primitives/buttons/context/` | **Active** | Yes | #128 decision surface |
+| `/vis/sprints/2026-w21/primitives/cards/` | **Active** | Yes | #129 |
+| `/vis/sprints/2026-w21/primitives/cards/context/` | **Active** | Yes | #129 decision surface |
+| `/vis/sprints/2026-w21/primitives/interaction-states/` | **Active** | Yes | #124D |
+| `/vis/sprints/2026-w21/primitives/inputs/` | Reference | Yes | Catalog entry |
+| `/vis/sprints/2026-w21/primitives/pills/` | Reference | Yes | Catalog entry |
+| `/vis/sprints/2026-w21/primitives/focus/` | Reference | Yes | Catalog entry |
+| `/vis/sprints/2026-w21/primitives/glass/` | Reference | Yes | Catalog entry |
+| `/vis/sprints/2026-w21/primitives/signals/` | Reference | Yes | Catalog entry |
+| `/vis/sprints/2026-w21/primitives/ai-action/` | Reference | Yes | Catalog entry |
+
+### C. System / reference (canonical docs i VIS)
+
+| Route | Status | Stakeholder-safe | Merknad |
+|-------|--------|------------------|---------|
+| `/vis/system/` | **Active** | **Needs cleanup** | God struktur, men bred |
+| `/vis/system/control-center` | **Active** | Yes | Viddel Control Center — agent entry |
+| `/vis/system/design-system-v01` | Reference | Needs cleanup | VOX token-klassenavn i UI |
+| `/vis/system/ia-principles-v01` | Reference | Yes | IA v0.1 |
+| `/vis/system/hub-mandate-v01` | Reference | Yes | Hub mandate |
+| `/vis/system/article-system` | Reference | Needs cleanup | «KlarLyd-artikler» i tekst |
+| `/vis/system/article/` | Reference | Yes | Article system hub |
+| `/vis/system/article/foundations` | Reference | Yes | |
+| `/vis/system/article/components` | Reference | Yes | |
+| `/vis/system/article/templates` | Reference | Yes | |
+| `/vis/system/article/changelog` | Reference | Yes | |
+| `/vis/system/roadmap-timeline-v01` | **Active** | Yes | Canonical roadmap (erstatter live board) |
+| `/vis/system/github-runtime-status` | **Active** | **No** | Operativ agent-feed — ikke design review |
+| `/vis/system/task-bus-live` | **Deprecated** | No | Pensjonert — redirect notice |
+
+### D. Raw HTML wireframes (`/vis/[slug]`)
+
+Generert fra `public/vis/raw/*.html` via `[slug].astro`.
+
+| Slug / route | Status | Stakeholder-safe | Navn-problem |
+|--------------|--------|------------------|--------------|
+| `/vis/Kjernebeskrivelser_V2.0` | Archive | No | Pre-Viddel dokument |
+| `/vis/KlarLyd_Forside_Variant_A` | Archive | No | KlarLyd + wireframe |
+| `/vis/KlarLyd_Forside_Variant_B_AI_v01` | Archive | No | KlarLyd |
+| `/vis/KlarLyd_Hub_NAV` | Archive | No | KlarLyd |
+| `/vis/KlarLyd_Spoke_Artikkel` | Archive | No | KlarLyd |
+| `/vis/KlarLyd_Merkevaregrunnlag_VIS_v0_2_1` | Reference | Needs cleanup | KlarLyd i slug |
+| `/vis/KlarLyd_Strategi_Notion_v05` | Archive | No | KlarLyd strategi |
+| `/vis/KlarLyd_Sprint_Roadmap_v08` | Archive | No | Superseded by roadmap-timeline |
+| `/vis/KlarLyd_Sprint_01_Foundation_Archive_v09` | Archive | No | Eksplisitt archive i navn |
+| `/vis/KlarLyd_Live_Board_Roadmap_v01` | **Deprecated** | No | Pensjonert — banner til roadmap-timeline |
+
+**Static assets (ikke Astro-ruter):** `public/vis/raw/*.png`, `*.github-state.json`
+
+---
+
+## Hva er trygt å vise Vibeke nå
+
+**Anbefalt «safe set» (design / retning):**
+
+1. `https://vox.raddum.no/vis/sprints/2026-w21/` — sprint preview
+2. `https://vox.raddum.no/vis/sprints/2026-w21/hub-types/` — hub type split
+3. `https://vox.raddum.no/vis/sprints/2026-w21/primitives/cards/context/`
+4. `https://vox.raddum.no/vis/sprints/2026-w21/primitives/buttons/context/`
+5. `https://vox.raddum.no/vis/sprints/2026-w21/primitives/interaction-states/`
+6. `https://vox.raddum.no/vis/sprints/2026-w21/color/`
+7. `https://vox.raddum.no/vis/sprints/2026-w21/typography/`
+
+**Unngå i stakeholder-review:**
+
+- `/vis/` full index (for mye historikk)
+- Alle `/vis/KlarLyd_*` raw wireframes
+- `/vis/system/github-runtime-status`
+- `/vis/system/task-bus-live`
+- Branch `*.vercel.app` previews (SSO)
+
+---
+
+## Krav for flytting til viddel.no / vis.viddel.no
+
+Ikke gjort i #131A — kartlegging only.
+
+| Steg | Eier | Beskrivelse |
+|------|------|-------------|
+| 1 | Drift/DNS | `vis.viddel.no` CNAME → Vercel (eller subdomain-prosjekt) |
+| 2 | Vercel | Legg domene på `vox-web`-prosjekt eller eget VIS-prosjekt |
+| 3 | Vercel | Avklar Deployment Protection: preview vs production policy |
+| 4 | Repo | Oppdater `docs/project/02_LINKS.md` canonical URLs |
+| 5 | Repo | Valgfritt: path rewrite `/vis` → root på vis-subdomain (#131D) |
+| 6 | Repo | 301 fra `vox.raddum.no/vis/*` i overgangsfase |
+| 7 | Kommunikasjon | Fast mal for Cursor Return Ticket: **alltid prod-URL etter merge** |
+| 8 | #131B | Stakeholder entry på ny URL uten raw-index-støy |
+
+**Merk:** Produksjon `/no/*` (app) og VIS bør skilles tydelig på domene — Vibeke skal ikke lande i MVP-app når hun skal reviewe design.
+
+---
+
+## Foreslåtte deloppgaver (#131B–#131E)
+
+| Issue | Tittel | Scope | Avhenger av |
+|-------|--------|-------|-------------|
+| **#131B** | Stakeholder-safe VIS entry | Ny `/vis/review/` eller erstatte topp av `/vis/` med «safe set» + tydelig Viddel-branding; skjul/archive-lenker | #131A |
+| **#131C** | Route taxonomy & labeling | Metadata (`vis:status`, badges Active/Reference/Archive/Deprecated) i index; ingen sletting | #131A |
+| **#131D** | Domain & access model | `vis.viddel.no`, redirect-plan, Vercel protection policy, Return Ticket URL-mal | #131A, drift |
+| **#131E** | Current-facing naming cleanup | Fjern KlarLyd/VOX fra titler brukere ser først; behold filer; rename display only der trygt | #131B |
+
+**Minste trygge neste steg etter #131A:** **#131B** — én kuratert inngang med direkte lenker til W21 safe set + «Do not share» for archive.
+
+---
+
+## No-delete-before-review guardrails
+
+Gjelder hele epic #131:
+
+1. **Ikke slett** filer under `public/vis/raw/` uten eksplisitt godkjenning og archive-backup.
+2. **Ikke slett** Astro-ruter — deprecate med notice-sider (mønster: `task-bus-live`, `KlarLyd_Live_Board_Roadmap_v01`).
+3. **Ikke flytt** paths uten redirect og oppdatert inventar.
+4. **Ikke endre domener** uten DNS + Vercel verifikasjon og dokumentert rollback.
+5. **Ikke skjul** historikk for agenter — archive skal fortsatt være reachable via direkte URL eller `/archive/`.
+6. **Alltid lever** merge + `vox.raddum.no` URL (inntil `vis.viddel.no` er live) i Return Ticket for VIS-arbeid.
+
+---
+
+## Oppsummering for Thomas
+
+- **~40+ VIS-ruter** (27 Astro-filer + 10 raw slugs + static assets).
+- **Aktiv review nå:** ` /vis/sprints/2026-w21/*` (spesielt primitives context + hub-types).
+- **Trygg QA-URL:** `https://vox.raddum.no/vis/...` etter merge — **ikke** branch preview uten Vercel SSO.
+- **Største forvirring:** én `/vis/`-index med historisk KlarLyd-støy + VOX-domene.
+- **Neste:** #131B stakeholder entry, deretter domene (#131D) og naming (#131E).

--- a/src/pages/vis/review/index.astro
+++ b/src/pages/vis/review/index.astro
@@ -1,0 +1,316 @@
+---
+/* CONTRACT: Stakeholder-safe VIS review entry (#131B).
+   Curated links to active decision surfaces only — no archive, raw KlarLyd, or agent runtime.
+*/
+import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import "../../../styles/global.css";
+
+const base = import.meta.env.BASE_URL;
+const sprint = `${base}vis/sprints/2026-w21`;
+
+const activeReviewLinks = [
+  {
+    title: "Sprint Preview 2026-W21",
+    description: "Overordnet inngang til MVP Design Lock — typography, color og primitives.",
+    href: `${sprint}/`,
+    issue: "#126",
+  },
+  {
+    title: "Hub type split",
+    description: "Utility/hjelpehub vs editorial/erfaringshub — beslutningsflate etter innholdsstrategi.",
+    href: `${sprint}/hub-types/`,
+    issue: "#125C",
+  },
+  {
+    title: "Interaction states",
+    description: "Hover, focus og state-adferd før MVP surface reskin.",
+    href: `${sprint}/primitives/interaction-states/`,
+    issue: "#124D",
+  },
+  {
+    title: "Cards context",
+    description: "Clickable surfaces og card-roller — hub, editorial, helper, AI bridge.",
+    href: `${sprint}/primitives/cards/context/`,
+    issue: "#129",
+  },
+  {
+    title: "Buttons context",
+    description: "Action taxonomy, seed questions og pill-hierarki.",
+    href: `${sprint}/primitives/buttons/context/`,
+    issue: "#128",
+  },
+];
+
+const referenceLinks = [
+  {
+    title: "Typography Lab",
+    description: "Typografisk retning for MVP — display, sans og editorial presisjon.",
+    href: `${sprint}/typography/`,
+    issue: "#123",
+  },
+  {
+    title: "Color Lab",
+    description: "Fargetokens og retninger for MVP Design Lock.",
+    href: `${sprint}/color/`,
+    issue: "#122",
+  },
+];
+---
+
+<PrototypeLayout title="Viddel Review">
+  <main class="vreview" data-vis-review-page>
+    <header class="vreview__hero">
+      <p class="vreview__kicker">VIS · #131B · Review entry</p>
+      <h1>Viddel Review</h1>
+      <p class="vreview__lead">
+        Kuratert reviewflate for aktive beslutningsflater i Viddel Lab — uten historisk støy eller
+        agent-runtime.
+      </p>
+      <div class="vreview__status">
+        <span>Status</span>
+        <strong>Working review surface</strong>
+      </div>
+    </header>
+
+    <aside class="vreview__note" role="note">
+      <p>
+        <strong>Dette er beslutningsflater og arbeidsflater, ikke ferdig produkt.</strong>
+      </p>
+      <p>Historisk materiale er skjult fra denne reviewinngangen.</p>
+    </aside>
+
+    <section class="vreview__panel" aria-labelledby="active-heading">
+      <h2 id="active-heading">Active review</h2>
+      <p class="vreview__section-lead">Trygge flater for design- og retningsvurdering nå.</p>
+      <ul class="vreview__links" role="list">
+        {activeReviewLinks.map((item) => (
+          <li>
+            <a href={item.href} class="vreview__link">
+              <span class="vreview__link-issue">{item.issue}</span>
+              <span class="vreview__link-title">{item.title}</span>
+              <span class="vreview__link-desc">{item.description}</span>
+              <span class="vreview__link-arrow" aria-hidden="true">→</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+
+    <section class="vreview__panel vreview__panel--reference" aria-labelledby="reference-heading">
+      <h2 id="reference-heading">Reference labs</h2>
+      <p class="vreview__section-lead">Støttende retningsflater — vurdert stakeholder-safe i #131A.</p>
+      <ul class="vreview__links vreview__links--compact" role="list">
+        {referenceLinks.map((item) => (
+          <li>
+            <a href={item.href} class="vreview__link vreview__link--compact">
+              <span class="vreview__link-issue">{item.issue}</span>
+              <span class="vreview__link-title">{item.title}</span>
+              <span class="vreview__link-desc">{item.description}</span>
+              <span class="vreview__link-arrow" aria-hidden="true">→</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+
+    <footer class="vreview__footer">
+      <p>
+        Agent- og arkivinnganger finnes utenfor denne siden. For full VIS-oversikt, bruk{" "}
+        <a href={`${base}vis/`}>operativ VIS-index</a> (intern).
+      </p>
+    </footer>
+  </main>
+
+  <style>
+    [data-vis-review-page] {
+      --vr-deep: #134d6a;
+      --vr-ink: #111827;
+      --vr-muted: #6b7280;
+      --vr-light: #ffffff;
+      --vr-subtle: #f8fafc;
+      --vr-border: rgb(17 24 39 / 0.12);
+      --vr-radius: 10px;
+
+      max-width: 42rem;
+      margin: 0 auto;
+      padding: 1.75rem 1rem 3rem;
+      color: var(--vr-ink);
+      font-family: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+    }
+
+    .vreview__hero {
+      padding-bottom: 1.25rem;
+      border-bottom: 1px solid var(--vr-border);
+    }
+
+    .vreview__kicker {
+      margin: 0;
+      font-size: 0.68rem;
+      font-weight: 800;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--vr-deep);
+    }
+
+    .vreview__hero h1 {
+      margin: 0.45rem 0 0;
+      font-family: var(--font-display);
+      font-size: clamp(1.85rem, 5vw, 2.35rem);
+      font-weight: 650;
+      letter-spacing: -0.045em;
+      line-height: 1.05;
+    }
+
+    .vreview__lead {
+      margin: 0.75rem 0 0;
+      font-size: 0.9375rem;
+      line-height: 1.65;
+      color: var(--vr-muted);
+    }
+
+    .vreview__status {
+      display: inline-flex;
+      gap: 0.55rem;
+      align-items: center;
+      margin-top: 1rem;
+      padding: 0.35rem 0.65rem;
+      border: 1px solid rgb(19 77 106 / 0.22);
+      border-radius: 999px;
+      background: rgb(19 77 106 / 0.05);
+      font-size: 0.76rem;
+    }
+
+    .vreview__status span {
+      color: var(--vr-muted);
+    }
+
+    .vreview__note {
+      margin-top: 1.25rem;
+      padding: 0.9rem 1rem;
+      border: 1px solid rgb(19 77 106 / 0.2);
+      border-radius: var(--vr-radius);
+      background: rgb(19 77 106 / 0.04);
+      font-size: 0.84rem;
+      line-height: 1.6;
+    }
+
+    .vreview__note p {
+      margin: 0;
+    }
+
+    .vreview__note p + p {
+      margin-top: 0.45rem;
+      color: var(--vr-muted);
+    }
+
+    .vreview__panel {
+      margin-top: 1.5rem;
+    }
+
+    .vreview__panel h2 {
+      margin: 0;
+      font-family: var(--font-display);
+      font-size: 1.0625rem;
+      font-weight: 650;
+      letter-spacing: -0.02em;
+    }
+
+    .vreview__section-lead {
+      margin: 0.35rem 0 0.85rem;
+      font-size: 0.8125rem;
+      line-height: 1.55;
+      color: var(--vr-muted);
+    }
+
+    .vreview__links {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 0.55rem;
+    }
+
+    .vreview__link {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      grid-template-rows: auto auto;
+      gap: 0.15rem 0.65rem;
+      align-items: baseline;
+      padding: 0.85rem 1rem;
+      border: 1px solid var(--vr-border);
+      border-radius: var(--vr-radius);
+      background: var(--vr-light);
+      color: inherit;
+      text-decoration: none;
+      transition:
+        border-color 160ms ease,
+        box-shadow 160ms ease,
+        transform 160ms ease;
+    }
+
+    .vreview__link:hover {
+      border-color: rgb(19 77 106 / 0.28);
+      box-shadow: 0 8px 22px rgb(15 23 42 / 0.06);
+      transform: translateY(-1px);
+    }
+
+    .vreview__link:focus-visible {
+      outline: 3px solid rgb(14 165 233 / 0.38);
+      outline-offset: 2px;
+    }
+
+    .vreview__link-issue {
+      grid-row: 1 / span 2;
+      align-self: start;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      background: rgb(19 77 106 / 0.08);
+      color: var(--vr-deep);
+      font-size: 0.62rem;
+      font-weight: 800;
+      letter-spacing: 0.04em;
+    }
+
+    .vreview__link-title {
+      font-size: 0.9375rem;
+      font-weight: 650;
+      letter-spacing: -0.02em;
+    }
+
+    .vreview__link-desc {
+      grid-column: 2;
+      font-size: 0.78rem;
+      line-height: 1.5;
+      color: var(--vr-muted);
+    }
+
+    .vreview__link-arrow {
+      grid-row: 1 / span 2;
+      align-self: center;
+      color: var(--vr-deep);
+      font-size: 0.95rem;
+    }
+
+    .vreview__link--compact {
+      padding: 0.7rem 0.9rem;
+    }
+
+    .vreview__panel--reference {
+      padding-top: 0.25rem;
+    }
+
+    .vreview__footer {
+      margin-top: 2rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--vr-border);
+      font-size: 0.75rem;
+      line-height: 1.55;
+      color: var(--vr-muted);
+    }
+
+    .vreview__footer a {
+      color: var(--vr-deep);
+      text-underline-offset: 2px;
+    }
+  </style>
+</PrototypeLayout>

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -4,6 +4,7 @@
    #123: Typography Lab at /typography/ — full-width direction review.
    #124: Primitives Lab at /primitives/ — VIS-only primitive candidates.
    #125C: Hub type split at /hub-types/ — utility vs editorial decision surface.
+   #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
 import PrototypeLayout from "../../../../layouts/PrototypeLayout.astro";
@@ -78,6 +79,9 @@ const typographyLabDirections = [
     <!-- 1. Header / status -->
     <header class="sprint-preview__hero">
       <p class="sprint-preview__kicker">VIS / sprint preview</p>
+      <p class="sprint-preview__review-link">
+        Stakeholder review: <a href={`${base}vis/review/`}>Viddel Review →</a>
+      </p>
       <h1>Viddel Sprint Preview — 2026-W21</h1>
       <p class="sprint-preview__subtitle">VIS reviewflate for #120 / #126</p>
       <p class="sprint-preview__focus">
@@ -349,6 +353,18 @@ const typographyLabDirections = [
       letter-spacing: 0.16em;
       text-transform: uppercase;
       color: rgb(var(--reading-accent-iris));
+    }
+
+    .sprint-preview__review-link {
+      margin: 0.55rem 0 0;
+      font-size: 0.78rem;
+      color: rgb(var(--reading-ink-secondary));
+    }
+
+    .sprint-preview__review-link a {
+      font-weight: 600;
+      color: rgb(var(--reading-ink));
+      text-underline-offset: 2px;
     }
 
     .sprint-preview__hero h1 {


### PR DESCRIPTION
## Summary
- **#131A:** VIS inventory & access map (`docs/project/tasks/ISSUE_131A_VIS_INVENTORY_ACCESS_MAP.md`)
- **#131B:** Stakeholder-safe review entry at `/vis/review/` with curated W21 decision links

## Test plan
- [ ] https://vox.raddum.no/vis/review/ (after merge)
- [ ] Active links open correct decision surfaces
- [ ] No KlarLyd/archive links on review page
- [ ] Sprint preview links to Viddel Review
- [ ] `npm run build` green


Made with [Cursor](https://cursor.com)