### PR TITLE
feat(#131C): VIS review registry & sprint navigation

### DIFF
--- a/docs/project/tasks/ISSUE_131A_VIS_INVENTORY_ACCESS_MAP.md
+++ b/docs/project/tasks/ISSUE_131A_VIS_INVENTORY_ACCESS_MAP.md
@@ -204,12 +204,14 @@ Ikke gjort i #131A — kartlegging only.
 
 | Issue | Tittel | Scope | Avhenger av |
 |-------|--------|-------|-------------|
-| **#131B** | Stakeholder-safe VIS entry | Ny `/vis/review/` eller erstatte topp av `/vis/` med «safe set» + tydelig Viddel-branding; skjul/archive-lenker | #131A |
-| **#131C** | Route taxonomy & labeling | Metadata (`vis:status`, badges Active/Reference/Archive/Deprecated) i index; ingen sletting | #131A |
+| **#131B** | Stakeholder-safe VIS entry | `/vis/review/` — kuratert inngang | **Done** (`fb5e29c3`) |
+| **#131C** | Review registry & sprint navigation | `src/pages/vis/review/_data.ts` — datadrevet review med sprint, type, status | #131B |
 | **#131D** | Domain & access model | `vis.viddel.no`, redirect-plan, Vercel protection policy, Return Ticket URL-mal | #131A, drift |
 | **#131E** | Current-facing naming cleanup | Fjern KlarLyd/VOX fra titler brukere ser først; behold filer; rename display only der trygt | #131B |
 
-**Minste trygge neste steg etter #131A:** **#131B** — én kuratert inngang med direkte lenker til W21 safe set + «Do not share» for archive.
+**Registry ( #131C):** Nye reviewflater legges i `src/pages/vis/review/_data.ts` med `stakeholderSafe`, `sprint`, `type` og `status`. `/vis/review/` filtrerer automatisk — ingen hardkodede kort.
+
+**Minste trygge neste steg etter #131C:** **#131D** — domene/access, eller **#131E** — naming cleanup på current-facing VIS.
 
 ---
 

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -1,0 +1,136 @@
+/* CONTRACT: VIS review registry (#131C) — data source for /vis/review/.
+   Add new review surfaces here with sprint, type, status and stakeholderSafe flag.
+   Only stakeholderSafe items render on the public review entry.
+ */
+
+export type ReviewItemType = "active" | "reference" | "archive" | "deprecated";
+
+export type ReviewItemStatus =
+  | "needs-review"
+  | "in-review"
+  | "decision-candidate"
+  | "closed"
+  | "reference";
+
+export type ReviewRegistryItem = {
+  id: string;
+  title: string;
+  /** Path from site root, e.g. /vis/sprints/2026-w21/hub-types/ */
+  href: string;
+  sprint: string;
+  issue: string;
+  type: ReviewItemType;
+  status: ReviewItemStatus;
+  stakeholderSafe: boolean;
+  description: string;
+};
+
+export const reviewStatusLabels: Record<ReviewItemStatus, string> = {
+  "needs-review": "Needs review",
+  "in-review": "In review",
+  "decision-candidate": "Decision candidate",
+  closed: "Closed",
+  reference: "Reference",
+};
+
+export const reviewRegistry: ReviewRegistryItem[] = [
+  {
+    id: "sprint-preview-2026-w21",
+    title: "Sprint Preview 2026-W21",
+    href: "/vis/sprints/2026-w21/",
+    sprint: "2026-W21",
+    issue: "#126",
+    type: "active",
+    status: "in-review",
+    stakeholderSafe: true,
+    description: "Overordnet inngang til MVP Design Lock — typography, color og primitives.",
+  },
+  {
+    id: "hub-type-split",
+    title: "Hub type split",
+    href: "/vis/sprints/2026-w21/hub-types/",
+    sprint: "2026-W21",
+    issue: "#125C",
+    type: "active",
+    status: "needs-review",
+    stakeholderSafe: true,
+    description: "Utility/hjelpehub vs editorial/erfaringshub — beslutningsflate etter innholdsstrategi.",
+  },
+  {
+    id: "interaction-states",
+    title: "Interaction states",
+    href: "/vis/sprints/2026-w21/primitives/interaction-states/",
+    sprint: "2026-W21",
+    issue: "#124D",
+    type: "reference",
+    status: "decision-candidate",
+    stakeholderSafe: true,
+    description: "Hover, focus og state-adferd før MVP surface reskin.",
+  },
+  {
+    id: "cards-context",
+    title: "Cards context",
+    href: "/vis/sprints/2026-w21/primitives/cards/context/",
+    sprint: "2026-W21",
+    issue: "#129",
+    type: "reference",
+    status: "decision-candidate",
+    stakeholderSafe: true,
+    description: "Clickable surfaces og card-roller — hub, editorial, helper, AI bridge.",
+  },
+  {
+    id: "buttons-context",
+    title: "Buttons context",
+    href: "/vis/sprints/2026-w21/primitives/buttons/context/",
+    sprint: "2026-W21",
+    issue: "#128",
+    type: "reference",
+    status: "decision-candidate",
+    stakeholderSafe: true,
+    description: "Action taxonomy, seed questions og pill-hierarki.",
+  },
+  {
+    id: "typography-lab",
+    title: "Typography Lab",
+    href: "/vis/sprints/2026-w21/typography/",
+    sprint: "2026-W21",
+    issue: "#123",
+    type: "reference",
+    status: "reference",
+    stakeholderSafe: true,
+    description: "Typografisk retning for MVP — display, sans og editorial presisjon.",
+  },
+  {
+    id: "color-lab",
+    title: "Color Lab",
+    href: "/vis/sprints/2026-w21/color/",
+    sprint: "2026-W21",
+    issue: "#122",
+    type: "reference",
+    status: "reference",
+    stakeholderSafe: true,
+    description: "Fargetokens og retninger for MVP Design Lock.",
+  },
+];
+
+/** Items safe to show on /vis/review/ */
+export function stakeholderSafeItems(items: ReviewRegistryItem[] = reviewRegistry): ReviewRegistryItem[] {
+  return items.filter((item) => item.stakeholderSafe);
+}
+
+export function activeBySprint(items: ReviewRegistryItem[]): { sprint: string; items: ReviewRegistryItem[] }[] {
+  const active = items.filter((item) => item.type === "active");
+  const sprintOrder = [...new Set(active.map((item) => item.sprint))].sort((a, b) => b.localeCompare(a));
+  return sprintOrder.map((sprint) => ({
+    sprint,
+    items: active.filter((item) => item.sprint === sprint),
+  }));
+}
+
+export function referenceItems(items: ReviewRegistryItem[]): ReviewRegistryItem[] {
+  return items.filter((item) => item.type === "reference");
+}
+
+export function archivedItems(items: ReviewRegistryItem[]): ReviewRegistryItem[] {
+  return items.filter((item) => item.type === "archive" || item.type === "deprecated");
+}

--- a/src/pages/vis/review/index.astro
+++ b/src/pages/vis/review/index.astro
@@ -1,66 +1,39 @@
 ---
-/* CONTRACT: Stakeholder-safe VIS review entry (#131B).
-   Curated links to active decision surfaces only — no archive, raw KlarLyd, or agent runtime.
+/* CONTRACT: Stakeholder-safe VIS review entry (#131B / #131C).
+   Renders from review registry — curated links only, no archive/KlarLyd/agent runtime.
 */
 import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
 import "../../../styles/global.css";
+import {
+  activeBySprint,
+  archivedItems,
+  referenceItems,
+  reviewStatusLabels,
+  stakeholderSafeItems,
+  type ReviewRegistryItem,
+} from "./_data";
 
 const base = import.meta.env.BASE_URL;
-const sprint = `${base}vis/sprints/2026-w21`;
 
-const activeReviewLinks = [
-  {
-    title: "Sprint Preview 2026-W21",
-    description: "Overordnet inngang til MVP Design Lock — typography, color og primitives.",
-    href: `${sprint}/`,
-    issue: "#126",
-  },
-  {
-    title: "Hub type split",
-    description: "Utility/hjelpehub vs editorial/erfaringshub — beslutningsflate etter innholdsstrategi.",
-    href: `${sprint}/hub-types/`,
-    issue: "#125C",
-  },
-  {
-    title: "Interaction states",
-    description: "Hover, focus og state-adferd før MVP surface reskin.",
-    href: `${sprint}/primitives/interaction-states/`,
-    issue: "#124D",
-  },
-  {
-    title: "Cards context",
-    description: "Clickable surfaces og card-roller — hub, editorial, helper, AI bridge.",
-    href: `${sprint}/primitives/cards/context/`,
-    issue: "#129",
-  },
-  {
-    title: "Buttons context",
-    description: "Action taxonomy, seed questions og pill-hierarki.",
-    href: `${sprint}/primitives/buttons/context/`,
-    issue: "#128",
-  },
-];
+const safeItems = stakeholderSafeItems();
+const sprintGroups = activeBySprint(safeItems);
+const referenceLabs = referenceItems(safeItems);
+const archivedLabs = archivedItems(safeItems);
 
-const referenceLinks = [
-  {
-    title: "Typography Lab",
-    description: "Typografisk retning for MVP — display, sans og editorial presisjon.",
-    href: `${sprint}/typography/`,
-    issue: "#123",
-  },
-  {
-    title: "Color Lab",
-    description: "Fargetokens og retninger for MVP Design Lock.",
-    href: `${sprint}/color/`,
-    issue: "#122",
-  },
-];
+function resolveHref(href: string): string {
+  const normalized = href.startsWith("/") ? href.slice(1) : href;
+  return `${base}${normalized}`;
+}
+
+function statusClass(status: ReviewRegistryItem["status"]): string {
+  return `vreview__badge vreview__badge--${status}`;
+}
 ---
 
 <PrototypeLayout title="Viddel Review">
   <main class="vreview" data-vis-review-page>
     <header class="vreview__hero">
-      <p class="vreview__kicker">VIS · #131B · Review entry</p>
+      <p class="vreview__kicker">VIS · #131C · Review registry</p>
       <h1>Viddel Review</h1>
       <p class="vreview__lead">
         Kuratert reviewflate for aktive beslutningsflater i Viddel Lab — uten historisk støy eller
@@ -77,41 +50,78 @@ const referenceLinks = [
         <strong>Dette er beslutningsflater og arbeidsflater, ikke ferdig produkt.</strong>
       </p>
       <p>Historisk materiale er skjult fra denne reviewinngangen.</p>
+      <p class="vreview__note--registry">
+        Reviewflaten er generert fra en enkel registry. Nye reviewflater skal legges inn i{" "}
+        <code>src/pages/vis/review/_data.ts</code> med sprint, status og stakeholder-safe vurdering.
+      </p>
     </aside>
 
-    <section class="vreview__panel" aria-labelledby="active-heading">
-      <h2 id="active-heading">Active review</h2>
-      <p class="vreview__section-lead">Trygge flater for design- og retningsvurdering nå.</p>
-      <ul class="vreview__links" role="list">
-        {activeReviewLinks.map((item) => (
-          <li>
-            <a href={item.href} class="vreview__link">
-              <span class="vreview__link-issue">{item.issue}</span>
-              <span class="vreview__link-title">{item.title}</span>
-              <span class="vreview__link-desc">{item.description}</span>
-              <span class="vreview__link-arrow" aria-hidden="true">→</span>
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
+    {sprintGroups.map((group) => (
+      <section class="vreview__panel" aria-labelledby={`sprint-${group.sprint}`}>
+        <h2 id={`sprint-${group.sprint}`}>Current review · {group.sprint}</h2>
+        <p class="vreview__section-lead">Aktive flater i sprint {group.sprint} — trygge for design- og retningsvurdering.</p>
+        <ul class="vreview__links" role="list">
+          {group.items.map((item) => (
+            <li>
+              <a href={resolveHref(item.href)} class="vreview__link">
+                <span class="vreview__link-meta">
+                  <span class="vreview__link-issue">{item.issue}</span>
+                  <span class={statusClass(item.status)}>{reviewStatusLabels[item.status]}</span>
+                </span>
+                <span class="vreview__link-title">{item.title}</span>
+                <span class="vreview__link-desc">{item.description}</span>
+                <span class="vreview__link-arrow" aria-hidden="true">→</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
 
-    <section class="vreview__panel vreview__panel--reference" aria-labelledby="reference-heading">
-      <h2 id="reference-heading">Reference labs</h2>
-      <p class="vreview__section-lead">Støttende retningsflater — vurdert stakeholder-safe i #131A.</p>
-      <ul class="vreview__links vreview__links--compact" role="list">
-        {referenceLinks.map((item) => (
-          <li>
-            <a href={item.href} class="vreview__link vreview__link--compact">
-              <span class="vreview__link-issue">{item.issue}</span>
-              <span class="vreview__link-title">{item.title}</span>
-              <span class="vreview__link-desc">{item.description}</span>
-              <span class="vreview__link-arrow" aria-hidden="true">→</span>
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
+    {referenceLabs.length ? (
+      <section class="vreview__panel vreview__panel--reference" aria-labelledby="reference-heading">
+        <h2 id="reference-heading">Reference labs</h2>
+        <p class="vreview__section-lead">Beslutnings- og retningsflater bevart som referanse — fortsatt tilgjengelige for review.</p>
+        <ul class="vreview__links vreview__links--compact" role="list">
+          {referenceLabs.map((item) => (
+            <li>
+              <a href={resolveHref(item.href)} class="vreview__link vreview__link--compact">
+                <span class="vreview__link-meta">
+                  <span class="vreview__link-issue">{item.issue}</span>
+                  <span class={statusClass(item.status)}>{reviewStatusLabels[item.status]}</span>
+                </span>
+                <span class="vreview__link-title">{item.title}</span>
+                <span class="vreview__link-desc">{item.description}</span>
+                <span class="vreview__link-sprint">{item.sprint}</span>
+                <span class="vreview__link-arrow" aria-hidden="true">→</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ) : null}
+
+    {archivedLabs.length ? (
+      <section class="vreview__panel vreview__panel--archived" aria-labelledby="archived-heading">
+        <h2 id="archived-heading">Previous · archived</h2>
+        <p class="vreview__section-lead">Eldre reviewflater — tilgjengelig ved behov, ikke primær inngang.</p>
+        <ul class="vreview__links vreview__links--compact" role="list">
+          {archivedLabs.map((item) => (
+            <li>
+              <a href={resolveHref(item.href)} class="vreview__link vreview__link--compact vreview__link--muted">
+                <span class="vreview__link-meta">
+                  <span class="vreview__link-issue">{item.issue}</span>
+                  <span class={statusClass(item.status)}>{reviewStatusLabels[item.status]}</span>
+                </span>
+                <span class="vreview__link-title">{item.title}</span>
+                <span class="vreview__link-desc">{item.description}</span>
+                <span class="vreview__link-arrow" aria-hidden="true">→</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ) : null}
 
     <footer class="vreview__footer">
       <p>
@@ -127,7 +137,6 @@ const referenceLinks = [
       --vr-ink: #111827;
       --vr-muted: #6b7280;
       --vr-light: #ffffff;
-      --vr-subtle: #f8fafc;
       --vr-border: rgb(17 24 39 / 0.12);
       --vr-radius: 10px;
 
@@ -203,6 +212,17 @@ const referenceLinks = [
       color: var(--vr-muted);
     }
 
+    .vreview__note--registry {
+      margin-top: 0.65rem;
+      padding-top: 0.65rem;
+      border-top: 1px solid rgb(19 77 106 / 0.12);
+      font-size: 0.78rem;
+    }
+
+    .vreview__note code {
+      font-size: 0.72rem;
+    }
+
     .vreview__panel {
       margin-top: 1.5rem;
     }
@@ -233,8 +253,8 @@ const referenceLinks = [
     .vreview__link {
       display: grid;
       grid-template-columns: auto 1fr auto;
-      grid-template-rows: auto auto;
-      gap: 0.15rem 0.65rem;
+      grid-template-rows: auto auto auto;
+      gap: 0.2rem 0.65rem;
       align-items: baseline;
       padding: 0.85rem 1rem;
       border: 1px solid var(--vr-border);
@@ -259,9 +279,15 @@ const referenceLinks = [
       outline-offset: 2px;
     }
 
-    .vreview__link-issue {
-      grid-row: 1 / span 2;
+    .vreview__link-meta {
+      grid-row: 1 / span 3;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
       align-self: start;
+    }
+
+    .vreview__link-issue {
       padding: 0.15rem 0.4rem;
       border-radius: 999px;
       background: rgb(19 77 106 / 0.08);
@@ -269,6 +295,42 @@ const referenceLinks = [
       font-size: 0.62rem;
       font-weight: 800;
       letter-spacing: 0.04em;
+      white-space: nowrap;
+    }
+
+    .vreview__badge {
+      padding: 0.12rem 0.38rem;
+      border-radius: 999px;
+      font-size: 0.58rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    .vreview__badge--needs-review {
+      background: rgb(245 158 11 / 0.14);
+      color: rgb(146 64 14);
+    }
+
+    .vreview__badge--in-review {
+      background: rgb(14 165 233 / 0.12);
+      color: rgb(3 105 161);
+    }
+
+    .vreview__badge--decision-candidate {
+      background: rgb(19 77 106 / 0.12);
+      color: var(--vr-deep);
+    }
+
+    .vreview__badge--closed {
+      background: rgb(107 114 128 / 0.14);
+      color: rgb(55 65 81);
+    }
+
+    .vreview__badge--reference {
+      background: rgb(17 24 39 / 0.06);
+      color: var(--vr-muted);
     }
 
     .vreview__link-title {
@@ -284,8 +346,17 @@ const referenceLinks = [
       color: var(--vr-muted);
     }
 
+    .vreview__link-sprint {
+      grid-column: 2;
+      font-size: 0.65rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgb(107 114 128 / 0.85);
+    }
+
     .vreview__link-arrow {
-      grid-row: 1 / span 2;
+      grid-row: 1 / span 3;
       align-self: center;
       color: var(--vr-deep);
       font-size: 0.95rem;
@@ -293,10 +364,19 @@ const referenceLinks = [
 
     .vreview__link--compact {
       padding: 0.7rem 0.9rem;
+      grid-template-rows: auto auto auto;
+    }
+
+    .vreview__link--muted {
+      opacity: 0.88;
     }
 
     .vreview__panel--reference {
       padding-top: 0.25rem;
+    }
+
+    .vreview__panel--archived {
+      opacity: 0.92;
     }
 
     .vreview__footer {


### PR DESCRIPTION
## Summary
- Data-driven review registry at `src/pages/vis/review/_data.ts`
- `/vis/review/` renders sprint groups, reference labs, status badges
- Stakeholder-safe filter preserved; doc note in #131A inventory

## Test plan
- [ ] https://vox.raddum.no/vis/review/ after merge
- [ ] Status badges visible per item
- [ ] Current review · 2026-W21 + Reference labs sections
- [ ] No KlarLyd/archive items
- [ ] `npm run build` green


Made with [Cursor](https://cursor.com)