### PR TITLE
chore(#125D): Close hub-type split and sync VIS status

### DIFF
--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -51,10 +51,23 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     href: "/vis/sprints/2026-w21/hub-types/",
     sprint: "2026-W21",
     issue: "#125C",
-    type: "active",
-    status: "needs-review",
+    type: "reference",
+    status: "closed",
     stakeholderSafe: true,
-    description: "Utility/hjelpehub vs editorial/erfaringshub — beslutningsflate etter innholdsstrategi.",
+    description:
+      "Beslutning tatt: Hjelp A3 for utility-hub. Editorial hub kommer senere. VIS-beslutningsflate avsluttet etter #125C-R1.",
+  },
+  {
+    id: "hjelp-a3-production",
+    title: "Hjelp A3 production slice",
+    href: "/no/hub/",
+    sprint: "2026-W21",
+    issue: "#125D",
+    type: "reference",
+    status: "closed",
+    stakeholderSafe: true,
+    description:
+      "Applied Hjelp A3 på /no/hub — QA-godkjent. Videre polish venter til editorial hub og forside er på plass.",
   },
   {
     id: "interaction-states",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -3,7 +3,8 @@
    Test bench for #122 Color tokens, #123 Typography, #124 Primitives.
    #123: Typography Lab at /typography/ — full-width direction review.
    #124: Primitives Lab at /primitives/ — VIS-only primitive candidates.
-   #125C: Hub type split at /hub-types/ — utility vs editorial decision surface.
+   #125C: Hub type split at /hub-types/ — closed; Hjelp A3 valgt for utility.
+   #125D: Hjelp A3 applied on /no/hub/ — QA accepted, closed.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -112,7 +113,8 @@ const typographyLabDirections = [
         <li><strong>Parent issue:</strong> #120 MVP Design Lock v0.1</li>
         <li><strong>Preview issue:</strong> #126 VIS design preview</li>
         <li><strong>Testes i preview:</strong> #123 Typography v0.1 · #122 Color tokens v0.1 · #124 Primitives v0.1</li>
-        <li><strong>Senere bruk:</strong> #125 Reskin MVP Surfaces etter at byggeklossene er testet</li>
+        <li><strong>Applied:</strong> #125D Hjelp A3 på <code>/no/hub/</code> — QA-godkjent, closed</li>
+        <li><strong>Senere bruk:</strong> Editorial hub og forside før videre polish på Hjelp</li>
       </ul>
     </section>
 
@@ -252,14 +254,38 @@ const typographyLabDirections = [
       <div class="sprint-preview__section-head">
         <p class="sprint-preview__kicker">08 · #125C</p>
         <h2 id="hub-types-heading">Hub type split</h2>
-        <p>Utility/hjelpehub vs editorial/erfaringshub — beslutningsflate etter #130.</p>
+        <p>Komplementære hubtyper: Hjelp og editorial — beslutningsflate etter #130 og #125C-R1.</p>
+      </div>
+      <div class="sprint-preview__typo-summary">
+        <p class="sprint-preview__typo-decision">
+          <strong>Decision:</strong> Hjelp A3 valgt for utility-hub. Editorial hub kommer senere.
+        </p>
+        <p class="sprint-preview__typo-status">
+          <strong>Status:</strong> Closed — beslutningsflate avsluttet
+        </p>
+        <a href={`${base}vis/sprints/2026-w21/hub-types/`} class="sprint-preview__typo-link">
+          Open hub type comparison (reference) →
+        </a>
+      </div>
+    </section>
+
+    <!-- Hjelp A3 production (#125D) -->
+    <section class="sprint-preview__section" aria-labelledby="hjelp-a3-heading">
+      <div class="sprint-preview__section-head">
+        <p class="sprint-preview__kicker">09 · #125D</p>
+        <h2 id="hjelp-a3-heading">Hjelp A3 production slice</h2>
+        <p>Applied utility-hub på produksjon — AI-inngang, oppgavekort, korte guider og eskalering.</p>
       </div>
       <div class="sprint-preview__typo-summary">
         <p class="sprint-preview__typo-status">
-          <strong>Status:</strong> Decision support — navn og ruter er forslag
+          <strong>Status:</strong> QA accepted / closed
         </p>
-        <a href={`${base}vis/sprints/2026-w21/hub-types/`} class="sprint-preview__typo-link">
-          Open hub type comparison →
+        <p class="sprint-preview__typo-sans">
+          Videre polish på <code>/no/hub/</code> venter til editorial hub og forside er på plass.
+          Darkmode-svakheter observert — parkert til senere eget konsept/sweep, ikke del av #125D.
+        </p>
+        <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
+          Open production Hjelp hub →
         </a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Close #125C hub type split in review registry (no longer needs-review)
- Add #125D Hjelp A3 production slice to registry and sprint preview
- Note darkmode parked; further hub polish waits for editorial hub + forside

## Test plan
- [ ] `/vis/review/` — hub-types not in Needs review; #125D visible in Reference labs
- [ ] `/vis/sprints/2026-w21/` — #125C closed, #125D applied section present
- [ ] `/no/hub/` unchanged
- [ ] `npm run build` green


Made with [Cursor](https://cursor.com)