### PR TITLE
chore(#125F): Close editorial production slice in VIS review registry

### DIFF
--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -87,11 +87,11 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     href: "/no/lyd-i-hverdagen/",
     sprint: "2026-W21",
     issue: "#125F",
-    type: "active",
-    status: "needs-review",
+    type: "reference",
+    status: "closed",
     stakeholderSafe: true,
     description:
-      "Første editorial production slice — E2 situation-first. Arbeidstittel/rute, ikke i toppmeny ennå.",
+      "Editorial production slice QA-godkjent på /no/lyd-i-hverdagen/. Videre polish venter til forside/routing og helhetsjustering.",
   },
   {
     id: "interaction-states",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -6,7 +6,7 @@
    #125C: Hub type split at /hub-types/ — closed; Hjelp A3 valgt for utility.
    #125D: Hjelp A3 applied on /no/hub/ — QA accepted, closed.
    #125E: Editorial hub prototype — QA accepted; E2 base for #125F.
-   #125F: Lyd i hverdagen production slice at /no/lyd-i-hverdagen/.
+   #125F: Lyd i hverdagen production slice at /no/lyd-i-hverdagen/ — QA accepted, closed.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -116,7 +116,8 @@ const typographyLabDirections = [
         <li><strong>Preview issue:</strong> #126 VIS design preview</li>
         <li><strong>Testes i preview:</strong> #123 Typography v0.1 · #122 Color tokens v0.1 · #124 Primitives v0.1</li>
         <li><strong>Applied:</strong> #125D Hjelp A3 på <code>/no/hub/</code> — QA-godkjent, closed</li>
-        <li><strong>Senere bruk:</strong> Editorial hub og forside før videre polish på Hjelp</li>
+        <li><strong>Applied:</strong> #125F Editorial hub på <code>/no/lyd-i-hverdagen/</code> — QA-godkjent, closed</li>
+        <li><strong>Neste:</strong> Forside/routing — videre polish venter til helhetsjustering</li>
       </ul>
     </section>
 
@@ -324,10 +325,11 @@ const typographyLabDirections = [
       </div>
       <div class="sprint-preview__typo-summary">
         <p class="sprint-preview__typo-status">
-          <strong>Status:</strong> Needs review
+          <strong>Status:</strong> QA accepted / closed
         </p>
         <p class="sprint-preview__typo-sans">
-          Arbeidstittel <code>/no/lyd-i-hverdagen/</code> — ikke i toppmeny ennå. Forside/routing kommer senere.
+          Editorial production slice på <code>/no/lyd-i-hverdagen/</code> er god nok for nå — ikke i toppmeny ennå.
+          Videre polish venter til forside/routing og helhetsjustering.
         </p>
         <a href={`${base}no/lyd-i-hverdagen/`} class="sprint-preview__typo-link">
           Open production editorial hub →


### PR DESCRIPTION
## Summary
- Close #125F in VIS review registry after Thomas QA sign-off
- Sync Sprint Preview 2026-W21 status to QA accepted / closed
- No production UI changes

## Test plan
- [ ] `/vis/review/` — #125F shows closed, not needs-review
- [ ] `/vis/sprints/2026-w21/` — #125F section updated
- [ ] `/no/lyd-i-hverdagen/` unchanged
- [ ] `npm run build` green

Made with [Cursor](https://cursor.com)