### PR TITLE
feat(#125H): Sync top menu and footer to hub model navigation

### DIFF
--- a/src/components/nav/Footer.astro
+++ b/src/components/nav/Footer.astro
@@ -28,8 +28,9 @@ const isSandboxTall = variant === "sandbox-tall";
       isArticle && !isSandboxTall ? "text-xs" : "text-sm",
     ]}
   >
-    <a href="/no/hubs" class="hover:text-[rgb(var(--text))]">Emnehuber</a>
-    <a href="/no/chat" class="hover:text-[rgb(var(--text))]">Hørehjelpen</a>
+    <a href="/no" class="hover:text-[rgb(var(--text))]">Forside</a>
+    <a href="/no/hub" class="hover:text-[rgb(var(--text))]">Hjelp</a>
+    <a href="/no/lyd-i-hverdagen" class="hover:text-[rgb(var(--text))]">Lyd i hverdagen</a>
     <a href="/no/ordbok" class="hover:text-[rgb(var(--text))]">Ordbok</a>
     <a href="/no/om" class="hover:text-[rgb(var(--text))]">Om</a>
     <a href="/no/personvern" class="hover:text-[rgb(var(--text))]">Personvern</a>

--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -1,7 +1,7 @@
 <!-- CONTRACT: Global site header with desktop nav and mobile menu trigger. -->
 ---
 import MobileMenuTrigger from "./MobileMenuTrigger.astro";
-import { NO_NAV_LINKS } from "../../lib/no-nav-links";
+import { NO_NAV_CHAT_HREF, NO_NAV_CHAT_LABEL, NO_NAV_LINKS } from "../../lib/no-nav-links";
 import { isNavActive } from "../../lib/nav-active";
 
 type Props = {
@@ -15,7 +15,8 @@ type Props = {
 const { currentPath = "", brand = "default", showDevtoolsToggle = false } = Astro.props as Props;
 const base = import.meta.env.BASE_URL;
 const homeHref = `${base}no`;
-const chatHref = `${base}no/chat`;
+const chatHref = `${base}${NO_NAV_CHAT_HREF.replace(/^\//, "")}`;
+const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
 ---
 
 <header class="h-16 sm:h-[4.5rem]">
@@ -98,9 +99,13 @@ const chatHref = `${base}no/chat`;
     </nav>
     <a
       href={chatHref}
-      class="hidden items-center justify-center rounded-full border border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface))/0.42] px-5 py-2.5 text-sm font-semibold text-[rgb(var(--text))] transition-colors hover:border-[rgb(var(--text))/0.34] hover:bg-[rgb(var(--surface-subtle))/0.62] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex"
+      class={`hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
+        chatActive
+          ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"
+          : "border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface))/0.42] text-[rgb(var(--text))] hover:border-[rgb(var(--text))/0.34] hover:bg-[rgb(var(--surface-subtle))/0.62]"
+      }`}
     >
-      Start samtale
+      {NO_NAV_CHAT_LABEL}
     </a>
     <MobileMenuTrigger />
   </div>

--- a/src/components/nav/MobileMenuSheet.astro
+++ b/src/components/nav/MobileMenuSheet.astro
@@ -1,6 +1,6 @@
 <!-- CONTRACT: Full-screen mobile drawer; must stay outside backdrop-blur ancestors so fixed positioning works. -->
 ---
-import { NO_NAV_LINKS } from "../../lib/no-nav-links";
+import { NO_NAV_CHAT_HREF, NO_NAV_CHAT_LABEL, NO_NAV_LINKS } from "../../lib/no-nav-links";
 import { isNavActive } from "../../lib/nav-active";
 
 type Props = {
@@ -12,6 +12,7 @@ type Props = {
 const { currentPath = "", brand = "default", showDevtoolsToggle = false } = Astro.props as Props;
 const menuTitle =
   brand === "klarlyd" ? "KLARLYD meny" : brand === "viddel" ? "Viddel meny" : "VOX meny";
+const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
 ---
 
 <div
@@ -55,6 +56,16 @@ const menuTitle =
         })
       }
     </nav>
+    <a
+      href={NO_NAV_CHAT_HREF}
+      class={`mt-4 flex w-full items-center justify-center rounded-full border px-5 py-3 text-sm font-semibold transition-colors ${
+        chatActive
+          ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"
+          : "border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))]"
+      }`}
+    >
+      {NO_NAV_CHAT_LABEL}
+    </a>
     {
       showDevtoolsToggle ? (
         <div class="mt-4 border-t border-[rgb(var(--border))/0.35] pt-4">

--- a/src/lib/nav-active.ts
+++ b/src/lib/nav-active.ts
@@ -1,9 +1,12 @@
-/* CONTRACT: Consistent active-state matching for global NO navigation (hub-and-spoke + AI). */
+/* CONTRACT: Consistent active-state matching for global NO navigation (#125H hub model). */
 
 export function isNavActive(href: string, currentPath: string): boolean {
   const p = currentPath || "";
-  if (href === "/no") return p === "/no";
-  if (href === "/no/hubs") return p === "/no/hubs" || p === "/no/hub" || p.startsWith("/no/artikkel");
+  if (href === "/no") return p === "/no" || p === "/no/";
+  if (href === "/no/hub") return p === "/no/hub" || p.startsWith("/no/hub/");
+  if (href === "/no/lyd-i-hverdagen") {
+    return p === "/no/lyd-i-hverdagen" || p.startsWith("/no/lyd-i-hverdagen/");
+  }
   if (href === "/no/chat") return p.startsWith("/no/chat");
   if (href !== "/no" && p.startsWith(`${href}/`)) return true;
   return p === href;

--- a/src/lib/no-nav-links.ts
+++ b/src/lib/no-nav-links.ts
@@ -1,10 +1,14 @@
-/* CONTRACT: Primary NO-site navigation labels (hub-and-spoke + fri samtale). */
+/* CONTRACT: Primary NO-site navigation (#125H) — hub model: Forside, Hjelp, Lyd i hverdagen, Ordbok, Om.
+   Hørehjelpen via header/mobile CTA only (not a regular nav item).
+ */
 
 export const NO_NAV_LINKS = [
   { href: "/no", label: "Forside" },
-  { href: "/no/hubs", label: "Emnehuber" },
-  { href: "/no/info", label: "Kom i gang" },
+  { href: "/no/hub", label: "Hjelp" },
+  { href: "/no/lyd-i-hverdagen", label: "Lyd i hverdagen" },
   { href: "/no/ordbok", label: "Ordbok" },
-  { href: "/no/chat", label: "Hørehjelpen" },
   { href: "/no/om", label: "Om" },
 ] as const;
+
+export const NO_NAV_CHAT_HREF = "/no/chat";
+export const NO_NAV_CHAT_LABEL = "Start samtale";

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -94,6 +94,18 @@ export const reviewRegistry: ReviewRegistryItem[] = [
       "Mandat godkjent — avklaringsflate / triage. Applied som #125G-R3 på /no/.",
   },
   {
+    id: "nav-top-menu",
+    title: "Navigation / top menu",
+    href: "/no/",
+    sprint: "2026-W21",
+    issue: "#125H",
+    type: "active",
+    status: "needs-review",
+    stakeholderSafe: true,
+    description:
+      "Toppmeny og footer synket til hubmodellen — Forside, Hjelp, Lyd i hverdagen, Ordbok, Om + Start samtale CTA.",
+  },
+  {
     id: "forside-routing",
     title: "Forside / routing",
     href: "/no/",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -9,6 +9,7 @@
    #125F: Lyd i hverdagen production slice at /no/lyd-i-hverdagen/ — QA accepted, closed.
    #125G: Forside/routing at /no/ — QA accepted, closed (#125G-R3 triage mandate).
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
+   #125H: Navigation / top menu pass — hub model in header and footer.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -120,7 +121,8 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125D Hjelp A3 på <code>/no/hub/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125F Editorial hub på <code>/no/lyd-i-hverdagen/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
-        <li><strong>Neste:</strong> Nav/toppmeny-pass eller sprint closure — ikke ny forside-polish nå</li>
+        <li><strong>Applied:</strong> #125H Nav/toppmeny — needs review</li>
+        <li><strong>Neste:</strong> Sprint closure eller videre IA etter nav-QA</li>
       </ul>
     </section>
 
@@ -378,6 +380,27 @@ const typographyLabDirections = [
         </p>
         <a href={`${base}vis/sprints/2026-w21/frontpage-mandate/`} class="sprint-preview__typo-link">
           Open frontpage mandate decision →
+        </a>
+      </div>
+    </section>
+
+    <!-- Navigation / top menu (#125H) -->
+    <section class="sprint-preview__section" aria-labelledby="nav-top-menu-heading">
+      <div class="sprint-preview__section-head">
+        <p class="sprint-preview__kicker">14 · #125H</p>
+        <h2 id="nav-top-menu-heading">Navigation / top menu</h2>
+        <p>Toppmeny og footer synket til hubmodellen etter #125G.</p>
+      </div>
+      <div class="sprint-preview__typo-summary">
+        <p class="sprint-preview__typo-status">
+          <strong>Status:</strong> Applied — needs review
+        </p>
+        <p class="sprint-preview__typo-sans">
+          Primærnav: Forside, Hjelp, Lyd i hverdagen, Ordbok, Om. CTA: Start samtale →{" "}
+          <code>/no/chat</code>. Emnehuber og Kom i gang fjernet fra primærnav.
+        </p>
+        <a href={`${base}no/`} class="sprint-preview__typo-link">
+          Verify navigation on production →
         </a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Primary nav: Forside, Hjelp, Lyd i hverdagen, Ordbok, Om
- CTA: Start samtale → /no/chat (desktop header + mobile menu)
- Footer aligned; Emnehuber/Kom i gang removed from primary nav
- VIS registry + sprint preview updated

## Test plan
- [ ] /no/hub/ shows Hjelp active
- [ ] /no/lyd-i-hverdagen/ shows Lyd i hverdagen active
- [ ] CTA works; no Emnehuber in header
- [ ] Live prod verified after merge

Made with [Cursor](https://cursor.com)