### PR TITLE
fix(#125H-R1): Stabilize header vertical placement across routes

### DIFF
--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -19,8 +19,8 @@ const chatHref = `${base}${NO_NAV_CHAT_HREF.replace(/^\//, "")}`;
 const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
 ---
 
-<header class="h-16 sm:h-[4.5rem]">
-  <div class="flex h-full items-center gap-3 sm:gap-4">
+<header class="h-full min-h-16 sm:min-h-[4.5rem]">
+  <div class="flex h-full min-h-16 items-center gap-3 sm:min-h-[4.5rem] sm:gap-4">
     <a
       href={homeHref}
       class="inline-flex items-center rounded-[var(--radius-sm)] px-2 py-1.5 text-sm font-semibold tracking-tight text-[rgb(var(--text))] sm:text-base"
@@ -47,15 +47,15 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
         )
       }
     </a>
-    <nav class="hidden flex-1 items-center justify-center gap-1 lg:flex">
+    <nav class="hidden min-h-9 flex-1 items-center justify-center gap-1 lg:flex">
       {NO_NAV_LINKS.map((link) => {
         const isActive = isNavActive(link.href, currentPath);
         return (
           <a
             href={link.href}
-            class={`rounded-[var(--radius-sm)] px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] ${
+            class={`inline-flex min-h-9 items-center rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] ${
               isActive
-                ? "bg-[rgb(var(--surface-subtle))] font-semibold text-[rgb(var(--text))] shadow-[var(--shadow-sm)]"
+                ? "bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))]"
                 : "text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-subtle))/0.7] hover:text-[rgb(var(--text))]"
             }`}
           >
@@ -99,7 +99,7 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
     </nav>
     <a
       href={chatHref}
-      class={`hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
+      class={`hidden min-h-[2.625rem] items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
         chatActive
           ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"
           : "border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface))/0.42] text-[rgb(var(--text))] hover:border-[rgb(var(--text))/0.34] hover:bg-[rgb(var(--surface-subtle))/0.62]"

--- a/src/components/nav/MobileMenuSheet.astro
+++ b/src/components/nav/MobileMenuSheet.astro
@@ -43,9 +43,9 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
           return (
             <a
               href={link.href}
-              class={`flex w-full items-center justify-between rounded-[var(--radius-sm)] px-3 py-3 text-sm transition-colors ${
+              class={`flex min-h-11 w-full items-center justify-between rounded-[var(--radius-sm)] px-3 py-3 text-sm font-medium leading-none transition-colors ${
                 isActive
-                  ? "bg-[rgb(var(--surface-subtle))] font-semibold text-[rgb(var(--text))]"
+                  ? "bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))]"
                   : "text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-subtle))/0.7] hover:text-[rgb(var(--text))]"
               }`}
             >

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -134,7 +134,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <header class="fixed inset-x-0 top-0 z-40">
       <div
-        class="bg-[rgb(var(--surface-elevated))/0.88] backdrop-blur-xl"
+        class="h-16 bg-[rgb(var(--surface-elevated))/0.88] backdrop-blur-xl sm:h-[4.5rem]"
         style="box-shadow: var(--shadow-header);"
       >
         <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- Locks fixed header shell to explicit `h-16 sm:h-[4.5rem]` in BaseLayout so backdrop height cannot vary between routes.
- Stabilizes desktop/mobile nav link metrics: consistent `font-medium`, fixed `min-h`, `leading-none`; removes active-state `font-semibold` and `shadow-sm` that caused subpixel vertical shift when switching pages.
- CTA keeps fixed `min-h-[2.625rem]` across active/inactive states.

## Cause
Active nav items switched from normal weight to `font-semibold` plus `shadow-sm`, changing text metrics and perceived vertical alignment within the header row. Header outer wrapper also lacked explicit height lock.

## Test plan
- [ ] `/no/` ↔ `/no/hub/` ↔ `/no/lyd-i-hverdagen/` ↔ `/no/chat/` ↔ `/no/ordbok/` ↔ `/no/om/` — header bar same vertical position
- [ ] Desktop nav active state still visible (background + text color)
- [ ] Mobile ~390px — nav items stable in sheet
- [ ] CTA «Start samtale» works; active on `/no/chat/`
- [ ] Light / dark / system
- [ ] Footer nav unchanged

Closes #125H-R1 (QA follow-up on #125H).


Made with [Cursor](https://cursor.com)