### PR TITLE
fix(#125H-R2): Revert R1 nav regression and stabilize header metrics

### DIFF
--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -17,10 +17,13 @@ const base = import.meta.env.BASE_URL;
 const homeHref = `${base}no`;
 const chatHref = `${base}${NO_NAV_CHAT_HREF.replace(/^\//, "")}`;
 const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
+
+const navLinkClass =
+  "inline-flex items-center rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4]";
 ---
 
-<header class="h-full min-h-16 sm:min-h-[4.5rem]">
-  <div class="flex h-full min-h-16 items-center gap-3 sm:min-h-[4.5rem] sm:gap-4">
+<header class="h-16 sm:h-[4.5rem]">
+  <div class="flex h-full items-center gap-3 sm:gap-4">
     <a
       href={homeHref}
       class="inline-flex items-center rounded-[var(--radius-sm)] px-2 py-1.5 text-sm font-semibold tracking-tight text-[rgb(var(--text))] sm:text-base"
@@ -47,13 +50,13 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
         )
       }
     </a>
-    <nav class="hidden min-h-9 flex-1 items-center justify-center gap-1 lg:flex">
+    <nav class="hidden flex-1 items-center justify-center gap-1 lg:flex">
       {NO_NAV_LINKS.map((link) => {
         const isActive = isNavActive(link.href, currentPath);
         return (
           <a
             href={link.href}
-            class={`inline-flex min-h-9 items-center rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] ${
+            class={`${navLinkClass} ${
               isActive
                 ? "bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))]"
                 : "text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-subtle))/0.7] hover:text-[rgb(var(--text))]"
@@ -99,7 +102,7 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
     </nav>
     <a
       href={chatHref}
-      class={`hidden min-h-[2.625rem] items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
+      class={`hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
         chatActive
           ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"
           : "border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface))/0.42] text-[rgb(var(--text))] hover:border-[rgb(var(--text))/0.34] hover:bg-[rgb(var(--surface-subtle))/0.62]"

--- a/src/components/nav/MobileMenuSheet.astro
+++ b/src/components/nav/MobileMenuSheet.astro
@@ -43,7 +43,7 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
           return (
             <a
               href={link.href}
-              class={`flex min-h-11 w-full items-center justify-between rounded-[var(--radius-sm)] px-3 py-3 text-sm font-medium leading-none transition-colors ${
+              class={`flex w-full items-center justify-between rounded-[var(--radius-sm)] px-3 py-3 text-sm font-medium transition-colors ${
                 isActive
                   ? "bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))]"
                   : "text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-subtle))/0.7] hover:text-[rgb(var(--text))]"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -134,7 +134,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <header class="fixed inset-x-0 top-0 z-40">
       <div
-        class="h-16 bg-[rgb(var(--surface-elevated))/0.88] backdrop-blur-xl sm:h-[4.5rem]"
+        class="bg-[rgb(var(--surface-elevated))/0.88] backdrop-blur-xl"
         style="box-shadow: var(--shadow-header);"
       >
         <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- Reverts all #125H-R1 layout changes that introduced a sharper vertical jump on global nav page switches (conflicting height locks, `leading-none`, extra `min-h` constraints).
- Keeps a minimal stability fix from pre-R1 baseline: nav links use consistent `font-medium` + `inline-flex items-center` on all states; active indicator is background/color only (no `font-semibold`, no `shadow-sm`).
- Restores single source of truth for header height in `Header.astro` (`h-16 sm:h-[4.5rem]`).

## R1 regression cause
R1 stacked fixed height on BaseLayout backdrop (`h-16 sm:h-[4.5rem]`) while Header switched to `h-full min-h-*` through a middle wrapper without explicit height — broken percentage chain + `leading-none`/`min-h-9` caused visible reflow on each full-page nav click.

## Verification (Playwright bounding-box check, local preview)
| Viewport | Route | fixed-shell top | height |
|---|---|---:|---:|
| desktop 1280 | /no/, /no/hub/, /no/lyd-i-hverdagen/, /no/chat/, /no/ordbok/, /no/om/ | 0 | 72 |
| mobile 390 | same routes | 0 | 64 |
Nav links (desktop): top=18, height=36 on all routes (active + inactive).

## Test plan
- [ ] /no/ ↔ /no/hub/ ↔ /no/lyd-i-hverdagen/ ↔ /no/chat/ — no header/nav jump
- [ ] Active state still readable (bg + text color)
- [ ] CTA «Start samtale» works
- [ ] Mobile ~390px
- [ ] Light / dark / system

Follow-up on #125. Does not close #125H (needs Thomas QA).


Made with [Cursor](https://cursor.com)