### PR TITLE
fix(#125H-R3): Stop transient header layout shift on load

### DIFF
--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -19,14 +19,14 @@ const chatHref = `${base}${NO_NAV_CHAT_HREF.replace(/^\//, "")}`;
 const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
 
 const navLinkClass =
-  "inline-flex items-center rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4]";
+  "inline-flex items-center rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4]";
 ---
 
 <header class="h-16 sm:h-[4.5rem]">
   <div class="flex h-full items-center gap-3 sm:gap-4">
     <a
       href={homeHref}
-      class="inline-flex items-center rounded-[var(--radius-sm)] px-2 py-1.5 text-sm font-semibold tracking-tight text-[rgb(var(--text))] sm:text-base"
+      class="vox-header-brand inline-flex items-center rounded-[var(--radius-sm)] px-2 py-1.5 text-sm font-semibold tracking-tight text-[rgb(var(--text))] sm:text-base"
       aria-label={brand === "viddel" ? "Viddel" : undefined}
     >
       {
@@ -102,7 +102,7 @@ const navLinkClass =
     </nav>
     <a
       href={chatHref}
-      class={`hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
+      class={`vox-header-chat-cta hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
         chatActive
           ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"
           : "border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface))/0.42] text-[rgb(var(--text))] hover:border-[rgb(var(--text))/0.34] hover:bg-[rgb(var(--surface-subtle))/0.62]"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,6 +55,107 @@ const isSandboxWhite = shellVariant === "sandbox-white";
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Epilogue:wght@500;600;700&family=Inter:wght@400;500;600&display=swap"
     />
+    <style is:inline>
+      /* #125H-R3: critical header/shell metrics before Tailwind bundle paints */
+      body > header.fixed {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 40;
+      }
+      body > header.fixed header {
+        height: 4rem;
+        min-height: 4rem;
+      }
+      body > header.fixed header > div {
+        display: flex;
+        height: 100%;
+        align-items: center;
+        gap: 0.75rem;
+      }
+      body > header.fixed header .vox-header-brand {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+      }
+      body > header.fixed header nav {
+        display: none;
+      }
+      body > header.fixed #menuToggleBtn {
+        display: inline-flex;
+        margin-left: auto;
+      }
+      body > header.fixed header .vox-header-chat-cta {
+        display: none;
+      }
+      @media (min-width: 640px) {
+        body > header.fixed header {
+          height: 4.5rem;
+          min-height: 4.5rem;
+        }
+        body > header.fixed header > div {
+          gap: 1rem;
+        }
+      }
+      @media (min-width: 1024px) {
+        body > header.fixed header nav {
+          display: flex;
+          flex: 1 1 0%;
+          align-items: center;
+          justify-content: center;
+          gap: 0.25rem;
+        }
+        body > header.fixed header nav a,
+        body > header.fixed header nav button[data-vox-header-devtools-toggle] {
+          display: inline-flex;
+          align-items: center;
+          font-size: 0.875rem;
+          line-height: 1.25rem;
+          font-weight: 500;
+        }
+        body > header.fixed header nav a {
+          padding: 0.5rem 0.75rem;
+        }
+        body > header.fixed header nav button[data-vox-header-devtools-toggle] {
+          padding: 0.5rem;
+        }
+        body > header.fixed #menuToggleBtn {
+          display: none;
+        }
+        body > header.fixed header .vox-header-chat-cta {
+          display: inline-flex;
+          align-items: center;
+          padding: 0.625rem 1.25rem;
+          font-size: 0.875rem;
+          line-height: 1.25rem;
+          font-weight: 600;
+        }
+      }
+      .vox-shell-content {
+        padding-top: 7rem;
+      }
+      @media (min-width: 640px) {
+        .vox-shell-content {
+          padding-top: 7.5rem;
+        }
+      }
+      body > header.fixed header .font-display {
+        display: inline-flex;
+        align-items: center;
+        line-height: 1.2;
+        min-height: 1.18rem;
+        font-size: 1.18rem;
+        font-weight: 650;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+      }
+      @media (min-width: 640px) {
+        body > header.fixed header .font-display {
+          min-height: 1.45rem;
+          font-size: 1.45rem;
+        }
+      }
+    </style>
     <InspectDrawerArmScript />
     <slot name="head" />
     <script defer src="https://www.gstatic.com/ces-console/fast/chat-messenger/prod/v1.15/chat-messenger.js"></script>
@@ -145,7 +246,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
 
-    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
+    <div class="vox-shell-content mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
       <slot />
     </div>
 


### PR DESCRIPTION
## Diagnosis
Playwright time-series with delayed `/_astro/` CSS reproduced the visible jump Thomas reported:

**Before fix (prod, 800ms CSS delay):**
| Metric | Before Tailwind | After Tailwind | Δ |
|---|---:|---:|---:|
| header top | 8px | 0px | **8px** |
| header height | 68px | 72px | 4px |
| nav top | 26px | 18px | **8px** |
| wordmark height | 18px (Times fallback) | 34.8px | 16.8px |

**Root cause:** HTML renders before Tailwind bundle paints. Utility classes (`fixed`, `top-0`, `h-16`, `hidden`, `lg:flex`, nav padding) are inert until CSS loads → header is not fixed, wrong height, nav/menu visibility wrong, then snaps when CSS arrives. Happens on hard refresh and full-page global nav clicks.

Theme init and final bounding boxes were already stable; issue is transient FOUC.

## Fix
- Inline critical CSS in `BaseLayout.astro` (not global.css): fixed header position, header height, shell content offset, flex row, responsive nav/menu/CTA display, wordmark metrics, nav link padding.
- Hook classes: `vox-shell-content`, `vox-header-brand`, `vox-header-chat-cta`.
- Remove `transition-colors` from nav links (color-only; not layout, avoids load flash).

**After fix (local, 800ms CSS delay):** headerΔtop=0, headerΔh=0, navΔtop=0 (desktop + mobile 390px).

## Test plan
- [ ] Hard refresh `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/` — no header/nav jump
- [ ] Global nav click between routes — no jump
- [ ] Mobile ~390px
- [ ] Light / dark / system

#125H remains needs-review.


Made with [Cursor](https://cursor.com)