### PR TITLE
#125H-R4: Revert R3 critical CSS; park header jump to #125I

### DIFF
--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -19,14 +19,14 @@ const chatHref = `${base}${NO_NAV_CHAT_HREF.replace(/^\//, "")}`;
 const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
 
 const navLinkClass =
-  "inline-flex items-center rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4]";
+  "inline-flex items-center rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4]";
 ---
 
 <header class="h-16 sm:h-[4.5rem]">
   <div class="flex h-full items-center gap-3 sm:gap-4">
     <a
       href={homeHref}
-      class="vox-header-brand inline-flex items-center rounded-[var(--radius-sm)] px-2 py-1.5 text-sm font-semibold tracking-tight text-[rgb(var(--text))] sm:text-base"
+      class="inline-flex items-center rounded-[var(--radius-sm)] px-2 py-1.5 text-sm font-semibold tracking-tight text-[rgb(var(--text))] sm:text-base"
       aria-label={brand === "viddel" ? "Viddel" : undefined}
     >
       {
@@ -102,7 +102,7 @@ const navLinkClass =
     </nav>
     <a
       href={chatHref}
-      class={`vox-header-chat-cta hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
+      class={`hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
         chatActive
           ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"
           : "border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface))/0.42] text-[rgb(var(--text))] hover:border-[rgb(var(--text))/0.34] hover:bg-[rgb(var(--surface-subtle))/0.62]"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,107 +55,6 @@ const isSandboxWhite = shellVariant === "sandbox-white";
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Epilogue:wght@500;600;700&family=Inter:wght@400;500;600&display=swap"
     />
-    <style is:inline>
-      /* #125H-R3: critical header/shell metrics before Tailwind bundle paints */
-      body > header.fixed {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        z-index: 40;
-      }
-      body > header.fixed header {
-        height: 4rem;
-        min-height: 4rem;
-      }
-      body > header.fixed header > div {
-        display: flex;
-        height: 100%;
-        align-items: center;
-        gap: 0.75rem;
-      }
-      body > header.fixed header .vox-header-brand {
-        display: inline-flex;
-        align-items: center;
-        padding: 0.375rem 0.5rem;
-      }
-      body > header.fixed header nav {
-        display: none;
-      }
-      body > header.fixed #menuToggleBtn {
-        display: inline-flex;
-        margin-left: auto;
-      }
-      body > header.fixed header .vox-header-chat-cta {
-        display: none;
-      }
-      @media (min-width: 640px) {
-        body > header.fixed header {
-          height: 4.5rem;
-          min-height: 4.5rem;
-        }
-        body > header.fixed header > div {
-          gap: 1rem;
-        }
-      }
-      @media (min-width: 1024px) {
-        body > header.fixed header nav {
-          display: flex;
-          flex: 1 1 0%;
-          align-items: center;
-          justify-content: center;
-          gap: 0.25rem;
-        }
-        body > header.fixed header nav a,
-        body > header.fixed header nav button[data-vox-header-devtools-toggle] {
-          display: inline-flex;
-          align-items: center;
-          font-size: 0.875rem;
-          line-height: 1.25rem;
-          font-weight: 500;
-        }
-        body > header.fixed header nav a {
-          padding: 0.5rem 0.75rem;
-        }
-        body > header.fixed header nav button[data-vox-header-devtools-toggle] {
-          padding: 0.5rem;
-        }
-        body > header.fixed #menuToggleBtn {
-          display: none;
-        }
-        body > header.fixed header .vox-header-chat-cta {
-          display: inline-flex;
-          align-items: center;
-          padding: 0.625rem 1.25rem;
-          font-size: 0.875rem;
-          line-height: 1.25rem;
-          font-weight: 600;
-        }
-      }
-      .vox-shell-content {
-        padding-top: 7rem;
-      }
-      @media (min-width: 640px) {
-        .vox-shell-content {
-          padding-top: 7.5rem;
-        }
-      }
-      body > header.fixed header .font-display {
-        display: inline-flex;
-        align-items: center;
-        line-height: 1.2;
-        min-height: 1.18rem;
-        font-size: 1.18rem;
-        font-weight: 650;
-        font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
-      }
-      @media (min-width: 640px) {
-        body > header.fixed header .font-display {
-          min-height: 1.45rem;
-          font-size: 1.45rem;
-        }
-      }
-    </style>
     <InspectDrawerArmScript />
     <slot name="head" />
     <script defer src="https://www.gstatic.com/ces-console/fast/chat-messenger/prod/v1.15/chat-messenger.js"></script>
@@ -246,7 +145,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
 
-    <div class="vox-shell-content mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
+    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
       <slot />
     </div>
 


### PR DESCRIPTION
## Summary
- **#125H-R4 visual diagnosis** on prod (`vox.raddum.no`): Playwright timeline + delayed-CSS tests across `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/` (mobile ~390px, light theme, hard refresh + globalnav).
- **Findings:** With R3 active, headless bounding-box metrics were stable (headerTop=0, headerH=64/72, navTop stable) after first paint — but Thomas QA still sees visible jump on refresh and globalnav clicks. Artificial CSS delay (pre-R3 FOUC repro) confirms header/nav metrics shift before Tailwind paints; R3 critical CSS masked metrics in automation but did not fix perceived UX.
- **Decision (option B):** Revert entire `#125H-R3` inline critical CSS block + hook classes. Keep **#125H IA** and **R2 nav active-state** (`font-medium` always, active via bg/color only). Park header jump fix to **#125I** cross-surface polish/layout pass.

## What moves (diagnosis)
| Phase | header top | header height | nav top | content padding-top |
|-------|-----------|---------------|---------|---------------------|
| Pre-Tailwind (FOUC, delayed CSS) | 8→0 | 68→72 | 26→18 | unset→120px |
| R3 prod (normal load, headless) | 0 (stable) | 64/72 (stable) | 0/18 (stable) | 112px (appears at ~16ms) |
| Cross-route nav click | 0 (identical all routes) | identical | identical | identical |

**Likely visible jump sources:** (1) transient FOUC before Tailwind when critical CSS insufficient or overridden; (2) content wrapper `padding-top` appearing ~16ms after commit on some routes; (3) possible compositing/backdrop-blur or font-swap effects not captured by getBoundingClientRect in headless.

## Changes
- Remove `#125H-R3` inline `<style is:inline>` from `BaseLayout.astro`
- Remove `.vox-shell-content` class from content wrapper
- Restore `vox-header-brand` / `vox-header-chat-cta` removal + `transition-colors` on nav links in `Header.astro`

## Test plan
- [ ] Hard refresh `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/` — confirm no regression vs R3 (jump may remain; that's expected/parked)
- [ ] Globalnav clicks between routes — header should behave same as pre-R3 baseline
- [ ] Nav IA unchanged (R2 labels/order)
- [ ] `npm run build` green
- [ ] #125H stays open for Thomas R4 QA

Closes nothing. Refs #125.


Made with [Cursor](https://cursor.com)