### PR TITLE
#125H-R5: Content offset stability at first paint

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,6 +55,17 @@ const isSandboxWhite = shellVariant === "sandbox-white";
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Epilogue:wght@500;600;700&family=Inter:wght@400;500;600&display=swap"
     />
+    <style is:inline>
+      /* #125H-R5: content offset under fixed header before Tailwind bundle paints */
+      .vox-shell-content {
+        padding-top: 7rem;
+      }
+      @media (min-width: 640px) {
+        .vox-shell-content {
+          padding-top: 7.5rem;
+        }
+      }
+    </style>
     <InspectDrawerArmScript />
     <slot name="head" />
     <script defer src="https://www.gstatic.com/ces-console/fast/chat-messenger/prod/v1.15/chat-messenger.js"></script>
@@ -145,7 +156,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
 
-    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
+    <div class="vox-shell-content mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
       <slot />
     </div>
 


### PR DESCRIPTION
## Summary
- Minimal inline critical CSS in `BaseLayout.astro` for `.vox-shell-content` only — `padding-top: 7rem` (mobile) / `7.5rem` (sm+), matching existing `pt-28` / `sm:pt-30`.
- Content offset is now present before the Tailwind bundle paints; no header/nav critical CSS reintroduced.

## Diagnosis (R4 + R5)
Thomas QA: content area “snaps” vertically after first paint while header looks stable. R4 found `contentPtChanged: true` — Tailwind `pt-28`/`sm:pt-30` only apply after `/_astro/` CSS loads.

**Delayed-CSS test (600ms `_astro/` delay, local preview):**
- Frame 1 when content wrapper appears: `contentPt: 120px` ✅ (critical CSS active)
- Stable through networkidle; no padding-top shift when Tailwind arrives

## Scope
- Only `BaseLayout.astro` — content wrapper class + 12-line inline style block
- IA (#125H), nav active-state (R2), header/nav unchanged

## Test plan
- [ ] Hard refresh: `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/`, `/no/ordbok/`, `/no/om/`
- [ ] Globalnav clicks between routes (desktop + mobile ~390px)
- [ ] No visible content snap under header
- [ ] `npm run build` green

Refs #125. Does not close #125H — needs Thomas R5 QA.


Made with [Cursor](https://cursor.com)