### PR TITLE
#125H-R6: Rollback to pre-fix layout baseline (73b17e25)

### DIFF
--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -17,9 +17,6 @@ const base = import.meta.env.BASE_URL;
 const homeHref = `${base}no`;
 const chatHref = `${base}${NO_NAV_CHAT_HREF.replace(/^\//, "")}`;
 const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
-
-const navLinkClass =
-  "inline-flex items-center rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4]";
 ---
 
 <header class="h-16 sm:h-[4.5rem]">
@@ -56,9 +53,9 @@ const navLinkClass =
         return (
           <a
             href={link.href}
-            class={`${navLinkClass} ${
+            class={`rounded-[var(--radius-sm)] px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] ${
               isActive
-                ? "bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))]"
+                ? "bg-[rgb(var(--surface-subtle))] font-semibold text-[rgb(var(--text))] shadow-[var(--shadow-sm)]"
                 : "text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-subtle))/0.7] hover:text-[rgb(var(--text))]"
             }`}
           >

--- a/src/components/nav/MobileMenuSheet.astro
+++ b/src/components/nav/MobileMenuSheet.astro
@@ -43,9 +43,9 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
           return (
             <a
               href={link.href}
-              class={`flex w-full items-center justify-between rounded-[var(--radius-sm)] px-3 py-3 text-sm font-medium transition-colors ${
+              class={`flex w-full items-center justify-between rounded-[var(--radius-sm)] px-3 py-3 text-sm transition-colors ${
                 isActive
-                  ? "bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))]"
+                  ? "bg-[rgb(var(--surface-subtle))] font-semibold text-[rgb(var(--text))]"
                   : "text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-subtle))/0.7] hover:text-[rgb(var(--text))]"
               }`}
             >

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,17 +55,6 @@ const isSandboxWhite = shellVariant === "sandbox-white";
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Epilogue:wght@500;600;700&family=Inter:wght@400;500;600&display=swap"
     />
-    <style is:inline>
-      /* #125H-R5: content offset under fixed header before Tailwind bundle paints */
-      .vox-shell-content {
-        padding-top: 7rem;
-      }
-      @media (min-width: 640px) {
-        .vox-shell-content {
-          padding-top: 7.5rem;
-        }
-      }
-    </style>
     <InspectDrawerArmScript />
     <slot name="head" />
     <script defer src="https://www.gstatic.com/ces-console/fast/chat-messenger/prod/v1.15/chat-messenger.js"></script>
@@ -156,7 +145,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
 
-    <div class="vox-shell-content mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
+    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
       <slot />
     </div>
 


### PR DESCRIPTION
## Summary
Stop R1–R5 stability micro-fixes. Restore layout/nav shell to **#125H initial merge baseline** (`73b17e25`, PR #149) while keeping IA changes.

## Baseline
`73b17e25` — last commit before R1–R5 layout/positioning experiments.

## Reverted (R1–R5 layout attempts)
- **R5:** inline critical CSS for `.vox-shell-content` + class on content wrapper
- **R2:** `navLinkClass` with `font-medium` / `inline-flex`; active state without `font-semibold`/`shadow-sm`
- **R1/R3:** already reverted in prior PRs; no residual markers

## Kept (#125H IA)
- Nav labels: Forside, Hjelp, Lyd i hverdagen, Ordbok, Om
- CTA: Start samtale (header + mobile drawer)
- `no-nav-links.ts`, `nav-active.ts`, Footer sync

## Restored (73b17e25 styling)
- Desktop nav active: `font-semibold` + `shadow-[var(--shadow-sm)]`
- Mobile nav active: `font-semibold`
- BaseLayout: plain `pt-28 sm:pt-30` content wrapper, no inline critical CSS

## Test plan
- [ ] Hard refresh + globalnav on desktop + mobile (~390px)
- [ ] Routes: `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/`, `/no/ordbok/`, `/no/om/`
- [ ] Compare jump vs R5 — Thomas QA decides if issue persists → park to #125I

Refs #125. Does not close #125H.


Made with [Cursor](https://cursor.com)