### PR TITLE
#125I-B: Shell first-paint layout stability / FOUC

### DIFF
--- a/public/shell-first-paint.css
+++ b/public/shell-first-paint.css
@@ -1,0 +1,118 @@
+/* #125I-B: shell layout before Tailwind / tokens bundle paints.
+   Scope: reset, fixed header metrics, content offset, responsive nav shell, wordmark box.
+   Values match pt-28 (7rem) / sm:pt-30 (7.5rem) and h-16 / sm:h-[4.5rem]. */
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body > header.fixed {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+}
+
+body > header.fixed header {
+  height: 4rem;
+  min-height: 4rem;
+}
+
+body > header.fixed header > div {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+body > header.fixed header nav {
+  display: none;
+}
+
+body > header.fixed #menuToggleBtn {
+  display: inline-flex;
+  margin-left: auto;
+}
+
+body > header.fixed header > div > a[href*="/chat"] {
+  display: none;
+}
+
+@media (min-width: 640px) {
+  body > header.fixed header {
+    height: 4.5rem;
+    min-height: 4.5rem;
+  }
+
+  body > header.fixed header > div {
+    gap: 1rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  body > header.fixed header nav {
+    display: flex;
+    flex: 1 1 0%;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+  }
+
+  body > header.fixed header nav a,
+  body > header.fixed header nav button[data-vox-header-devtools-toggle] {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+
+  body > header.fixed header nav a {
+    padding: 0.5rem 0.75rem;
+  }
+
+  body > header.fixed header nav button[data-vox-header-devtools-toggle] {
+    padding: 0.5rem;
+  }
+
+  body > header.fixed #menuToggleBtn {
+    display: none;
+  }
+
+  body > header.fixed header > div > a[href*="/chat"] {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.625rem 1.25rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    font-weight: 600;
+  }
+}
+
+[data-vox-shell-main] {
+  padding-top: 7rem;
+}
+
+@media (min-width: 640px) {
+  [data-vox-shell-main] {
+    padding-top: 7.5rem;
+  }
+}
+
+body > header.fixed header .font-display {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.2;
+  min-height: 1.18rem;
+  font-size: 1.18rem;
+  font-weight: 650;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+
+@media (min-width: 640px) {
+  body > header.fixed header .font-display {
+    min-height: 1.45rem;
+    font-size: 1.45rem;
+  }
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
-/* CONTRACT: Shared application shell with global header, background mood layer, and CES bootstrapping. */
+/* CONTRACT: Shared application shell with global header, background mood layer, and CES bootstrapping.
+   #125I-B: /shell-first-paint.css loads before Tailwind for stable first-paint shell metrics. */
 import "../styles/global.css";
 import Header from "../components/nav/Header.astro";
 import MobileMenuSheet from "../components/nav/MobileMenuSheet.astro";
@@ -48,6 +49,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
         document.documentElement.style.colorScheme = resolvedColorScheme(mode);
       })();
     </script>
+    <link rel="stylesheet" href="/shell-first-paint.css" />
     <title>{title}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -145,7 +147,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
 
-    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
+    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8" data-vox-shell-main>
       <slot />
     </div>
 

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -106,6 +106,18 @@ export const reviewRegistry: ReviewRegistryItem[] = [
       "IA/nav-sync QA-godkjent — Forside, Hjelp, Lyd i hverdagen, Ordbok, Om + Start samtale CTA. Footer synket. Layout jump/FOUC known issue → #125I.",
   },
   {
+    id: "layout-stability-fouc",
+    title: "Layout stability / FOUC",
+    href: "/no/",
+    sprint: "2026-W21",
+    issue: "#125I-B",
+    type: "active",
+    status: "needs-review",
+    stakeholderSafe: true,
+    description:
+      "Shell first-paint CSS — body reset, fixed header, content offset. Needs Thomas QA on refresh + globalnav.",
+  },
+  {
     id: "forside-routing",
     title: "Forside / routing",
     href: "/no/",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -10,6 +10,7 @@
    #125G: Forside/routing at /no/ — QA accepted, closed (#125G-R3 triage mandate).
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
+   #125I-B: Layout stability / FOUC — shell-first-paint.css, needs review.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -122,8 +123,8 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125F Editorial hub på <code>/no/lyd-i-hverdagen/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
-        <li><strong>Known issue:</strong> #125I Cross-surface layout/polish — transient layout jump / FOUC</li>
-        <li><strong>Neste:</strong> Sprint closure eller #125I layout/polish</li>
+        <li><strong>Active:</strong> #125I-B Layout stability / FOUC — needs review</li>
+        <li><strong>Neste:</strong> #125I-B Thomas QA, deretter #125I-C Frontpage polish</li>
       </ul>
     </section>
 
@@ -406,6 +407,27 @@ const typographyLabDirections = [
         </p>
         <a href={`${base}no/`} class="sprint-preview__typo-link">
           Verify navigation on production →
+        </a>
+      </div>
+    </section>
+
+    <!-- Layout stability / FOUC (#125I-B) -->
+    <section class="sprint-preview__section" aria-labelledby="layout-stability-heading">
+      <div class="sprint-preview__section-head">
+        <p class="sprint-preview__kicker">15 · #125I-B</p>
+        <h2 id="layout-stability-heading">Layout stability / FOUC</h2>
+        <p>Shell first-paint CSS — body reset, fixed header metrics, content offset under header.</p>
+      </div>
+      <div class="sprint-preview__typo-summary">
+        <p class="sprint-preview__typo-status">
+          <strong>Status:</strong> Applied — needs review
+        </p>
+        <p class="sprint-preview__typo-sans">
+          <code>/shell-first-paint.css</code> lastes før Tailwind. Diagnose viste body margin 8px, header static og
+          manglende content offset ved first paint. Playwright (800ms CSS delay): headerTop 8→0 eliminert.
+        </p>
+        <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
+          Verify layout stability on production →
         </a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- **Diagnosis:** Before Tailwind paints: `bodyMargin: 8px`, header `position: static` (top 8), no content `padding-top`, wordmark in Times 18px → shifts to Inter 72px header at idle.
- **Strategy A:** Minimal shell-critical CSS via static `/shell-first-paint.css` loaded before Google Fonts and Tailwind bundle.
- Covers: html/body reset, fixed header, header height, flex row, responsive nav shell, content offset (`data-vox-shell-main`), wordmark metrics.

## Changes
- `public/shell-first-paint.css` (new)
- `src/layouts/BaseLayout.astro` — link + `data-vox-shell-main`
- VIS review + sprint registry (#125I-B needs-review)

## Verification (Playwright, 800ms `_astro/` delay)
| Metric | Before | After |
|--------|--------|-------|
| headerTop @ commit | 8 | 0 |
| bodyMargin @ commit | 8px | 0px |
| fixedPos @ commit | static | fixed |
| wordmark @ commit | Times | Inter |

## Not changed
- Nav IA/labels, page content, tokens, global.css, Header.astro

## Test plan
- [ ] Hard refresh + globalnav on desktop + mobile ~390px
- [ ] `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/`, `/no/ordbok/`, `/no/om/`
- [ ] Thomas visual QA — no vertical snap

Refs #157. Does not close #125I-B until Thomas QA.


Made with [Cursor](https://cursor.com)