### PR TITLE
fix(#125I-B-R2): revert R1 shell + horizontal shift diagnosis

### DIFF
--- a/scripts/diagnose-125i-b-horizontal-shift.mjs
+++ b/scripts/diagnose-125i-b-horizontal-shift.mjs
@@ -1,0 +1,261 @@
+/**
+ * #125I-B-R2 — horizontal layout shift diagnosis.
+ * Usage: node scripts/diagnose-125i-b-horizontal-shift.mjs [baseUrl] [--mobile] [--nav-clicks]
+ */
+import { chromium } from "playwright";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const baseUrl = process.argv.find((a) => a.startsWith("http")) ?? "http://127.0.0.1:4321";
+const mobile = process.argv.includes("--mobile");
+const navClicks = process.argv.includes("--nav-clicks");
+const delayCssMs = Number(process.argv.find((a) => a.startsWith("--delay-css="))?.split("=")[1] ?? 0);
+const label = mobile ? "mobile" : "desktop";
+const outDir = join(process.cwd(), "tmp/nav-jump-125i-b-r2", label);
+const joinUrl = (path) => `${baseUrl.replace(/\/$/, "")}${path.startsWith("/") ? path : `/${path}`}`;
+const routes = ["/no/", "/no/hub/", "/no/lyd-i-hverdagen/", "/no/chat/"];
+const viewport = mobile ? { width: 390, height: 844 } : { width: 1280, height: 800 };
+
+const MEASURE_INIT = () => {
+  window.__voxHShift = { samples: [], markers: [] };
+
+  const box = (el) => {
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return {
+      left: +r.left.toFixed(2),
+      width: +r.width.toFixed(2),
+      right: +r.right.toFixed(2),
+      marginLeft: cs.marginLeft,
+      marginRight: cs.marginRight,
+      paddingLeft: cs.paddingLeft,
+      paddingRight: cs.paddingRight,
+      transform: cs.transform,
+    };
+  };
+
+  const measure = (marker) => {
+    try {
+      const html = document.documentElement;
+      const body = document.body;
+      if (!body) {
+        return {
+          marker,
+          t: +performance.now().toFixed(1),
+          route: location.pathname,
+          note: "body-not-ready",
+        };
+      }
+    const outerHeader =
+      document.querySelector("body > header.fixed") ?? document.querySelector("body > header");
+    const headerInner = outerHeader?.querySelector(":scope > div > div.mx-auto");
+    const headerComponent = outerHeader?.querySelector("header");
+    const nav = headerComponent?.querySelector("nav");
+    const wordmark =
+      headerComponent?.querySelector(".font-display") ??
+      headerComponent?.querySelector('a[aria-label="Viddel"]');
+    const cta =
+      headerComponent?.querySelector("a.sonic-pulse-cta") ??
+      headerComponent?.querySelector('a[href*="/no/chat"]');
+    const contentWrapper = document.querySelector(
+      "body > header.fixed ~ div.mx-auto, body > header ~ div.mx-auto",
+    );
+    const firstContent =
+      contentWrapper?.querySelector("main h1, main, section h1, h1") ??
+      contentWrapper?.firstElementChild;
+
+    const scrollbarW = window.innerWidth - html.clientWidth;
+    const htmlCs = getComputedStyle(html);
+    const bodyCs = getComputedStyle(body);
+
+    const vwEls = [...document.querySelectorAll("*")]
+      .filter((el) => {
+        try {
+          const w = getComputedStyle(el).width;
+          const cls = typeof el.className === "string" ? el.className : "";
+          return w.includes("vw") || cls.includes("w-screen");
+        } catch {
+          return false;
+        }
+      })
+      .slice(0, 8)
+      .map((el) => ({
+        tag: el.tagName.toLowerCase(),
+        cls: (el.className?.toString?.() ?? "").slice(0, 80),
+        width: getComputedStyle(el).width,
+        left: +el.getBoundingClientRect().left.toFixed(2),
+        scrollW: el.scrollWidth,
+        clientW: el.clientWidth,
+      }));
+
+    return {
+      marker,
+      t: +performance.now().toFixed(1),
+      route: location.pathname,
+      innerWidth: window.innerWidth,
+      htmlClientW: html.clientWidth,
+      htmlScrollW: html.scrollWidth,
+      bodyClientW: body.clientWidth,
+      bodyScrollW: body.scrollWidth,
+      scrollbarW,
+      hasHOverflow: html.scrollWidth > html.clientWidth || body.scrollWidth > body.clientWidth,
+      htmlOverflowX: htmlCs.overflowX,
+      bodyOverflowX: bodyCs.overflowX,
+      htmlScrollbarGutter: htmlCs.scrollbarGutter,
+      bodyMargin: bodyCs.margin,
+      htmlMargin: htmlCs.margin,
+      outerHeader: box(outerHeader),
+      headerInner: box(headerInner),
+      headerComponent: box(headerComponent),
+      nav: box(nav),
+      wordmark: box(wordmark),
+      cta: box(cta),
+      contentWrapper: box(contentWrapper),
+      firstContent: box(firstContent),
+      fonts: document.fonts?.status ?? "n/a",
+      astroCss: [...document.querySelectorAll('link[rel="stylesheet"]')].some((l) =>
+        l.href.includes("/_astro/"),
+      ),
+      vwCandidates: vwEls,
+    };
+    } catch (err) {
+      return { marker, t: +performance.now().toFixed(1), error: String(err) };
+    }
+  };
+
+  const push = (marker) => {
+    window.__voxHShift.samples.push(measure(marker));
+  };
+
+  push("sync-init");
+  requestAnimationFrame(() => push("raf-1"));
+  setTimeout(() => push("t-16ms"), 16);
+  setTimeout(() => push("t-50ms"), 50);
+  setTimeout(() => push("t-100ms"), 100);
+  setTimeout(() => push("t-250ms"), 250);
+  document.addEventListener("DOMContentLoaded", () => push("DOMContentLoaded"), { once: true });
+  if (document.fonts?.ready) {
+    document.fonts.ready.then(() => push("fonts.ready"));
+  }
+  window.addEventListener("load", () => {
+    push("load");
+    setTimeout(() => push("load+500ms"), 500);
+  });
+};
+
+function deltaSummary(samples) {
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  if (!first || !last) return null;
+
+  const d = (a, b, key) => {
+    const fa = a?.[key];
+    const la = b?.[key];
+    if (!fa || !la) return null;
+    return {
+      left: +(la.left - fa.left).toFixed(2),
+      width: +(la.width - fa.width).toFixed(2),
+    };
+  };
+
+  return {
+    from: first.marker,
+    to: last.marker,
+    innerWidth: last.innerWidth - first.innerWidth,
+    htmlClientW: last.htmlClientW - first.htmlClientW,
+    scrollbarW: last.scrollbarW - first.scrollbarW,
+    hasHOverflow: { from: first.hasHOverflow, to: last.hasHOverflow },
+    outerHeader: d(first, last, "outerHeader"),
+    headerInner: d(first, last, "headerInner"),
+    contentWrapper: d(first, last, "contentWrapper"),
+    firstContent: d(first, last, "firstContent"),
+    wordmark: d(first, last, "wordmark"),
+    nav: d(first, last, "nav"),
+    cta: d(first, last, "cta"),
+  };
+}
+
+await mkdir(outDir, { recursive: true });
+const browser = await chromium.launch({ headless: true });
+const summary = [];
+
+for (const route of routes) {
+  const ctx = await browser.newContext({ viewport, colorScheme: "light" });
+  await ctx.addInitScript(() => localStorage.setItem("vox-theme", "light"));
+  await ctx.addInitScript(MEASURE_INIT);
+  if (delayCssMs > 0) {
+    await ctx.route("**/_astro/**", async (r) => {
+      await new Promise((res) => setTimeout(res, delayCssMs));
+      await r.continue();
+    });
+  }
+  const page = await ctx.newPage();
+  await page.goto(joinUrl(route), { waitUntil: "load" });
+  await page.waitForTimeout(700);
+
+  const samples = await page.evaluate(() => window.__voxHShift?.samples ?? []);
+  const entry = { route, phase: "hard-refresh", samples, delta: deltaSummary(samples) };
+  summary.push(entry);
+  await writeFile(join(outDir, `${route.replace(/\//g, "_") || "root"}-refresh.json`), JSON.stringify(entry, null, 2));
+  await ctx.close();
+}
+
+if (navClicks) {
+  const ctx = await browser.newContext({ viewport, colorScheme: "light" });
+  await ctx.addInitScript(() => localStorage.setItem("vox-theme", "light"));
+  const page = await ctx.newPage();
+  const chain = ["/no/", "/no/hub/", "/no/lyd-i-hverdagen/", "/no/chat/", "/no/"];
+  const navHrefs = mobile
+    ? null
+    : [
+        "/no",
+        "/no/hub",
+        "/no/lyd-i-hverdagen",
+        "/no/chat",
+        "/no",
+      ];
+
+  for (let i = 0; i < chain.length - 1; i++) {
+    await ctx.addInitScript(MEASURE_INIT);
+    await page.goto(joinUrl(chain[i]), { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(300);
+    const target = chain[i + 1];
+    const link = mobile
+      ? page.locator(`footer a[href="${target.replace(/\/$/, "")}"], footer a[href="${target}"]`).first()
+      : page.locator(`header nav a[href="${target.replace(/\/$/, "")}"], header nav a[href="${target}"]`).first();
+    if ((await link.count()) === 0) continue;
+    await link.click();
+    await page.waitForLoadState("load");
+    await page.waitForTimeout(700);
+    const samples = await page.evaluate(() => window.__voxHShift?.samples ?? []);
+    const entry = {
+      route: `${chain[i]} -> ${chain[i + 1]}`,
+      phase: "nav-click",
+      samples,
+      delta: deltaSummary(samples),
+    };
+    summary.push(entry);
+  }
+  await ctx.close();
+}
+
+const report = {
+  baseUrl,
+  viewport,
+  label,
+  generatedAt: new Date().toISOString(),
+  summary: summary.map(({ route, phase, delta, samples }) => ({
+    route,
+    phase,
+    delta,
+    keyFrames: samples.filter((s) =>
+      ["sync-init", "t-16ms", "DOMContentLoaded", "fonts.ready", "load", "load+500ms"].includes(s.marker),
+    ),
+  })),
+};
+
+await writeFile(join(outDir, "summary.json"), JSON.stringify(report, null, 2));
+
+console.log(JSON.stringify(report.summary, null, 2));
+await browser.close();

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,5 @@
 ---
-/* CONTRACT: Shared application shell with global header, background mood layer, and CES bootstrapping.
-   #125I-B-R1: Header in normal document flow — no fixed header or content offset padding. */
+/* CONTRACT: Shared application shell with global header, background mood layer, and CES bootstrapping. */
 import "../styles/global.css";
 import Header from "../components/nav/Header.astro";
 import MobileMenuSheet from "../components/nav/MobileMenuSheet.astro";
@@ -133,7 +132,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
       }
     </div>
 
-    <header class="relative z-40">
+    <header class="fixed inset-x-0 top-0 z-40">
       <div
         class="bg-[rgb(var(--surface-elevated))/0.88] backdrop-blur-xl"
         style="box-shadow: var(--shadow-header);"
@@ -146,7 +145,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
 
-    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
       <slot />
     </div>
 

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -115,7 +115,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "needs-review",
     stakeholderSafe: true,
     description:
-      "Shell simplification (#125I-B-R1): header static flow, no shell-first-paint.css. Needs Thomas QA.",
+      "R2 rollback to pre-#125I-B shell baseline; horizontal layout shift diagnosis. Needs Thomas QA.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -10,7 +10,7 @@
    #125G: Forside/routing at /no/ — QA accepted, closed (#125G-R3 triage mandate).
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
-   #125I-B-R1: Shell simplification — static header, no content offset; needs review.
+   #125I-B-R2: R1 rollback + horizontal shift diagnosis; needs review.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -123,7 +123,7 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125F Editorial hub på <code>/no/lyd-i-hverdagen/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
-        <li><strong>Active:</strong> #125I-B-R1 Shell simplification — static header, needs review</li>
+        <li><strong>Active:</strong> #125I-B-R2 Rollback R1 + horizontal shift diagnosis</li>
         <li><strong>Neste:</strong> #125I-B Thomas QA, deretter #125I-C Frontpage polish</li>
       </ul>
     </section>
@@ -411,20 +411,20 @@ const typographyLabDirections = [
       </div>
     </section>
 
-    <!-- Layout stability / FOUC (#125I-B / R1) -->
+    <!-- Layout stability / FOUC (#125I-B / R2) -->
     <section class="sprint-preview__section" aria-labelledby="layout-stability-heading">
       <div class="sprint-preview__section-head">
-        <p class="sprint-preview__kicker">15 · #125I-B-R1</p>
-        <h2 id="layout-stability-heading">Layout stability / shell simplification</h2>
-        <p>Test: header i normal dokumentflyt — ingen fixed header eller content offset padding.</p>
+        <p class="sprint-preview__kicker">15 · #125I-B-R2</p>
+        <h2 id="layout-stability-heading">Layout stability / horizontal shift</h2>
+        <p>R1 revertet. Shell tilbake til pre-#125I-B (fixed header + content offset). Diagnose fokuserer horisontal shift.</p>
       </div>
       <div class="sprint-preview__typo-summary">
         <p class="sprint-preview__typo-status">
           <strong>Status:</strong> Applied — needs review
         </p>
         <p class="sprint-preview__typo-sans">
-          #125I-B shell-first-paint.css revertet. Header <code>relative</code> (ikke fixed); content wrapper uten{" "}
-          <code>pt-28</code>/<code>sm:pt-30</code>. Hypotese: fjern fixed+offset-modellen som årsak til synlig snap.
+          #125I-B-R1 static header revertet. Baseline: fixed header,{" "}
+          <code>pt-28</code>/<code>sm:pt-30</code>, ingen shell-first-paint.css. Thomas rapporterer sideveis hopp — ikke vertikal offset.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify layout stability on production →


### PR DESCRIPTION
## Summary
- Reverts #125I-B-R1 static header shell (PR #162) — Thomas QA failed.
- Restores pre-#125I-B baseline (`8af5d009` shell): fixed header + `pt-28`/`sm:pt-30`, no `shell-first-paint.css`.
- Adds `scripts/diagnose-125i-b-horizontal-shift.mjs` for horizontal layout shift timeline.

## Diagnosis (no fix yet)
Thomas reports **horizontal** jump, not vertical. Playwright with delayed `/_astro/` CSS shows:
- Before Tailwind preflight: `bodyMargin: 8px`, shell elements at `left: 8px`, no centered `max-w-6xl`.
- After Tailwind loads: `bodyMargin: 0px`, `headerInner.left: 64px` — **~56px horizontal shift** in header inner + **8px** page shift from margin reset.
- After fonts load (stable CSS): nav reflows ~3.7px from wordmark width change (Epilogue swap).
- No scrollbar width change, no `100vw` overflow, no `scrollWidth > clientWidth`.

## Test plan
- [ ] Hard refresh: `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/`, `/no/ordbok/`, `/no/om/`
- [ ] Shell back to fixed header (not static R1)
- [ ] No `shell-first-paint.css` link
- [ ] `npm run build` green

#125I-B stays **needs-review**. No CSS fix in this PR.


Made with [Cursor](https://cursor.com)