### PR TITLE
fix(#125I-B-R3): inline horizontal first-paint shell CSS

### DIFF
--- a/scripts/diagnose-125i-b-horizontal-shift.mjs
+++ b/scripts/diagnose-125i-b-horizontal-shift.mjs
@@ -49,7 +49,9 @@ const MEASURE_INIT = () => {
       }
     const outerHeader =
       document.querySelector("body > header.fixed") ?? document.querySelector("body > header");
-    const headerInner = outerHeader?.querySelector(":scope > div > div.mx-auto");
+    const headerInner =
+      outerHeader?.querySelector("[data-vox-shell-container]") ??
+      outerHeader?.querySelector(":scope > div > div.mx-auto");
     const headerComponent = outerHeader?.querySelector("header");
     const nav = headerComponent?.querySelector("nav");
     const wordmark =
@@ -58,9 +60,9 @@ const MEASURE_INIT = () => {
     const cta =
       headerComponent?.querySelector("a.sonic-pulse-cta") ??
       headerComponent?.querySelector('a[href*="/no/chat"]');
-    const contentWrapper = document.querySelector(
-      "body > header.fixed ~ div.mx-auto, body > header ~ div.mx-auto",
-    );
+    const contentWrapper =
+      document.querySelector("[data-vox-shell-main]") ??
+      document.querySelector("body > header.fixed ~ div.mx-auto, body > header ~ div.mx-auto");
     const firstContent =
       contentWrapper?.querySelector("main h1, main, section h1, h1") ??
       contentWrapper?.firstElementChild;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
-/* CONTRACT: Shared application shell with global header, background mood layer, and CES bootstrapping. */
+/* CONTRACT: Shared application shell with global header, background mood layer, and CES bootstrapping.
+   #125I-B-R3: Inline first-paint horizontal shell CSS in head — before Tailwind bundle. */
 import "../styles/global.css";
 import Header from "../components/nav/Header.astro";
 import MobileMenuSheet from "../components/nav/MobileMenuSheet.astro";
@@ -28,6 +29,55 @@ const isSandboxWhite = shellVariant === "sandbox-white";
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style is:inline>
+      /* #125I-B-R3 — horizontal first-paint shell (preflight + container layout only) */
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body > header.fixed {
+        position: fixed;
+        z-index: 40;
+        top: 0;
+        right: 0;
+        left: 0;
+        width: 100%;
+      }
+      [data-vox-shell-container],
+      [data-vox-shell-main] {
+        width: 100%;
+        max-width: 72rem;
+        margin-inline: auto;
+        padding-inline: 1rem;
+      }
+      @media (min-width: 640px) {
+        [data-vox-shell-container],
+        [data-vox-shell-main] {
+          padding-inline: 1.5rem;
+        }
+      }
+      @media (min-width: 1024px) {
+        [data-vox-shell-container],
+        [data-vox-shell-main] {
+          padding-inline: 2rem;
+        }
+      }
+      body > header.fixed header .font-display {
+        display: inline-block;
+        min-width: 3.375rem;
+      }
+      @media (min-width: 640px) {
+        body > header.fixed header .font-display {
+          min-width: 4.25rem;
+        }
+      }
+    </style>
     <script is:inline>
       (function () {
         var STORAGE_KEY = "vox-theme";
@@ -137,7 +187,10 @@ const isSandboxWhite = shellVariant === "sandbox-white";
         class="bg-[rgb(var(--surface-elevated))/0.88] backdrop-blur-xl"
         style="box-shadow: var(--shadow-header);"
       >
-        <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div
+          class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8"
+          data-vox-shell-container
+        >
           <Header currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
         </div>
       </div>
@@ -145,7 +198,10 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
 
-    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
+    <div
+      class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8"
+      data-vox-shell-main
+    >
       <slot />
     </div>
 

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -115,7 +115,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "needs-review",
     stakeholderSafe: true,
     description:
-      "R2 rollback to pre-#125I-B shell baseline; horizontal layout shift diagnosis. Needs Thomas QA.",
+      "R3 horizontal first-paint shell CSS — inline preflight + container layout. Needs Thomas QA.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -10,7 +10,7 @@
    #125G: Forside/routing at /no/ — QA accepted, closed (#125G-R3 triage mandate).
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
-   #125I-B-R2: R1 rollback + horizontal shift diagnosis; needs review.
+   #125I-B-R3: Horizontal first-paint shell CSS; needs review.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -123,7 +123,7 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125F Editorial hub på <code>/no/lyd-i-hverdagen/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
-        <li><strong>Active:</strong> #125I-B-R2 Rollback R1 + horizontal shift diagnosis</li>
+        <li><strong>Active:</strong> #125I-B-R3 Horizontal first-paint shell fix — needs review</li>
         <li><strong>Neste:</strong> #125I-B Thomas QA, deretter #125I-C Frontpage polish</li>
       </ul>
     </section>
@@ -411,20 +411,20 @@ const typographyLabDirections = [
       </div>
     </section>
 
-    <!-- Layout stability / FOUC (#125I-B / R2) -->
+    <!-- Layout stability / FOUC (#125I-B / R3) -->
     <section class="sprint-preview__section" aria-labelledby="layout-stability-heading">
       <div class="sprint-preview__section-head">
-        <p class="sprint-preview__kicker">15 · #125I-B-R2</p>
-        <h2 id="layout-stability-heading">Layout stability / horizontal shift</h2>
-        <p>R1 revertet. Shell tilbake til pre-#125I-B (fixed header + content offset). Diagnose fokuserer horisontal shift.</p>
+        <p class="sprint-preview__kicker">15 · #125I-B-R3</p>
+        <h2 id="layout-stability-heading">Layout stability / horizontal first-paint</h2>
+        <p>Inline shell CSS i head — preflight + container layout før Tailwind bundle.</p>
       </div>
       <div class="sprint-preview__typo-summary">
         <p class="sprint-preview__typo-status">
           <strong>Status:</strong> Applied — needs review
         </p>
         <p class="sprint-preview__typo-sans">
-          #125I-B-R1 static header revertet. Baseline: fixed header,{" "}
-          <code>pt-28</code>/<code>sm:pt-30</code>, ingen shell-first-paint.css. Thomas rapporterer sideveis hopp — ikke vertikal offset.
+          <code>data-vox-shell-container</code> / <code>data-vox-shell-main</code> med inline max-width 72rem,
+          margin-inline auto, padding-inline 1rem/1.5rem/2rem. Body margin 0 ved first paint. Wordmark min-width reservert.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify layout stability on production →


### PR DESCRIPTION
## Summary
Minimal inline CSS in `BaseLayout` head (before Tailwind bundle) to stabilize horizontal shell at first paint:
- html/body margin reset + box-sizing
- fixed header outer width/position
- `data-vox-shell-container` / `data-vox-shell-main`: max-width 72rem, margin-inline auto, responsive padding-inline
- wordmark min-width to reduce nav reflow on font swap

## Diagnosis (delayed `/_astro/` 800ms, desktop 1280px)
| Metric | Pre-R3 (R2) | Post-R3 |
|--------|-------------|---------|
| bodyMargin @ first paint | 8px | **0px** |
| headerInner.left @ first paint | 8px | **64px** |
| nav.left shift (DOM→load) | ~3.7px | **0px** |

## Scope
- Shell only (`BaseLayout.astro`). No IA/content/tokens/global.css changes.
- No vertical offset changes.

## Test plan
- [ ] Hard refresh + globalnav on `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/`, `/no/ordbok/`, `/no/om/`
- [ ] Desktop 1280px + mobile ~390px — horizontal snap reduced/gone
- [ ] `npm run build` green

#125I-B stays **needs-review** until Thomas live QA.


Made with [Cursor](https://cursor.com)