### PR TITLE
fix(#125I-B-R4): revert R3, park FOUC as known issue

### DIFF
--- a/scripts/diagnose-125i-b-horizontal-shift.mjs
+++ b/scripts/diagnose-125i-b-horizontal-shift.mjs
@@ -49,9 +49,7 @@ const MEASURE_INIT = () => {
       }
     const outerHeader =
       document.querySelector("body > header.fixed") ?? document.querySelector("body > header");
-    const headerInner =
-      outerHeader?.querySelector("[data-vox-shell-container]") ??
-      outerHeader?.querySelector(":scope > div > div.mx-auto");
+    const headerInner = outerHeader?.querySelector(":scope > div > div.mx-auto");
     const headerComponent = outerHeader?.querySelector("header");
     const nav = headerComponent?.querySelector("nav");
     const wordmark =
@@ -60,9 +58,9 @@ const MEASURE_INIT = () => {
     const cta =
       headerComponent?.querySelector("a.sonic-pulse-cta") ??
       headerComponent?.querySelector('a[href*="/no/chat"]');
-    const contentWrapper =
-      document.querySelector("[data-vox-shell-main]") ??
-      document.querySelector("body > header.fixed ~ div.mx-auto, body > header ~ div.mx-auto");
+    const contentWrapper = document.querySelector(
+      "body > header.fixed ~ div.mx-auto, body > header ~ div.mx-auto",
+    );
     const firstContent =
       contentWrapper?.querySelector("main h1, main, section h1, h1") ??
       contentWrapper?.firstElementChild;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,5 @@
 ---
-/* CONTRACT: Shared application shell with global header, background mood layer, and CES bootstrapping.
-   #125I-B-R3: Inline first-paint horizontal shell CSS in head — before Tailwind bundle. */
+/* CONTRACT: Shared application shell with global header, background mood layer, and CES bootstrapping. */
 import "../styles/global.css";
 import Header from "../components/nav/Header.astro";
 import MobileMenuSheet from "../components/nav/MobileMenuSheet.astro";
@@ -29,55 +28,6 @@ const isSandboxWhite = shellVariant === "sandbox-white";
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <style is:inline>
-      /* #125I-B-R3 — horizontal first-paint shell (preflight + container layout only) */
-      *,
-      *::before,
-      *::after {
-        box-sizing: border-box;
-      }
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-      }
-      body > header.fixed {
-        position: fixed;
-        z-index: 40;
-        top: 0;
-        right: 0;
-        left: 0;
-        width: 100%;
-      }
-      [data-vox-shell-container],
-      [data-vox-shell-main] {
-        width: 100%;
-        max-width: 72rem;
-        margin-inline: auto;
-        padding-inline: 1rem;
-      }
-      @media (min-width: 640px) {
-        [data-vox-shell-container],
-        [data-vox-shell-main] {
-          padding-inline: 1.5rem;
-        }
-      }
-      @media (min-width: 1024px) {
-        [data-vox-shell-container],
-        [data-vox-shell-main] {
-          padding-inline: 2rem;
-        }
-      }
-      body > header.fixed header .font-display {
-        display: inline-block;
-        min-width: 3.375rem;
-      }
-      @media (min-width: 640px) {
-        body > header.fixed header .font-display {
-          min-width: 4.25rem;
-        }
-      }
-    </style>
     <script is:inline>
       (function () {
         var STORAGE_KEY = "vox-theme";
@@ -187,10 +137,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
         class="bg-[rgb(var(--surface-elevated))/0.88] backdrop-blur-xl"
         style="box-shadow: var(--shadow-header);"
       >
-        <div
-          class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8"
-          data-vox-shell-container
-        >
+        <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <Header currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
         </div>
       </div>
@@ -198,10 +145,7 @@ const isSandboxWhite = shellVariant === "sandbox-white";
 
     <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
 
-    <div
-      class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8"
-      data-vox-shell-main
-    >
+    <div class="mx-auto max-w-6xl px-4 pt-28 sm:px-6 sm:pt-30 lg:px-8">
       <slot />
     </div>
 

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -111,11 +111,11 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     href: "/no/",
     sprint: "2026-W21",
     issue: "#125I-B",
-    type: "active",
-    status: "needs-review",
+    type: "reference",
+    status: "closed",
     stakeholderSafe: true,
     description:
-      "R3 horizontal first-paint shell CSS — inline preflight + container layout. Needs Thomas QA.",
+      "Diagnose completed — horizontal layout shift / FOUC not solved. R1–R3 CSS attempts reverted (no visible QA improvement). Known issue / teknisk gjeld. Neste polish: #125I-C.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -10,7 +10,7 @@
    #125G: Forside/routing at /no/ — QA accepted, closed (#125G-R3 triage mandate).
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
-   #125I-B-R3: Horizontal first-paint shell CSS; needs review.
+   #125I-B: Layout shift / FOUC — diagnose completed, parked (known issue). Neste: #125I-C.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -123,8 +123,8 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125F Editorial hub på <code>/no/lyd-i-hverdagen/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
-        <li><strong>Active:</strong> #125I-B-R3 Horizontal first-paint shell fix — needs review</li>
-        <li><strong>Neste:</strong> #125I-B Thomas QA, deretter #125I-C Frontpage polish</li>
+        <li><strong>Parked:</strong> #125I-B Layout shift / FOUC — diagnose completed, not solved (known issue)</li>
+        <li><strong>Neste:</strong> #125I-C Frontpage polish (med kjent layout issue)</li>
       </ul>
     </section>
 
@@ -411,20 +411,20 @@ const typographyLabDirections = [
       </div>
     </section>
 
-    <!-- Layout stability / FOUC (#125I-B / R3) -->
+    <!-- Layout stability / FOUC (#125I-B — parked) -->
     <section class="sprint-preview__section" aria-labelledby="layout-stability-heading">
       <div class="sprint-preview__section-head">
-        <p class="sprint-preview__kicker">15 · #125I-B-R3</p>
-        <h2 id="layout-stability-heading">Layout stability / horizontal first-paint</h2>
-        <p>Inline shell CSS i head — preflight + container layout før Tailwind bundle.</p>
+        <p class="sprint-preview__kicker">15 · #125I-B</p>
+        <h2 id="layout-stability-heading">Layout stability / FOUC</h2>
+        <p>Diagnose completed — horisontal layout shift parkert som known issue. Ingen flere CSS-forsøk i denne slicen.</p>
       </div>
       <div class="sprint-preview__typo-summary">
         <p class="sprint-preview__typo-status">
-          <strong>Status:</strong> Applied — needs review
+          <strong>Status:</strong> Diagnose completed / parked
         </p>
         <p class="sprint-preview__typo-sans">
-          <code>data-vox-shell-container</code> / <code>data-vox-shell-main</code> med inline max-width 72rem,
-          margin-inline auto, padding-inline 1rem/1.5rem/2rem. Body margin 0 ved first paint. Wordmark min-width reservert.
+          R2 identifiserte horisontal shift (body margin 8→0, container layout ved Tailwind-load). R3 first-paint CSS
+          ga bedre målinger men ingen synlig QA-forbedring — revertet. FOUC beholdes som teknisk gjeld. Neste: #125I-C.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify layout stability on production →


### PR DESCRIPTION
## Summary
- Reverts #125I-B-R3 inline first-paint shell CSS (PR #164) — Thomas QA: no visible improvement.
- Restores pre-R3 shell markup (fixed header, no data attributes, no inline preflight CSS).
- Parks #125I-B in VIS as **closed / diagnose completed** — FOUC remains known technical debt.
- Keeps `scripts/diagnose-125i-b-horizontal-shift.mjs` for future spike (documented in #157).

## Not in scope
- No new CSS
- No #125I-C work
- No content/IA/tokens changes

## Test plan
- [ ] `/no/` shell back to pre-R3 (no `data-vox-shell-*`, no inline margin reset block)
- [ ] Nav/CTA/footer work on `/no/`, `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/chat/`
- [ ] `npm run build` green


Made with [Cursor](https://cursor.com)