### PR TITLE
fix(#125I-C-R1): frontpage polish — reduce and unify

### DIFF
--- a/src/pages/no/index.astro
+++ b/src/pages/no/index.astro
@@ -1,6 +1,6 @@
 ---
-/* CONTRACT: Norwegian landing — triage / avklaringsflate (#125G-R3, polish #125I-C).
-   Two primary hub entries + Hørehjelpen fast-track. Shared Viddel layout family with hub/editorial pages.
+/* CONTRACT: Norwegian landing — triage / avklaringsflate (#125G-R3, polish #125I-C-R1).
+   Two primary hub entries + Hørehjelpen fast-track in one choice module. Mandate unchanged.
  */
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Footer from "../../components/nav/Footer.astro";
@@ -14,22 +14,14 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
   <main class="land-page" data-landing-page>
     <div class="land-container">
       <header class="land-header">
-        <p class="land-kicker">Forside</p>
         <h1>Hva trenger du hjelp til nå?</h1>
         <p class="land-lead">
           Få rask hjelp når noe ikke virker, les om hverdagen med høreapparat, eller spør Hørehjelpen
           direkte.
         </p>
-        <ul class="land-paths" aria-label="Tre måter inn i Viddel">
-          <li><span class="land-paths__label">Rask hjelp</span> når noe ikke virker</li>
-          <li><span class="land-paths__label">Forstå mer</span> om lyd og hverdagen</li>
-          <li><span class="land-paths__label">Spør direkte</span> til Hørehjelpen</li>
-        </ul>
-        <p class="land-note">Fagstoff og guider oppdateres fortløpende av Viddel-redaksjonen.</p>
       </header>
 
-      <section class="land-block land-block--choices" aria-labelledby="choices-heading">
-        <h2 id="choices-heading" class="land-block__title">Velg vei</h2>
+      <section class="land-choices" aria-label="Velg hva du trenger">
         <ul class="land-entry-grid" role="list">
           <li>
             <a href="/no/hub/" class="land-entry land-entry--help">
@@ -44,7 +36,6 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
           <li>
             <a href="/no/lyd-i-hverdagen/" class="land-entry land-entry--editorial">
               <span class="land-entry__kicker">Lyd i hverdagen</span>
-              <span class="land-entry__stripe" aria-hidden="true"></span>
               <span class="land-entry__title">Vil du forstå og mestre mer?</span>
               <span class="land-entry__hint">
                 Les om lyttetrøtthet, små lyder, sosialt liv og strategier som gjør hverdagen lettere.
@@ -53,12 +44,12 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
             </a>
           </li>
         </ul>
-      </section>
 
-      <aside class="land-fasttrack" aria-label="Direkte til Hørehjelpen">
-        <p class="land-fasttrack__text">Vil du heller spørre direkte?</p>
-        <a href="/no/chat" class="land-fasttrack__cta">Start samtale med Hørehjelpen</a>
-      </aside>
+        <div class="land-fasttrack">
+          <p class="land-fasttrack__text">Vil du heller spørre direkte?</p>
+          <a href="/no/chat" class="land-fasttrack__cta">Start samtale med Hørehjelpen</a>
+        </div>
+      </section>
     </div>
   </main>
   <Footer />
@@ -74,7 +65,7 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
 </BaseLayout>
 
 <style>
-  /* #125I-C — shared Viddel page family (hub/ed rhythm), mandate unchanged (#125G-R3) */
+  /* #125I-C-R1 — reduce, unify; shared card family + integrated fast-track */
   .land-page {
     padding: 0;
   }
@@ -82,7 +73,7 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
   .land-container {
     max-width: min(100%, 52rem);
     margin: 0 auto;
-    padding: 0 1rem clamp(3.5rem, 7vw, 5rem);
+    padding: 0 1rem clamp(3.75rem, 7vw, 5rem);
   }
 
   @media (min-width: 640px) {
@@ -98,84 +89,31 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
   }
 
   .land-header {
-    padding: clamp(2rem, 6vw, 3.25rem) 0 clamp(1.35rem, 3.5vw, 1.85rem);
-    border-bottom: 1px solid rgb(var(--border) / 0.22);
-  }
-
-  .land-kicker {
-    margin: 0 0 0.55rem;
-    font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgb(var(--reading-ink-secondary));
+    padding: clamp(2rem, 6vw, 3rem) 0 clamp(1.1rem, 2.8vw, 1.45rem);
+    border-bottom: 1px solid rgb(var(--border) / 0.2);
   }
 
   [data-landing-page] h1 {
     margin: 0;
     font-family: var(--font-display);
-    font-size: clamp(2rem, 5.8vw, 2.65rem);
+    font-size: clamp(2rem, 5.8vw, 2.55rem);
     font-weight: 650;
-    line-height: 1.04;
+    line-height: 1.05;
     letter-spacing: -0.055em;
     text-wrap: balance;
     color: rgb(var(--reading-ink));
   }
 
   .land-lead {
-    margin: clamp(0.7rem, 2vw, 0.95rem) 0 0;
-    max-width: 38rem;
-    font-size: clamp(0.94rem, 2.2vw, 1.04rem);
-    line-height: 1.55;
+    margin: clamp(0.65rem, 1.8vw, 0.85rem) 0 0;
+    max-width: 36rem;
+    font-size: clamp(0.93rem, 2.1vw, 1.02rem);
+    line-height: 1.5;
     color: rgb(var(--reading-ink-secondary));
   }
 
-  .land-paths {
-    margin: clamp(0.95rem, 2.5vw, 1.15rem) 0 0;
-    padding: 0;
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-    max-width: 38rem;
-    font-size: 0.84rem;
-    line-height: 1.45;
-    color: rgb(var(--reading-ink-secondary));
-  }
-
-  @media (min-width: 640px) {
-    .land-paths {
-      flex-direction: row;
-      flex-wrap: wrap;
-      column-gap: 1.15rem;
-      row-gap: 0.35rem;
-    }
-  }
-
-  .land-paths__label {
-    font-weight: 650;
-    color: rgb(var(--reading-ink));
-  }
-
-  .land-note {
-    margin: clamp(0.85rem, 2.2vw, 1rem) 0 0;
-    font-size: 0.76rem;
-    line-height: 1.45;
-    color: rgb(var(--reading-ink-secondary) / 0.82);
-  }
-
-  .land-block {
-    padding: clamp(1.35rem, 3.5vw, 1.75rem) 0;
-    border-bottom: 1px solid rgb(var(--border) / 0.15);
-  }
-
-  .land-block__title {
-    margin: 0 0 0.85rem;
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgb(var(--reading-accent-iris));
+  .land-choices {
+    padding-top: clamp(1.1rem, 2.8vw, 1.35rem);
   }
 
   .land-entry-grid {
@@ -184,13 +122,13 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
     list-style: none;
     display: grid;
     grid-template-columns: 1fr;
-    gap: 0.65rem;
+    gap: 0.6rem;
   }
 
   @media (min-width: 640px) {
     .land-entry-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.75rem;
+      gap: 0.65rem;
     }
   }
 
@@ -198,17 +136,18 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
     position: relative;
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: 0.38rem;
     min-height: 100%;
-    padding: 0.95rem 0.95rem 2.15rem;
+    padding: 0.95rem 0.95rem 2.1rem;
+    border: 1px solid rgb(var(--border) / 0.24);
     border-radius: 10px;
+    background: rgb(var(--reading-paper));
     color: inherit;
     text-decoration: none;
     transition:
       background-color 150ms ease,
       border-color 150ms ease,
-      box-shadow 150ms ease,
-      transform 150ms ease;
+      box-shadow 150ms ease;
   }
 
   .land-entry:focus-visible {
@@ -225,88 +164,68 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
   }
 
   .land-entry__title {
-    font-size: 1.02rem;
+    font-size: 1rem;
     font-weight: 650;
     letter-spacing: -0.025em;
-    line-height: 1.25;
+    line-height: 1.28;
     color: rgb(var(--reading-ink));
   }
 
   .land-entry__hint {
     flex: 1;
     font-size: 0.82rem;
-    line-height: 1.5;
+    line-height: 1.48;
     color: rgb(var(--reading-ink-secondary));
   }
 
   .land-entry__arrow {
     position: absolute;
     right: 0.95rem;
-    bottom: 0.9rem;
-    font-size: 0.9rem;
+    bottom: 0.88rem;
+    font-size: 0.88rem;
     line-height: 1;
-    color: rgb(var(--reading-ink-secondary) / 0.55);
+    color: rgb(var(--reading-ink-secondary) / 0.5);
     transition: color 150ms ease, transform 150ms ease;
   }
 
+  .land-entry:hover {
+    border-color: rgb(var(--border) / 0.38);
+    box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
+  }
+
   .land-entry:hover .land-entry__arrow {
-    color: rgb(var(--reading-ink));
+    color: rgb(var(--reading-ink-secondary));
     transform: translateX(2px);
   }
 
-  /* Hjelp — utility / A3 problem-card DNA */
-  .land-entry--help {
-    border: 1px solid rgb(var(--border) / 0.32);
-    border-left: 4px solid rgb(var(--primary));
-    background: rgb(var(--reading-paper));
+  /* Hjelp — utility: solid surface, tettere hint */
+  .land-entry--help .land-entry__hint {
+    line-height: 1.45;
   }
 
-  .land-entry--help:hover {
-    border-color: rgb(var(--border) / 0.52);
-    border-left-color: rgb(var(--primary));
-    box-shadow: 0 3px 14px rgb(var(--reading-ink) / 0.06);
-    transform: translateY(-1px);
-  }
-
-  .land-entry--help .land-entry__kicker {
-    color: rgb(var(--reading-accent-iris));
-  }
-
-  /* Editorial — situation-card DNA + tonal stripe */
+  /* Lyd i hverdagen — editorial: roligere surface, litt mer luft i tekst */
   .land-entry--editorial {
-    border: 1px solid rgb(var(--border) / 0.14);
-    background: transparent;
-    padding-top: 0.8rem;
+    background: rgb(var(--reading-paper) / 0.72);
+    border-color: rgb(var(--border) / 0.18);
   }
 
   .land-entry--editorial:hover {
     background: rgb(var(--reading-paper));
-    border-color: rgb(var(--border) / 0.28);
   }
 
-  .land-entry__stripe {
-    display: block;
-    height: 0.28rem;
-    margin: 0.05rem 0 0.1rem;
-    border-radius: 999px;
-    background: linear-gradient(
-      90deg,
-      rgb(19 77 106 / 0.35) 0%,
-      rgb(95 82 220 / 0.12) 55%,
-      rgb(253 252 250) 100%
-    );
+  .land-entry--editorial .land-entry__hint {
+    line-height: 1.52;
   }
 
-  /* Hørehjelpen — compact fast-track */
+  /* Hørehjelpen — integrated fast-track */
   .land-fasttrack {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.7rem;
-    margin: 0;
-    padding: clamp(1.15rem, 3vw, 1.4rem) 0 0;
-    border: 0;
-    background: transparent;
+    gap: 0.65rem;
+    margin-top: 0.85rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid rgb(var(--border) / 0.16);
   }
 
   @media (min-width: 480px) {
@@ -330,7 +249,7 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    padding: 0.55rem 1rem;
+    padding: 0.52rem 0.95rem;
     border-radius: 999px;
     background: rgb(var(--reading-ink));
     color: rgb(var(--reading-paper));
@@ -338,12 +257,11 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
     font-weight: 650;
     letter-spacing: -0.01em;
     text-decoration: none;
-    transition: opacity 150ms ease, transform 150ms ease;
+    transition: opacity 150ms ease;
   }
 
   .land-fasttrack__cta:hover {
-    opacity: 0.92;
-    transform: translateY(-1px);
+    opacity: 0.9;
   }
 
   .land-fasttrack__cta:focus-visible {

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -127,7 +127,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "needs-review",
     stakeholderSafe: true,
     description:
-      "Shared Viddel layout family on /no/ — strammere rytme, tydeligere hovedvalg, hub/ed-aligned container. Mandat uendret. Needs Thomas QA.",
+      "R1 refinement — unified card family, reduced meta copy, integrated fast-track. Mandat uendret. Needs Thomas QA.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -10,7 +10,7 @@
    #125G: Forside/routing at /no/ — QA accepted, closed (#125G-R3 triage mandate).
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
-   #125I-C: Frontpage polish — shared Viddel layout family; needs review.
+   #125I-C-R1: Frontpage polish refinement — reduce and unify; needs review.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -124,7 +124,7 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
         <li><strong>Parked:</strong> #125I-B Layout shift / FOUC — known issue</li>
-        <li><strong>Active:</strong> #125I-C Frontpage polish på <code>/no/</code> — needs review</li>
+        <li><strong>Active:</strong> #125I-C-R1 Frontpage polish refinement på <code>/no/</code> — needs review</li>
         <li><strong>Neste:</strong> #125I-D Hub polish etter Thomas QA på #125I-C</li>
       </ul>
     </section>
@@ -424,8 +424,8 @@ const typographyLabDirections = [
           <strong>Status:</strong> Applied — needs review
         </p>
         <p class="sprint-preview__typo-sans">
-          Hub/ed-aligned container (52rem), block-rytme, tre-veier-paths, utility vs editorial entry cards, kompakt
-          Hørehjelpen fast-track. Mandat #125G-R3 uendret. FOUC ikke adressert.
+          R1: fjernet meta («Velg vei», redaksjonell note, side-accent). Samlet kortfamilie + integrert
+          Hørehjelpen fast-track. Mandat #125G-R3 uendret.
         </p>
         <a href={`${base}no/`} class="sprint-preview__typo-link">
           Verify frontpage polish on production →


### PR DESCRIPTION
## Summary
Thomas QA on #125I-C: too explanatory, cards not unified, blue side-accent felt like old visual debt.

- Removed «Velg vei», editorial note, three-path list, «Forside» kicker
- Unified Hjelp + Lyd i hverdagen card structure (no border-l accent, no gradient stripe)
- Integrated Hørehjelpen fast-track inside choice module
- Tighter hero + vertical rhythm

Mandate (#125G-R3) unchanged. Only `/no/`.

## Test plan
- [ ] `/no/` — samlet, rolig, two equal cards, compact chat row
- [ ] No «Velg vei», no blue side accent
- [ ] Other routes unchanged, build green


Made with [Cursor](https://cursor.com)