### PR TITLE
fix(#125I-C-R2): frontpage card family, width and fast-track

### DIFF
--- a/src/pages/no/index.astro
+++ b/src/pages/no/index.astro
@@ -1,6 +1,6 @@
 ---
-/* CONTRACT: Norwegian landing — triage / avklaringsflate (#125G-R3, polish #125I-C-R1).
-   Two primary hub entries + Hørehjelpen fast-track in one choice module. Mandate unchanged.
+/* CONTRACT: Norwegian landing — triage / avklaringsflate (#125G-R3, polish #125I-C-R2).
+   Unified card family, wider module, tight fast-track. Mandate unchanged.
  */
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Footer from "../../components/nav/Footer.astro";
@@ -46,8 +46,10 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
         </ul>
 
         <div class="land-fasttrack">
-          <p class="land-fasttrack__text">Vil du heller spørre direkte?</p>
-          <a href="/no/chat" class="land-fasttrack__cta">Start samtale med Hørehjelpen</a>
+          <div class="land-fasttrack__row">
+            <p class="land-fasttrack__text">Vil du heller spørre direkte?</p>
+            <a href="/no/chat" class="land-fasttrack__cta">Start samtale med Hørehjelpen</a>
+          </div>
         </div>
       </section>
     </div>
@@ -65,13 +67,13 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
 </BaseLayout>
 
 <style>
-  /* #125I-C-R1 — reduce, unify; shared card family + integrated fast-track */
+  /* #125I-C-R2 — same card surface, wider module, tight fast-track row */
   .land-page {
     padding: 0;
   }
 
   .land-container {
-    max-width: min(100%, 52rem);
+    max-width: min(100%, 60rem);
     margin: 0 auto;
     padding: 0 1rem clamp(3.75rem, 7vw, 5rem);
   }
@@ -89,31 +91,35 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
   }
 
   .land-header {
-    padding: clamp(2rem, 6vw, 3rem) 0 clamp(1.1rem, 2.8vw, 1.45rem);
+    padding: clamp(2rem, 6vw, 3rem) 0 clamp(1rem, 2.5vw, 1.3rem);
     border-bottom: 1px solid rgb(var(--border) / 0.2);
   }
 
   [data-landing-page] h1 {
     margin: 0;
     font-family: var(--font-display);
-    font-size: clamp(2rem, 5.8vw, 2.55rem);
+    font-size: clamp(2rem, 5.8vw, 2.6rem);
     font-weight: 650;
     line-height: 1.05;
     letter-spacing: -0.055em;
     text-wrap: balance;
     color: rgb(var(--reading-ink));
+    max-width: 42rem;
   }
 
   .land-lead {
     margin: clamp(0.65rem, 1.8vw, 0.85rem) 0 0;
-    max-width: 36rem;
+    max-width: 38rem;
     font-size: clamp(0.93rem, 2.1vw, 1.02rem);
     line-height: 1.5;
     color: rgb(var(--reading-ink-secondary));
   }
 
   .land-choices {
-    padding-top: clamp(1.1rem, 2.8vw, 1.35rem);
+    margin-top: clamp(1rem, 2.5vw, 1.2rem);
+    padding: clamp(0.9rem, 2.2vw, 1.05rem);
+    border: 1px solid rgb(var(--border) / 0.16);
+    border-radius: 12px;
   }
 
   .land-entry-grid {
@@ -128,7 +134,7 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
   @media (min-width: 640px) {
     .land-entry-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.65rem;
+      gap: 0.7rem;
     }
   }
 
@@ -138,14 +144,13 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
     flex-direction: column;
     gap: 0.38rem;
     min-height: 100%;
-    padding: 0.95rem 0.95rem 2.1rem;
-    border: 1px solid rgb(var(--border) / 0.24);
+    padding: 1rem 1rem 2.15rem;
+    border: 1px solid rgb(var(--border) / 0.22);
     border-radius: 10px;
     background: rgb(var(--reading-paper));
     color: inherit;
     text-decoration: none;
     transition:
-      background-color 150ms ease,
       border-color 150ms ease,
       box-shadow 150ms ease;
   }
@@ -164,7 +169,7 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
   }
 
   .land-entry__title {
-    font-size: 1rem;
+    font-size: 1.02rem;
     font-weight: 650;
     letter-spacing: -0.025em;
     line-height: 1.28;
@@ -180,8 +185,8 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
 
   .land-entry__arrow {
     position: absolute;
-    right: 0.95rem;
-    bottom: 0.88rem;
+    right: 1rem;
+    bottom: 0.9rem;
     font-size: 0.88rem;
     line-height: 1;
     color: rgb(var(--reading-ink-secondary) / 0.5);
@@ -189,7 +194,7 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
   }
 
   .land-entry:hover {
-    border-color: rgb(var(--border) / 0.38);
+    border-color: rgb(var(--border) / 0.36);
     box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
   }
 
@@ -198,49 +203,41 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
     transform: translateX(2px);
   }
 
-  /* Hjelp — utility: solid surface, tettere hint */
+  /* Tone via text rhythm only — same base surface for both */
   .land-entry--help .land-entry__hint {
-    line-height: 1.45;
-  }
-
-  /* Lyd i hverdagen — editorial: roligere surface, litt mer luft i tekst */
-  .land-entry--editorial {
-    background: rgb(var(--reading-paper) / 0.72);
-    border-color: rgb(var(--border) / 0.18);
-  }
-
-  .land-entry--editorial:hover {
-    background: rgb(var(--reading-paper));
+    line-height: 1.44;
   }
 
   .land-entry--editorial .land-entry__hint {
     line-height: 1.52;
   }
 
-  /* Hørehjelpen — integrated fast-track */
   .land-fasttrack {
+    margin-top: 0.75rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid rgb(var(--border) / 0.14);
+  }
+
+  .land-fasttrack__row {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.65rem;
-    margin-top: 0.85rem;
-    padding-top: 0.9rem;
-    border-top: 1px solid rgb(var(--border) / 0.16);
+    gap: 0.45rem;
   }
 
   @media (min-width: 480px) {
-    .land-fasttrack {
+    .land-fasttrack__row {
       flex-direction: row;
+      flex-wrap: wrap;
       align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
+      gap: 0.55rem 0.75rem;
     }
   }
 
   .land-fasttrack__text {
     margin: 0;
     font-size: 0.84rem;
-    line-height: 1.45;
+    line-height: 1.4;
     color: rgb(var(--reading-ink-secondary));
   }
 

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -127,7 +127,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "needs-review",
     stakeholderSafe: true,
     description:
-      "R1 refinement — unified card family, reduced meta copy, integrated fast-track. Mandat uendret. Needs Thomas QA.",
+      "R2 — unified card surface, wider module (60rem), tight fast-track row. Mandat uendret. Needs Thomas QA.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -10,7 +10,7 @@
    #125G: Forside/routing at /no/ — QA accepted, closed (#125G-R3 triage mandate).
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
-   #125I-C-R1: Frontpage polish refinement — reduce and unify; needs review.
+   #125I-C-R2: Card family, width, fast-track refinement; needs review.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -124,7 +124,7 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
         <li><strong>Parked:</strong> #125I-B Layout shift / FOUC — known issue</li>
-        <li><strong>Active:</strong> #125I-C-R1 Frontpage polish refinement på <code>/no/</code> — needs review</li>
+        <li><strong>Active:</strong> #125I-C-R2 Frontpage polish på <code>/no/</code> — needs review</li>
         <li><strong>Neste:</strong> #125I-D Hub polish etter Thomas QA på #125I-C</li>
       </ul>
     </section>
@@ -424,8 +424,7 @@ const typographyLabDirections = [
           <strong>Status:</strong> Applied — needs review
         </p>
         <p class="sprint-preview__typo-sans">
-          R1: fjernet meta («Velg vei», redaksjonell note, side-accent). Samlet kortfamilie + integrert
-          Hørehjelpen fast-track. Mandat #125G-R3 uendret.
+          R2: samme kort-surface, bredere modul (60rem), fast-track som tett rad. Mandat uendret.
         </p>
         <a href={`${base}no/`} class="sprint-preview__typo-link">
           Verify frontpage polish on production →


### PR DESCRIPTION
## Summary
- Same base surface on Hjelp + Lyd i hverdagen cards (tone via hint line-height only)
- Wider page module (52rem → 60rem) with bordered choice module
- Fast-track text + CTA as tight row (no space-between gap)

Mandate unchanged. Only `/no/`.


Made with [Cursor](https://cursor.com)