### PR TITLE
#125I-D Hub polish — CBA v0.1 (QA accepted)

### DIFF
--- a/docs/project/decisions/DECISION_125I_D_HELP_HUB_CBA.md
+++ b/docs/project/decisions/DECISION_125I_D_HELP_HUB_CBA.md
@@ -1,0 +1,93 @@
+# Decision #125I-D — Help hub CBA v0.1
+
+Status: **QA accepted / CBA v0.1 / closed**  
+Sprint: 2026-W21  
+Route: `/no/hub/`  
+Related: #125D (Hjelp A3), #125I Cross-surface polish (#157), #125I-B (FOUC)
+
+## Kort beslutning
+
+`/no/hub/` er en **praktisk hjelpehub** (utility / problemløsning), ikke en magasin- eller redaksjonell hub.  
+Etter polish R1–R8 og Thomas QA (2026-05) er flaten **god nok for nå** som **CBA v0.1** — current best answer, ikke endelig design lock.
+
+---
+
+## Informasjonsarkitektur
+
+| Element | Rolle |
+|--------|--------|
+| **H1** — «Hva trenger du hjelp med?» | Primær orientering |
+| **Composer** | Primær inngang (AI-spørsmål først i DOM) |
+| **Kategori-kort** | Sekundær inngang til problemområder |
+| **«Hjelp meg med»-liste** | Tertiær, kompakt problemliste |
+| **Eskalering** | Audiograf / «Still et spørsmål» |
+
+Hub-innhold skal **ikke** inneholde «Hørehjelpen» som egen hub-tittel eller redaksjonell framing.
+
+---
+
+## Visuell retning (CBA v0.1)
+
+### Kategori-kort
+
+- **Hvite flater** (`--reading-paper`) — tekststerke, uten endelig ikonsett
+- **Store korttitler** som visuelle anker
+- **Editorial card-hover:** hvit flate beholdes; hover via soft shadow + lett lift (`translateY(-2px)`)
+- **Ingen fersken/offwhite** som interactive card surface
+- Mønster tett på editorial cards i Lyd i hverdagen — uten magasinhub-følelse
+
+### Liste-rader
+
+- **Nøytral row-hover** (`#F5F6F5`) på «Hjelp meg med» og tilsvarende rader
+- `#F5F6F5` er **ikke** category card hover — kun row/list IXD
+
+### Surface
+
+- Article-paritet: 46rem lesebredde, `--radius-md`, hvit hub-surface på canvas
+- Ingen offwhite/peach på kort som interaktive flater
+
+---
+
+## Hva CBA betyr
+
+**CBA = current best answer** — god nok retning for videre arbeid og produksjon, ikke endelig design lock.  
+Endringer krever nytt mandat eller eget issue; ikke ad hoc polish i lukket slice.
+
+---
+
+## Known issue (utenfor denne beslutningen)
+
+**FOUC / layout shift** ved lasting av hub (og enkelte andre ruter) forblir **known technical debt** (#125I-B).  
+Ingen fix er del av #125I-D.
+
+---
+
+## Follow-ups (ikke i #125I-D)
+
+| Tema | Beskrivelse |
+|------|-------------|
+| **Ikon-/illustrasjonspass** | Eget pass for hjelpekategorier — ikonsett er bevisst utelatt i CBA v0.1 |
+| **Composer-paritet** | Hub-composer vs. artikkel-/editorial-composer — felles oppførsel senere |
+| **Footer / editorial-shell** | Visuell og strukturell sammenheng mellom hub og redaksjonelle flater |
+| **FOUC / layout shift** | Teknisk spike eller felles page shell (#125I-B) |
+| **Copy / nav naming** | Senere pass (#125J) — navnetiketter, microcopy, IA-ordlyd |
+
+---
+
+## QA-lås (Thomas, R8)
+
+Godkjent som **godt nok for nå**:
+
+- H1 + composer som primær inngang
+- Hvite kategori-kort uten ikoner, tekststerke titler
+- Editorial card-hover (ikke grå fill på kort)
+- Row-hover beholdt på liste
+- Ingen «Hørehjelpen» i hub-innhold
+- `/no/` uendret av denne slicen
+
+---
+
+## Arbeidsregel
+
+Bruk denne beslutningen som gjeldende retning for `/no/hub/` til eksplisitt nytt mandat.  
+Follow-ups startes som egne issues — ikke som utvidelse av lukket #125I-D.

--- a/docs/project/tasks/ISSUE_125I_CROSS_SURFACE_POLISH_PLAN.md
+++ b/docs/project/tasks/ISSUE_125I_CROSS_SURFACE_POLISH_PLAN.md
@@ -56,10 +56,13 @@
 
 ### P1 — Layout jump / FOUC (kritisk, systemnivå)
 
-- **Symptom:** Vertikal «snap» ved hard refresh og globalnav-klikk. Innhold under fixed header tegnes først med feil offset, deretter på plass.
+- **Symptom (oppdatert Thomas QA, 2026-05):** Horisontal «snap» ved **lasting av enkelte sider** — ikke primært ved globalnav-klikk. `/no/` står rolig; `/no/hub/`, `/no/lyd-i-hverdagen/`, `/no/ordbok/`, `/no/om/` hopper sideveis (ca. like mye, noe variasjon). Tidligere også rapportert ved refresh/globalnav.
 - **Diagnose (R7):** Identisk FOUC-signatur i pre-#125H (`284037aa`) og #125H initial (`73b17e25`). **Ikke introdusert av #125H.**
-- **Hypotese:** Fixed header, nav-layout og content `padding-top` (`pt-28` / `sm:pt-30`) avhenger av Tailwind-bundle i `/_astro/*.css` som laster etter first paint.
-- **Behandles som:** Layout-systemproblem i `BaseLayout` / shell — **ikke** nav-label- eller IA-problem.
+- **Diagnose (R2):** Horisontal shift ved Tailwind preflight + container layout (body margin 8→0, headerInner 8→64px). R3 first-paint CSS ga bedre målinger, ingen synlig QA-forbedring — revertet.
+- **Tolkning (2026-05):** Peeker mot **route-spesifikk layout/CSS-arv**, ikke bare global header. Sammenlign `/no/` (stabil) vs hub/ordbok/om (hopper).
+- **Hypotese (shell):** Fixed header + content offset avhenger av Tailwind-bundle etter first paint.
+- **Hypotese (route):** Ulik page-scoped CSS, containerbredde, main/footer-forhold mellom flater.
+- **Behandles som:** Known issue / teknisk gjeld. **Ingen ny FOUC-fix uten eksplisitt mandat.** Observasjon tas med inn i #125I-D (felles page shell) og evt. senere teknisk spike.
 
 ### P2 — Forsiden visuelt umoden
 
@@ -152,6 +155,7 @@ Målet er at Viddel føles **trygg, aktuell og redaksjonelt moden** — ikke som
 
 - Samlet polish for **Hjelp** + **Lyd i hverdagen**.
 - Kort, spacing, visual hierarchy, surface-bruk — sett i sammenheng, ikke isolert per side.
+- **Layout-jump observasjon (Thomas QA):** Ta med felles page shell — samme containerbredde, mindre page-scoped historisk CSS, samme main/footer-forhold. Sammenlign stabile `/no/` vs hoppende hub/ordbok/om. **Ikke start dedikert FOUC-fix i hub-polish uten mandat** — alignment kan redusere symptom, men root cause kan kreve egen spike.
 
 ### #125I-E Article surface alignment
 

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Hjelp hub (A3) — praktisk hjelpehub for konkrete problemer.
-   #125I-D-R5 — direkte H1, tyngre kategorikort/ikoner, tydeligere gestalt.
+   #125I-D-R6 — hvite kategorikort uten ikonstøy; ikoner midlertidig fjernet.
    Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
@@ -10,50 +10,41 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
 
 const hubHeading = "Hva trenger du hjelp med?";
 
-type CategoryIcon = "piping" | "bluetooth" | "app" | "filter" | "battery" | "sound";
-
 const categoryCards: Array<{
   title: string;
   hint: string;
   href?: string;
-  icon: CategoryIcon;
   status?: "gap";
 }> = [
   {
     title: "Piping og ulyd",
     hint: "Slutt på piping og ulyd i øret",
     href: "/no/artikkel/fa-slutt-pa-pipingen",
-    icon: "piping",
   },
   {
     title: "Mobil og Bluetooth",
     hint: "Koble høreapparatet til mobilen",
     href: "/no/artikkel/koble-horeapparatet-til-mobilen",
-    icon: "bluetooth",
   },
   {
     title: "App og tilkobling",
     hint: "Når appen ikke finner apparatet",
     href: "/no/artikkel/appen-finner-ikke-horeapparatet",
-    icon: "app",
   },
   {
     title: "Filter og vedlikehold",
     hint: "Bytte filter og enkel vedlikehold",
     href: "/no/artikkel/bytte-filter-uten-stress",
-    icon: "filter",
   },
   {
     title: "Batteri og lading",
     hint: "Sjekke batteri og lading",
-    icon: "battery",
     status: "gap",
   },
   {
     title: "Lyd og tilpasning",
     hint: "Når lyden føles feil eller slitsom",
     href: "/no/artikkel/lyden-blir-slitsom-utpa-dagen",
-    icon: "sound",
   },
 ];
 
@@ -115,48 +106,11 @@ const audiografEscalation = {
                 <li>
                   {card.href ? (
                     <a href={card.href} class="hub-cat-card">
-                      <span class="hub-cat-card__icon" aria-hidden="true" data-icon={card.icon}>
-                        {card.icon === "piping" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-                            <path d="M4 12c2-4 4-4 6 0s4 4 6 0 4-4 6 0" />
-                          </svg>
-                        )}
-                        {card.icon === "bluetooth" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round">
-                            <path d="M8 7l8 5-8 5V7z" /><path d="M16 7v10" />
-                          </svg>
-                        )}
-                        {card.icon === "app" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-                            <rect x="5" y="3" width="14" height="18" rx="2" /><path d="M10 17h4" />
-                          </svg>
-                        )}
-                        {card.icon === "filter" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-                            <path d="M4 6h16M7 12h10M10 18h4" />
-                          </svg>
-                        )}
-                        {card.icon === "battery" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <rect x="3" y="7" width="16" height="10" rx="2" /><path d="M21 10v4" /><path d="M7 11v2" />
-                          </svg>
-                        )}
-                        {card.icon === "sound" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-                            <path d="M6 10v4h3l4 3V7L9 10H6z" /><path d="M17 9a3 3 0 010 6" />
-                          </svg>
-                        )}
-                      </span>
                       <span class="hub-cat-card__title">{card.title}</span>
                       <span class="hub-cat-card__hint">{card.hint}</span>
                     </a>
                   ) : (
                     <span class="hub-cat-card hub-cat-card--gap">
-                      <span class="hub-cat-card__icon" aria-hidden="true" data-icon={card.icon}>
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                          <rect x="3" y="7" width="16" height="10" rx="2" /><path d="M21 10v4" /><path d="M7 11v2" />
-                        </svg>
-                      </span>
                       <span class="hub-cat-card__title">{card.title}</span>
                       <span class="hub-cat-card__hint">{card.hint}</span>
                       <span class="hub-cat-card__badge">Kommer</span>
@@ -201,7 +155,7 @@ const audiografEscalation = {
 </BaseLayout>
 
 <style>
-  /* #125I-D-R5 — tydelig gestalt, tyngre kort/ikoner, direkte H1 */
+  /* #125I-D-R6 — hvite kategorikort, gestalt via spacing; ikoner midlertidig fjernet */
   .hub-page {
     background: rgb(var(--article-page-canvas));
     padding: 0.5rem 0 clamp(3rem, 6vw, 4rem);
@@ -368,7 +322,7 @@ const audiografEscalation = {
     padding-top: 0.15rem;
   }
 
-  /* ── Kategorikort — equal height, tyngre ikoner (midlertidige line-glyphs, R5) ── */
+  /* ── Kategorikort — hvite flater, equal height, ingen ikonbokser (R6) ── */
   .hub-cat-grid {
     margin: 0;
     padding: 0;
@@ -376,7 +330,7 @@ const audiografEscalation = {
     display: grid;
     grid-template-columns: 1fr;
     grid-auto-rows: 1fr;
-    gap: 0.9rem;
+    gap: 0.75rem;
   }
 
   .hub-cat-grid > li {
@@ -387,13 +341,14 @@ const audiografEscalation = {
   @media (min-width: 540px) {
     .hub-cat-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 1rem;
+      gap: 0.85rem;
     }
   }
 
   @media (min-width: 960px) {
     .hub-cat-grid {
       grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.9rem;
     }
   }
 
@@ -403,25 +358,23 @@ const audiografEscalation = {
     width: 100%;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.65rem;
-    min-height: 10.75rem;
-    padding: 1.35rem 1.25rem 1.3rem;
-    border: 1px solid rgb(var(--border) / 0.4);
+    gap: 0.4rem;
+    min-height: 6.5rem;
+    padding: 1.15rem 1.2rem;
+    border: 1px solid rgb(var(--border) / 0.3);
     border-radius: var(--radius-md);
-    background: rgb(var(--surface-subtle) / 0.55);
-    box-shadow: 0 1px 3px rgb(var(--reading-ink) / 0.07);
+    background: rgb(var(--reading-paper));
+    box-shadow: 0 1px 2px rgb(var(--reading-ink) / 0.04);
     color: inherit;
     text-decoration: none;
     transition:
       border-color 150ms ease,
-      box-shadow 150ms ease,
-      transform 150ms ease;
+      box-shadow 150ms ease;
   }
 
   a.hub-cat-card:hover {
-    border-color: rgb(var(--border) / 0.52);
-    box-shadow: 0 4px 14px rgb(var(--reading-ink) / 0.08);
-    transform: translateY(-1px);
+    border-color: rgb(var(--border) / 0.44);
+    box-shadow: 0 2px 8px rgb(var(--reading-ink) / 0.06);
   }
 
   a.hub-cat-card:focus-visible {
@@ -431,37 +384,13 @@ const audiografEscalation = {
 
   .hub-cat-card--gap {
     color: rgb(var(--reading-ink-secondary));
-    opacity: 0.92;
-  }
-
-  .hub-cat-card__icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 3.25rem;
-    height: 3.25rem;
-    flex-shrink: 0;
-    border: 1px solid rgb(var(--border) / 0.38);
-    border-radius: var(--radius-md);
-    background: rgb(var(--reading-paper));
-    box-shadow: 0 1px 2px rgb(var(--reading-ink) / 0.06);
-    color: rgb(var(--reading-ink));
-  }
-
-  .hub-cat-card--gap .hub-cat-card__icon {
-    color: rgb(var(--reading-ink-secondary) / 0.75);
-  }
-
-  .hub-cat-card__icon svg {
-    width: 1.65rem;
-    height: 1.65rem;
   }
 
   .hub-cat-card__title {
     font-size: 1rem;
     font-weight: 650;
     letter-spacing: -0.02em;
-    line-height: 1.28;
+    line-height: 1.3;
     color: rgb(var(--reading-ink));
   }
 
@@ -470,15 +399,13 @@ const audiografEscalation = {
   }
 
   .hub-cat-card__hint {
-    margin-top: auto;
-    font-size: 0.82rem;
-    line-height: 1.42;
+    font-size: 0.84rem;
+    line-height: 1.45;
     color: rgb(var(--reading-ink-secondary));
   }
 
   .hub-cat-card__badge {
     margin-top: auto;
-    align-self: flex-start;
     font-size: 0.62rem;
     font-weight: 700;
     letter-spacing: 0.08em;

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,7 +1,6 @@
 ---
-/* CONTRACT: Hjelp hub (A3) — «Få høreapparatet til å fungere».
-   Utility-first: AI ask → problem cards → short guides → escalation.
-   #125D applied slice; #125I-D-R1 polish — layout family aligned with /no/ (#125I-C).
+/* CONTRACT: Hjelp hub (A3) — praktisk hjelpehub for konkrete problemer.
+   #125D applied slice; #125I-D-R2 — én primærvei, færre visuelle nivåer, samlet link-familie.
    Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
@@ -14,53 +13,27 @@ const hubSupport = "Vanlige problemer og rask hjelp — velg det som passer, ell
 
 type TaskStatus = "finnes" | "gap";
 
-const problemCards: Array<{
+const commonProblems: Array<{
   title: string;
-  href: string;
+  href?: string;
+  status?: TaskStatus;
 }> = [
   { title: "Stoppe piping", href: "/no/artikkel/fa-slutt-pa-pipingen" },
   { title: "Koble til mobilen", href: "/no/artikkel/koble-horeapparatet-til-mobilen" },
   { title: "Appen finner ikke høreapparatet", href: "/no/artikkel/appen-finner-ikke-horeapparatet" },
   { title: "Bytte filter", href: "/no/artikkel/bytte-filter-uten-stress" },
-];
-
-const moreProblems: Array<{
-  label: string;
-  href?: string;
-  status: TaskStatus;
-}> = [
-  { label: "Fikse app eller Bluetooth", href: "/no/artikkel/appen-finner-ikke-horeapparatet", status: "finnes" },
-  { label: "Sjekke batteri og lading", status: "gap" },
-  { label: "Forstå om lyden er feil eller normal", href: "/no/artikkel/lyden-blir-slitsom-utpa-dagen", status: "finnes" },
-  { label: "Vite når audiograf bør kontaktes", href: "/no/artikkel/audiograf-nar-det-haster", status: "finnes" },
+  { title: "Fikse app eller Bluetooth", href: "/no/artikkel/appen-finner-ikke-horeapparatet" },
+  { title: "Sjekke batteri og lading", status: "gap" },
+  { title: "Forstå om lyden er feil eller normal", href: "/no/artikkel/lyden-blir-slitsom-utpa-dagen" },
+  { title: "Vite når audiograf bør kontaktes", href: "/no/artikkel/audiograf-nar-det-haster" },
 ];
 
 const shortGuides = [
-  {
-    label: "Feilsøking",
-    title: "Få slutt på pipingen",
-    href: "/no/artikkel/fa-slutt-pa-pipingen",
-  },
-  {
-    label: "Tilkobling",
-    title: "Koble høreapparatet til mobilen",
-    href: "/no/artikkel/koble-horeapparatet-til-mobilen",
-  },
-  {
-    label: "App og Bluetooth",
-    title: "Appen finner ikke høreapparatet",
-    href: "/no/artikkel/appen-finner-ikke-horeapparatet",
-  },
-  {
-    label: "Vedlikehold",
-    title: "Bytte filter uten stress",
-    href: "/no/artikkel/bytte-filter-uten-stress",
-  },
-  {
-    label: "Lyd og tilpasning",
-    title: "Lyden blir slitsom utpå dagen",
-    href: "/no/artikkel/lyden-blir-slitsom-utpa-dagen",
-  },
+  { title: "Få slutt på pipingen", href: "/no/artikkel/fa-slutt-pa-pipingen" },
+  { title: "Koble høreapparatet til mobilen", href: "/no/artikkel/koble-horeapparatet-til-mobilen" },
+  { title: "Appen finner ikke høreapparatet", href: "/no/artikkel/appen-finner-ikke-horeapparatet" },
+  { title: "Bytte filter uten stress", href: "/no/artikkel/bytte-filter-uten-stress" },
+  { title: "Lyden blir slitsom utpå dagen", href: "/no/artikkel/lyden-blir-slitsom-utpa-dagen" },
 ];
 
 const audiografEscalation = {
@@ -75,39 +48,21 @@ const audiografEscalation = {
 
   <main class="hub-page" data-hub-help>
     <div class="hub-container">
-
       <header class="hub-header">
         <nav class="hub-breadcrumb" aria-label="Du er her">
           <a href="/no">Forside</a>
           <span aria-hidden="true">/</span>
           <span>Hjelp</span>
         </nav>
-        <p class="hub-kicker">Hjelp</p>
         <h1>{hubTitle}</h1>
         <p class="hub-lead">{hubSupport}</p>
       </header>
 
-      <div class="hub-module">
-
-        <!-- Problem cards — primary paths first -->
-        <section class="hub-section" aria-labelledby="problems-heading">
-          <h2 id="problems-heading" class="hub-section__title">Dette kan du prøve først</h2>
-          <ul class="hub-problem-grid" role="list">
-            {problemCards.map((card) => (
-              <li>
-                <a href={card.href} class="hub-problem-card">
-                  <span class="hub-problem-card__title">{card.title}</span>
-                  <span class="hub-problem-card__arrow" aria-hidden="true">→</span>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
-
-        <!-- AI ask — compact utility row -->
-        <section class="hub-section hub-section--ai" aria-labelledby="ai-ask-heading">
-          <h2 id="ai-ask-heading" class="hub-section__title">Hva fungerer ikke?</h2>
-          <p class="hub-ai-ask__lead">
+      <div class="hub-inner">
+        <!-- 1. Primærvei: beskriv problemet -->
+        <section class="hub-primary" aria-labelledby="ai-ask-heading">
+          <h2 id="ai-ask-heading">Hva fungerer ikke?</h2>
+          <p class="hub-primary__lead">
             Beskriv problemet — Hørehjelpen åpnes med spørsmålet ditt og hjelper deg videre.
           </p>
           <form class="hub-ai-form" action="/no/chat" method="get">
@@ -127,21 +82,21 @@ const audiografEscalation = {
           </form>
         </section>
 
-        <!-- More problems — compact list -->
-        <section class="hub-section" aria-labelledby="more-problems-heading">
-          <h2 id="more-problems-heading" class="hub-section__title">Flere vanlige problemer</h2>
-          <ul class="hub-task-list" role="list">
-            {moreProblems.map((task) => (
-              <li class:list={["hub-task-row", task.status === "gap" && "hub-task-row--gap"]}>
-                {task.href ? (
-                  <a href={task.href} class="hub-task-row__link">
-                    <span class="hub-task-row__label">{task.label}</span>
-                    <span class="hub-task-row__arrow" aria-hidden="true">→</span>
+        <!-- 2. Vanlige problemer — samme link-familie -->
+        <section class="hub-block" aria-labelledby="problems-heading">
+          <h2 id="problems-heading">Vanlige problemer</h2>
+          <ul class="hub-link-list" role="list">
+            {commonProblems.map((item) => (
+              <li class:list={["hub-link-row", item.status === "gap" && "hub-link-row--gap"]}>
+                {item.href ? (
+                  <a href={item.href} class="hub-link-row__action">
+                    <span class="hub-link-row__title">{item.title}</span>
+                    <span class="hub-link-row__arrow" aria-hidden="true">→</span>
                   </a>
                 ) : (
-                  <span class="hub-task-row__coming">
-                    <span class="hub-task-row__label">{task.label}</span>
-                    <span class="hub-task-row__badge">Kommer</span>
+                  <span class="hub-link-row__static">
+                    <span class="hub-link-row__title">{item.title}</span>
+                    <span class="hub-link-row__badge">Kommer</span>
                   </span>
                 )}
               </li>
@@ -149,37 +104,33 @@ const audiografEscalation = {
           </ul>
         </section>
 
-        <!-- Short guides -->
-        <section class="hub-section" aria-labelledby="guides-heading">
-          <h2 id="guides-heading" class="hub-section__title">Korte guider</h2>
-          <ul class="hub-guide-rows" role="list">
+        <!-- 3. Korte guider — samme radmønster -->
+        <section class="hub-block" aria-labelledby="guides-heading">
+          <h2 id="guides-heading">Korte guider</h2>
+          <ul class="hub-link-list" role="list">
             {shortGuides.map((guide) => (
-              <li>
-                <a href={guide.href} class="hub-guide-row">
-                  <span class="hub-guide-row__label">{guide.label}</span>
-                  <span class="hub-guide-row__title">{guide.title}</span>
-                  <span class="hub-guide-row__arrow" aria-hidden="true">→</span>
+              <li class="hub-link-row">
+                <a href={guide.href} class="hub-link-row__action">
+                  <span class="hub-link-row__title">{guide.title}</span>
+                  <span class="hub-link-row__arrow" aria-hidden="true">→</span>
                 </a>
               </li>
             ))}
           </ul>
         </section>
 
-        <!-- Escalation -->
-        <section class="hub-section hub-section--escalation" aria-labelledby="escalation-heading">
+        <!-- 4. Eskalering — rolig avslutningskort -->
+        <section class="hub-block hub-block--escalation" aria-labelledby="escalation-heading">
           <h2 id="escalation-heading" class="sr-only">Videre hjelp</h2>
-          <a href="/no/chat?from=hub" class="hub-escalation-chat">
-            Fant du ikke svaret? Spør Hørehjelpen
-            <span aria-hidden="true">→</span>
+          <a href={audiografEscalation.href} class="hub-escalation-card">
+            <span class="hub-escalation-card__title">{audiografEscalation.title}</span>
+            <span class="hub-escalation-card__deck">{audiografEscalation.deck}</span>
+            <span class="hub-escalation-card__arrow" aria-hidden="true">→</span>
           </a>
-          <a href={audiografEscalation.href} class="hub-escalation-audiograf">
-            <span class="hub-escalation-audiograf__label">Audiograf</span>
-            <span class="hub-escalation-audiograf__title">{audiografEscalation.title}</span>
-            <span class="hub-escalation-audiograf__deck">{audiografEscalation.deck}</span>
-            <span class="hub-escalation-audiograf__arrow" aria-hidden="true">→</span>
-          </a>
+          <p class="hub-escalation-fallback">
+            <a href="/no/chat?from=hub">Fant du ikke svaret? Spør Hørehjelpen</a>
+          </p>
         </section>
-
       </div>
     </div>
   </main>
@@ -188,7 +139,7 @@ const audiografEscalation = {
 </BaseLayout>
 
 <style>
-  /* #125I-D-R1 — layout family aligned with /no/ (#125I-C): 60rem module, calm surfaces */
+  /* #125I-D-R2 — praktisk hjelpehub: én primærvei, ett link-mønster, smalere innholdsflate */
   .hub-page {
     padding: 0;
   }
@@ -211,8 +162,19 @@ const audiografEscalation = {
     }
   }
 
+  .hub-inner {
+    max-width: 44rem;
+    margin: 0 auto;
+    padding-top: clamp(1.1rem, 2.8vw, 1.45rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.35rem, 3.2vw, 1.75rem);
+  }
+
   .hub-header {
-    padding: clamp(2rem, 6vw, 3rem) 0 clamp(1rem, 2.5vw, 1.3rem);
+    max-width: 44rem;
+    margin: 0 auto;
+    padding: clamp(2rem, 6vw, 3rem) 0 clamp(0.85rem, 2vw, 1.1rem);
     border-bottom: 1px solid rgb(var(--border) / 0.2);
   }
 
@@ -220,7 +182,7 @@ const audiografEscalation = {
     display: flex;
     align-items: center;
     gap: 0.45rem;
-    margin-bottom: 0.85rem;
+    margin-bottom: 0.75rem;
     font-size: 0.68rem;
     font-weight: 600;
     letter-spacing: 0.12em;
@@ -234,15 +196,6 @@ const audiografEscalation = {
     text-underline-offset: 2px;
   }
 
-  .hub-kicker {
-    margin: 0 0 0.45rem;
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgb(var(--reading-ink-secondary));
-  }
-
   [data-hub-help] h1 {
     margin: 0;
     font-family: var(--font-display);
@@ -252,53 +205,38 @@ const audiografEscalation = {
     letter-spacing: -0.055em;
     text-wrap: balance;
     color: rgb(var(--reading-ink));
-    max-width: 42rem;
   }
 
   .hub-lead {
     margin: clamp(0.65rem, 1.8vw, 0.85rem) 0 0;
-    max-width: 38rem;
     font-size: clamp(0.93rem, 2.1vw, 1.02rem);
     line-height: 1.5;
     color: rgb(var(--reading-ink-secondary));
   }
 
-  .hub-module {
-    margin-top: clamp(1rem, 2.5vw, 1.2rem);
-    padding: clamp(0.9rem, 2.2vw, 1.05rem);
-    border: 1px solid rgb(var(--border) / 0.16);
+  /* Section headings — én rolig nivå, ikke uppercase micro-labels */
+  .hub-block h2,
+  .hub-primary h2 {
+    margin: 0 0 0.6rem;
+    font-family: var(--font-body, inherit);
+    font-size: 1rem;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    line-height: 1.3;
+    color: rgb(var(--reading-ink));
+  }
+
+  /* ── Primærvei: beskriv problemet ── */
+  .hub-primary {
+    padding: clamp(1rem, 2.4vw, 1.2rem);
+    border: 1px solid rgb(var(--border) / 0.2);
     border-radius: 12px;
+    background: rgb(var(--reading-paper));
   }
 
-  .hub-section {
-    padding: clamp(0.85rem, 2vw, 1rem) 0;
-  }
-
-  .hub-section + .hub-section {
-    border-top: 1px solid rgb(var(--border) / 0.14);
-  }
-
-  .hub-section:first-child {
-    padding-top: 0;
-  }
-
-  .hub-section:last-child {
-    padding-bottom: 0;
-  }
-
-  .hub-section__title {
-    margin: 0 0 0.65rem;
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgb(var(--reading-ink-secondary));
-  }
-
-  /* ── AI ask — compact utility, not dominant widget ── */
-  .hub-ai-ask__lead {
-    margin: 0 0 0.75rem;
-    font-size: 0.84rem;
+  .hub-primary__lead {
+    margin: 0 0 0.85rem;
+    font-size: 0.88rem;
     line-height: 1.48;
     color: rgb(var(--reading-ink-secondary));
   }
@@ -353,138 +291,77 @@ const audiografEscalation = {
     box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
   }
 
-  /* ── Problem cards — same calm surface family as forside entry cards ── */
-  .hub-problem-grid {
+  /* ── Felles link-liste for problemer og guider ── */
+  .hub-link-list {
     margin: 0;
     padding: 0;
     list-style: none;
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 0.6rem;
-  }
-
-  @media (min-width: 640px) {
-    .hub-problem-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.7rem;
-    }
-  }
-
-  .hub-problem-card {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    gap: 0.25rem;
-    min-height: 4.5rem;
-    padding: 0.95rem 1rem 2rem;
-    border: 1px solid rgb(var(--border) / 0.22);
-    border-radius: 10px;
-    background: rgb(var(--reading-paper));
-    color: inherit;
-    text-decoration: none;
-    transition:
-      border-color 150ms ease,
-      box-shadow 150ms ease;
-  }
-
-  .hub-problem-card:hover {
-    border-color: rgb(var(--border) / 0.36);
-    box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
-  }
-
-  .hub-problem-card:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
-  }
-
-  .hub-problem-card__title {
-    font-size: 0.98rem;
-    font-weight: 650;
-    letter-spacing: -0.025em;
-    line-height: 1.28;
-    color: rgb(var(--reading-ink));
-  }
-
-  .hub-problem-card__arrow {
-    position: absolute;
-    right: 1rem;
-    bottom: 0.85rem;
-    font-size: 0.88rem;
-    line-height: 1;
-    color: rgb(var(--reading-ink-secondary) / 0.5);
-    transition: color 150ms ease, transform 150ms ease;
-  }
-
-  .hub-problem-card:hover .hub-problem-card__arrow {
-    color: rgb(var(--reading-ink-secondary));
-    transform: translateX(2px);
-  }
-
-  /* ── Compact task list ── */
-  .hub-task-list {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    border: 1px solid rgb(var(--border) / 0.22);
+    border: 1px solid rgb(var(--border) / 0.2);
     border-radius: 10px;
     overflow: hidden;
     background: rgb(var(--reading-paper));
   }
 
-  .hub-task-row {
-    border-bottom: 1px solid rgb(var(--border) / 0.14);
+  .hub-link-row {
+    border-bottom: 1px solid rgb(var(--border) / 0.12);
   }
 
-  .hub-task-row:last-child {
+  .hub-link-row:last-child {
     border-bottom: 0;
   }
 
-  .hub-task-row__link,
-  .hub-task-row__coming {
+  .hub-link-row__action,
+  .hub-link-row__static {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
-    padding: 0.8rem 0.95rem;
+    padding: 0.82rem 0.95rem;
     text-decoration: none;
   }
 
-  .hub-task-row__link {
+  .hub-link-row__action {
     color: rgb(var(--reading-ink));
     transition: background-color 100ms ease;
   }
 
-  .hub-task-row__link:hover {
-    background: rgb(var(--border) / 0.12);
+  .hub-link-row__action:hover {
+    background: rgb(var(--border) / 0.1);
   }
 
-  .hub-task-row__link:focus-visible {
+  .hub-link-row__action:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 2px rgb(14 165 233 / 0.35);
   }
 
-  .hub-task-row__coming {
+  .hub-link-row__static {
     color: rgb(var(--reading-ink-secondary));
   }
 
-  .hub-task-row--gap .hub-task-row__label {
-    color: rgb(var(--reading-ink-secondary) / 0.6);
+  .hub-link-row--gap .hub-link-row__title {
+    color: rgb(var(--reading-ink-secondary) / 0.65);
   }
 
-  .hub-task-row__label {
-    font-size: 0.88rem;
+  .hub-link-row__title {
+    font-size: 0.9rem;
     line-height: 1.4;
     font-weight: 500;
+    letter-spacing: -0.01em;
   }
 
-  .hub-task-row__arrow {
+  .hub-link-row__arrow {
     flex-shrink: 0;
-    color: rgb(var(--reading-ink-secondary) / 0.5);
+    color: rgb(var(--reading-ink-secondary) / 0.45);
     font-size: 0.88rem;
+    transition: color 100ms ease, transform 100ms ease;
   }
 
-  .hub-task-row__badge {
+  .hub-link-row__action:hover .hub-link-row__arrow {
+    color: rgb(var(--reading-ink-secondary));
+    transform: translateX(2px);
+  }
+
+  .hub-link-row__badge {
     flex-shrink: 0;
     font-size: 0.62rem;
     font-weight: 700;
@@ -496,24 +373,19 @@ const audiografEscalation = {
     padding: 0.12rem 0.38rem;
   }
 
-  /* ── Short guide rows ── */
-  .hub-guide-rows {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    display: grid;
-    gap: 0.55rem;
+  /* ── Eskalering ── */
+  .hub-block--escalation {
+    padding-top: 0.15rem;
   }
 
-  .hub-guide-row {
+  .hub-escalation-card {
     display: grid;
-    grid-template-columns: auto 1fr auto;
-    gap: 0.35rem 0.75rem;
-    align-items: baseline;
-    padding: 0.85rem 0.95rem;
+    grid-template-columns: 1fr auto;
+    gap: 0.3rem 0.75rem;
+    padding: 0.95rem 1rem;
+    border: 1px solid rgb(var(--border) / 0.2);
     border-radius: 10px;
     background: rgb(var(--reading-paper));
-    border: 1px solid rgb(var(--border) / 0.22);
     color: inherit;
     text-decoration: none;
     transition:
@@ -521,120 +393,60 @@ const audiografEscalation = {
       box-shadow 150ms ease;
   }
 
-  .hub-guide-row:hover {
-    border-color: rgb(var(--border) / 0.36);
-    box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
+  .hub-escalation-card:hover {
+    border-color: rgb(var(--border) / 0.32);
+    box-shadow: 0 2px 10px rgb(var(--reading-ink) / 0.04);
   }
 
-  .hub-guide-row:focus-visible {
+  .hub-escalation-card:focus-visible {
     outline: none;
     box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
   }
 
-  .hub-guide-row__label {
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgb(var(--reading-ink-secondary));
-  }
-
-  .hub-guide-row__title {
-    font-size: 0.88rem;
+  .hub-escalation-card__title {
+    grid-column: 1;
+    font-size: 0.95rem;
     font-weight: 650;
     letter-spacing: -0.02em;
     line-height: 1.3;
     color: rgb(var(--reading-ink));
   }
 
-  .hub-guide-row__arrow {
-    color: rgb(var(--reading-ink-secondary) / 0.5);
-    font-size: 0.88rem;
-  }
-
-  /* ── Escalation ── */
-  .hub-section--escalation {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-
-  .hub-escalation-chat {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
+  .hub-escalation-card__deck {
+    grid-column: 1;
     font-size: 0.84rem;
-    font-weight: 650;
-    color: rgb(var(--reading-ink-secondary));
-    text-decoration: underline;
-    text-underline-offset: 3px;
-  }
-
-  .hub-escalation-chat:hover {
-    color: rgb(var(--reading-ink));
-  }
-
-  .hub-escalation-chat:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
-    border-radius: 4px;
-  }
-
-  .hub-escalation-audiograf {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.25rem 0.75rem;
-    padding: 0.95rem 1rem;
-    border: 1px solid rgb(var(--border) / 0.22);
-    border-radius: 10px;
-    background: rgb(var(--reading-paper));
-    color: inherit;
-    text-decoration: none;
-    transition:
-      border-color 150ms ease,
-      box-shadow 150ms ease;
-  }
-
-  .hub-escalation-audiograf:hover {
-    border-color: rgb(var(--border) / 0.36);
-    box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
-  }
-
-  .hub-escalation-audiograf:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
-  }
-
-  .hub-escalation-audiograf__label {
-    grid-column: 1;
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgb(var(--reading-ink-secondary));
-  }
-
-  .hub-escalation-audiograf__title {
-    grid-column: 1;
-    font-size: 0.98rem;
-    font-weight: 650;
-    letter-spacing: -0.025em;
-    line-height: 1.28;
-    color: rgb(var(--reading-ink));
-  }
-
-  .hub-escalation-audiograf__deck {
-    grid-column: 1;
-    font-size: 0.82rem;
     line-height: 1.48;
     color: rgb(var(--reading-ink-secondary));
   }
 
-  .hub-escalation-audiograf__arrow {
+  .hub-escalation-card__arrow {
     grid-column: 2;
-    grid-row: 1 / span 3;
+    grid-row: 1 / span 2;
     align-self: center;
-    color: rgb(var(--reading-ink-secondary) / 0.5);
+    color: rgb(var(--reading-ink-secondary) / 0.45);
+  }
+
+  .hub-escalation-fallback {
+    margin: 0.65rem 0 0;
+    font-size: 0.84rem;
+    line-height: 1.4;
+  }
+
+  .hub-escalation-fallback a {
+    color: rgb(var(--reading-ink-secondary));
+    font-weight: 550;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .hub-escalation-fallback a:hover {
+    color: rgb(var(--reading-ink));
+  }
+
+  .hub-escalation-fallback a:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
+    border-radius: 4px;
   }
 
   .sr-only {
@@ -661,11 +473,11 @@ const audiografEscalation = {
   }
 
   @media (max-width: 479px) {
-    .hub-escalation-audiograf {
+    .hub-escalation-card {
       grid-template-columns: 1fr;
     }
 
-    .hub-escalation-audiograf__arrow {
+    .hub-escalation-card__arrow {
       display: none;
     }
   }

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Hjelp hub (A3) — praktisk hjelpehub for konkrete problemer.
-   #125D applied slice; #125I-D-R2 — én primærvei, færre visuelle nivåer, samlet link-familie.
+   #125D applied slice; #125I-D-R2b — composer-inngang speiler artikkelsidens inline compose.
    Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
@@ -59,26 +59,27 @@ const audiografEscalation = {
       </header>
 
       <div class="hub-inner">
-        <!-- 1. Primærvei: beskriv problemet -->
+        <!-- 1. Primærvei: composer (speiler artikkel inline compose) -->
         <section class="hub-primary" aria-labelledby="ai-ask-heading">
-          <h2 id="ai-ask-heading">Hva fungerer ikke?</h2>
-          <p class="hub-primary__lead">
-            Beskriv problemet — Hørehjelpen åpnes med spørsmålet ditt og hjelper deg videre.
-          </p>
-          <form class="hub-ai-form" action="/no/chat" method="get">
-            <label class="hub-ai-form__field">
-              <span class="sr-only">Beskriv hva som ikke fungerer</span>
+          <h2 id="ai-ask-heading">Hva trenger du hjelp med?</h2>
+          <form class="hub-compose" action="/no/chat" method="get">
+            <label class="sr-only" for="hub-compose-input">Hva trenger du hjelp med?</label>
+            <div class="hub-compose__input-wrap">
               <input
+                id="hub-compose-input"
                 type="search"
                 name="seed"
+                class="hub-compose__input"
                 required
                 autocomplete="off"
                 enterkeyhint="search"
                 placeholder="F.eks. piping, Bluetooth, filter…"
               />
-            </label>
+            </div>
             <input type="hidden" name="from" value="hub" />
-            <button type="submit" class="hub-ai-form__submit">Spør Hørehjelpen</button>
+            <button type="submit" class="hub-compose__send" aria-label="Send spørsmål">
+              <span aria-hidden="true">↑</span>
+            </button>
           </form>
         </section>
 
@@ -226,69 +227,85 @@ const audiografEscalation = {
     color: rgb(var(--reading-ink));
   }
 
-  /* ── Primærvei: beskriv problemet ── */
+  /* ── Primærvei: composer — speiler ArticleInlineChatShell compose, roligere skygge ── */
   .hub-primary {
-    padding: clamp(1rem, 2.4vw, 1.2rem);
-    border: 1px solid rgb(var(--border) / 0.2);
-    border-radius: 12px;
-    background: rgb(var(--reading-paper));
-  }
-
-  .hub-primary__lead {
-    margin: 0 0 0.85rem;
-    font-size: 0.88rem;
-    line-height: 1.48;
-    color: rgb(var(--reading-ink-secondary));
-  }
-
-  .hub-ai-form {
     display: flex;
     flex-direction: column;
+    gap: 0.65rem;
+  }
+
+  .hub-compose {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: flex-end;
     gap: 0.55rem;
+    padding: 0.62rem;
+    border: 1px solid rgb(var(--border) / 0.46);
+    border-radius: 1.15rem;
+    background: rgb(var(--surface) / 0.97);
+    transition:
+      border-color 150ms ease,
+      box-shadow 150ms ease;
   }
 
-  .hub-ai-form__field input {
+  .hub-compose:focus-within {
+    border-color: rgb(var(--reading-accent-iris) / 0.46);
+    box-shadow: 0 0 0 3px rgb(14 165 233 / 0.14);
+  }
+
+  .hub-compose__input-wrap {
+    min-width: 0;
+  }
+
+  .hub-compose__input {
     width: 100%;
-    padding: 0.62rem 0.95rem;
-    border: 1px solid rgb(var(--border) / 0.28);
-    border-radius: 999px;
-    background: rgb(var(--reading-paper));
+    min-height: 2.75rem;
+    padding: 0.5rem 0.4rem;
+    border: 0;
+    background: transparent;
     color: rgb(var(--reading-ink));
-    font-size: 0.86rem;
-    line-height: 1.4;
+    font: inherit;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    outline: 0;
   }
 
-  .hub-ai-form__field input::placeholder {
-    color: rgb(var(--reading-ink-secondary) / 0.55);
+  .hub-compose__input::placeholder {
+    color: rgb(var(--reading-ink-secondary) / 0.72);
   }
 
-  .hub-ai-form__field input:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
-    border-color: rgb(14 165 233 / 0.45);
-  }
-
-  .hub-ai-form__submit {
-    align-self: flex-start;
-    padding: 0.52rem 0.95rem;
+  .hub-compose__send {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 2.68rem;
+    height: 2.68rem;
+    min-height: 2.68rem;
+    padding: 0;
     border: 0;
     border-radius: 999px;
     background: rgb(var(--reading-ink));
-    color: rgb(var(--reading-paper));
-    font-size: 0.82rem;
-    font-weight: 650;
-    letter-spacing: -0.01em;
+    color: rgb(var(--surface));
+    font-size: 1.02rem;
+    font-weight: 700;
+    line-height: 1;
     cursor: pointer;
     transition: opacity 150ms ease;
   }
 
-  .hub-ai-form__submit:hover {
+  .hub-compose__send:hover {
     opacity: 0.9;
   }
 
-  .hub-ai-form__submit:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
+  .hub-compose__send:focus-visible {
+    outline: 2px solid rgb(var(--reading-accent-iris) / 0.42);
+    outline-offset: 3px;
+  }
+
+  .hub-compose__send:disabled {
+    cursor: not-allowed;
+    opacity: 0.46;
   }
 
   /* ── Felles link-liste for problemer og guider ── */
@@ -459,17 +476,6 @@ const audiografEscalation = {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
-  }
-
-  @media (min-width: 480px) {
-    .hub-ai-form {
-      flex-direction: row;
-      align-items: stretch;
-    }
-
-    .hub-ai-form__field {
-      flex: 1;
-    }
   }
 
   @media (max-width: 479px) {

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Hjelp hub (A3) — praktisk hjelpehub for konkrete problemer.
-   #125I-D-R6 — hvite kategorikort uten ikonstøy; ikoner midlertidig fjernet.
+   #125I-D-R7 — tekststerke kort, nøytral hover #F5F6F5; good-enough polish.
    Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
@@ -155,7 +155,10 @@ const audiografEscalation = {
 </BaseLayout>
 
 <style>
-  /* #125I-D-R6 — hvite kategorikort, gestalt via spacing; ikoner midlertidig fjernet */
+  /* #125I-D-R7 — nøytral hub-hover; tekststerke kategorikort */
+  [data-hub-help] {
+    --hub-hover: #f5f6f5;
+  }
   .hub-page {
     background: rgb(var(--article-page-canvas));
     padding: 0.5rem 0 clamp(3rem, 6vw, 4rem);
@@ -341,14 +344,14 @@ const audiografEscalation = {
   @media (min-width: 540px) {
     .hub-cat-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.85rem;
+      gap: 0.9rem;
     }
   }
 
   @media (min-width: 960px) {
     .hub-cat-grid {
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 0.9rem;
+      gap: 1rem;
     }
   }
 
@@ -358,9 +361,9 @@ const audiografEscalation = {
     width: 100%;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.4rem;
-    min-height: 6.5rem;
-    padding: 1.15rem 1.2rem;
+    gap: 0.45rem;
+    min-height: 7.5rem;
+    padding: 1.3rem 1.25rem;
     border: 1px solid rgb(var(--border) / 0.3);
     border-radius: var(--radius-md);
     background: rgb(var(--reading-paper));
@@ -369,12 +372,14 @@ const audiografEscalation = {
     text-decoration: none;
     transition:
       border-color 150ms ease,
-      box-shadow 150ms ease;
+      box-shadow 150ms ease,
+      background-color 150ms ease;
   }
 
   a.hub-cat-card:hover {
-    border-color: rgb(var(--border) / 0.44);
-    box-shadow: 0 2px 8px rgb(var(--reading-ink) / 0.06);
+    background: var(--hub-hover);
+    border-color: rgb(var(--border) / 0.38);
+    box-shadow: 0 2px 8px rgb(var(--reading-ink) / 0.05);
   }
 
   a.hub-cat-card:focus-visible {
@@ -387,10 +392,10 @@ const audiografEscalation = {
   }
 
   .hub-cat-card__title {
-    font-size: 1rem;
+    font-size: clamp(1.15rem, 3.2vw, 1.38rem);
     font-weight: 650;
-    letter-spacing: -0.02em;
-    line-height: 1.3;
+    letter-spacing: -0.025em;
+    line-height: 1.1;
     color: rgb(var(--reading-ink));
   }
 
@@ -399,8 +404,9 @@ const audiografEscalation = {
   }
 
   .hub-cat-card__hint {
-    font-size: 0.84rem;
-    line-height: 1.45;
+    margin-top: auto;
+    font-size: 0.82rem;
+    line-height: 1.42;
     color: rgb(var(--reading-ink-secondary));
   }
 
@@ -447,7 +453,7 @@ const audiografEscalation = {
   }
 
   .hub-link-row__action:hover {
-    background: rgb(var(--border) / 0.1);
+    background: var(--hub-hover);
   }
 
   .hub-link-row__action:focus-visible {
@@ -491,12 +497,14 @@ const audiografEscalation = {
     text-decoration: none;
     transition:
       border-color 150ms ease,
-      box-shadow 150ms ease;
+      box-shadow 150ms ease,
+      background-color 150ms ease;
   }
 
   .hub-escalation-card:hover {
-    border-color: rgb(var(--border) / 0.32);
-    box-shadow: 0 2px 10px rgb(var(--reading-ink) / 0.04);
+    background: var(--hub-hover);
+    border-color: rgb(var(--border) / 0.3);
+    box-shadow: 0 2px 8px rgb(var(--reading-ink) / 0.04);
   }
 
   .hub-escalation-card:focus-visible {

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Hjelp hub (A3) — praktisk hjelpehub for konkrete problemer.
-   #125I-D-R4 — artikkel-paritet surface (46rem/radius-md), større kategorikort, copy-justeringer.
+   #125I-D-R5 — direkte H1, tyngre kategorikort/ikoner, tydeligere gestalt.
    Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
@@ -8,8 +8,7 @@ import Footer from "../../components/nav/Footer.astro";
 
 Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
 
-const hubTitle = "Få høreapparatet til å fungere";
-const hubSupport = "Vanlige problemer og hjelp, velg det som passer, eller spør Hørehjelpen.";
+const hubHeading = "Hva trenger du hjelp med?";
 
 type CategoryIcon = "piping" | "bluetooth" | "app" | "filter" | "battery" | "sound";
 
@@ -72,7 +71,7 @@ const audiografEscalation = {
 };
 ---
 
-<BaseLayout title={`Viddel - ${hubTitle}`} currentPath="/no/hub" shellVariant="article">
+<BaseLayout title={`Viddel - ${hubHeading}`} currentPath="/no/hub" shellVariant="article">
   <meta slot="head" name="robots" content="noindex,follow" />
 
   <main class="hub-page" data-hub-help>
@@ -84,15 +83,13 @@ const audiografEscalation = {
             <span aria-hidden="true">/</span>
             <span>Hjelp</span>
           </nav>
-          <h1>{hubTitle}</h1>
-          <p class="hub-lead">{hubSupport}</p>
+          <h1>{hubHeading}</h1>
         </header>
 
         <div class="hub-body">
-          <section class="hub-primary" aria-labelledby="ai-ask-heading">
-            <h2 id="ai-ask-heading">Hva trenger du hjelp med?</h2>
+          <section class="hub-intro" aria-label="Still et spørsmål">
             <form class="hub-compose" action="/no/chat" method="get">
-              <label class="sr-only" for="hub-compose-input">Hva trenger du hjelp med?</label>
+              <label class="sr-only" for="hub-compose-input">{hubHeading}</label>
               <div class="hub-compose__input-wrap">
                 <input
                   id="hub-compose-input"
@@ -106,7 +103,7 @@ const audiografEscalation = {
                 />
               </div>
               <input type="hidden" name="from" value="hub" />
-              <button type="submit" class="hub-compose__send" aria-label="Send spørsmål">
+              <button type="submit" class="hub-compose__send" aria-label="Still et spørsmål">
                 <span aria-hidden="true">↑</span>
               </button>
             </form>
@@ -120,44 +117,43 @@ const audiografEscalation = {
                     <a href={card.href} class="hub-cat-card">
                       <span class="hub-cat-card__icon" aria-hidden="true" data-icon={card.icon}>
                         {card.icon === "piping" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
                             <path d="M4 12c2-4 4-4 6 0s4 4 6 0 4-4 6 0" />
                           </svg>
                         )}
                         {card.icon === "bluetooth" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round">
                             <path d="M8 7l8 5-8 5V7z" /><path d="M16 7v10" />
                           </svg>
                         )}
                         {card.icon === "app" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
                             <rect x="5" y="3" width="14" height="18" rx="2" /><path d="M10 17h4" />
                           </svg>
                         )}
                         {card.icon === "filter" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
                             <path d="M4 6h16M7 12h10M10 18h4" />
                           </svg>
                         )}
                         {card.icon === "battery" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <rect x="3" y="7" width="16" height="10" rx="2" /><path d="M21 10v4" /><path d="M7 11v2" />
                           </svg>
                         )}
                         {card.icon === "sound" && (
-                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
                             <path d="M6 10v4h3l4 3V7L9 10H6z" /><path d="M17 9a3 3 0 010 6" />
                           </svg>
                         )}
                       </span>
                       <span class="hub-cat-card__title">{card.title}</span>
                       <span class="hub-cat-card__hint">{card.hint}</span>
-                      <span class="hub-cat-card__arrow" aria-hidden="true">→</span>
                     </a>
                   ) : (
                     <span class="hub-cat-card hub-cat-card--gap">
                       <span class="hub-cat-card__icon" aria-hidden="true" data-icon={card.icon}>
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                           <rect x="3" y="7" width="16" height="10" rx="2" /><path d="M21 10v4" /><path d="M7 11v2" />
                         </svg>
                       </span>
@@ -193,7 +189,7 @@ const audiografEscalation = {
               <span class="hub-escalation-card__arrow" aria-hidden="true">→</span>
             </a>
             <p class="hub-escalation-fallback">
-              <a href="/no/chat?from=hub">Fant du ikke svaret? Spør Hørehjelpen</a>
+              <a href="/no/chat?from=hub">Finner du ikke svaret? Still et spørsmål</a>
             </p>
           </section>
         </div>
@@ -205,7 +201,7 @@ const audiografEscalation = {
 </BaseLayout>
 
 <style>
-  /* #125I-D-R4 — surface paritet med artikkel (46rem, --radius-md); større kategorikort */
+  /* #125I-D-R5 — tydelig gestalt, tyngre kort/ikoner, direkte H1 */
   .hub-page {
     background: rgb(var(--article-page-canvas));
     padding: 0.5rem 0 clamp(3rem, 6vw, 4rem);
@@ -244,8 +240,8 @@ const audiografEscalation = {
   }
 
   .hub-header {
-    padding-bottom: clamp(0.85rem, 2vw, 1.1rem);
-    border-bottom: 1px solid rgb(var(--border) / 0.14);
+    padding-bottom: 0;
+    border-bottom: 0;
   }
 
   .hub-breadcrumb {
@@ -277,38 +273,28 @@ const audiografEscalation = {
     color: rgb(var(--reading-ink));
   }
 
-  .hub-lead {
-    margin: clamp(0.65rem, 1.8vw, 0.85rem) 0 0;
-    font-size: clamp(0.93rem, 2.1vw, 1.02rem);
-    line-height: 1.5;
-    color: rgb(var(--reading-ink-secondary));
-  }
-
   .hub-body {
-    padding-top: clamp(1rem, 2.5vw, 1.25rem);
+    padding-top: clamp(1.1rem, 2.8vw, 1.35rem);
     display: flex;
     flex-direction: column;
-    gap: clamp(1.35rem, 3.2vw, 1.75rem);
+    gap: clamp(2rem, 4.5vw, 2.65rem);
   }
 
-  .hub-block h2,
-  .hub-primary h2 {
-    margin: 0 0 0.65rem;
+  .hub-intro {
+    margin-top: -0.15rem;
+  }
+
+  .hub-block h2 {
+    margin: 0 0 0.75rem;
     font-family: var(--font-body, inherit);
-    font-size: 1rem;
+    font-size: 0.95rem;
     font-weight: 650;
     letter-spacing: -0.02em;
     line-height: 1.3;
-    color: rgb(var(--reading-ink));
+    color: rgb(var(--reading-ink-secondary));
   }
 
-  /* ── Composer (R2b) på hvit flate ── */
-  .hub-primary {
-    display: flex;
-    flex-direction: column;
-    gap: 0.65rem;
-  }
-
+  /* ── Composer ── */
   .hub-compose {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
@@ -379,23 +365,29 @@ const audiografEscalation = {
   }
 
   .hub-block--categories {
-    margin-top: -0.15rem;
+    padding-top: 0.15rem;
   }
 
-  /* ── Kategorikort — ikon over tekst, midlertidige line-glyphs (R4) ── */
+  /* ── Kategorikort — equal height, tyngre ikoner (midlertidige line-glyphs, R5) ── */
   .hub-cat-grid {
     margin: 0;
     padding: 0;
     list-style: none;
     display: grid;
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    grid-auto-rows: 1fr;
+    gap: 0.9rem;
+  }
+
+  .hub-cat-grid > li {
+    display: flex;
+    min-height: 0;
   }
 
   @media (min-width: 540px) {
     .hub-cat-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.85rem;
+      gap: 1rem;
     }
   }
 
@@ -406,26 +398,30 @@ const audiografEscalation = {
   }
 
   .hub-cat-card {
-    position: relative;
     display: flex;
+    flex: 1;
+    width: 100%;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.45rem;
-    min-height: 8.25rem;
-    padding: 1.2rem 1.15rem 2.35rem;
-    border: 1px solid rgb(var(--border) / 0.22);
+    gap: 0.65rem;
+    min-height: 10.75rem;
+    padding: 1.35rem 1.25rem 1.3rem;
+    border: 1px solid rgb(var(--border) / 0.4);
     border-radius: var(--radius-md);
-    background: rgb(var(--reading-paper));
+    background: rgb(var(--surface-subtle) / 0.55);
+    box-shadow: 0 1px 3px rgb(var(--reading-ink) / 0.07);
     color: inherit;
     text-decoration: none;
     transition:
       border-color 150ms ease,
-      box-shadow 150ms ease;
+      box-shadow 150ms ease,
+      transform 150ms ease;
   }
 
   a.hub-cat-card:hover {
-    border-color: rgb(var(--border) / 0.36);
-    box-shadow: 0 2px 10px rgb(var(--reading-ink) / 0.05);
+    border-color: rgb(var(--border) / 0.52);
+    box-shadow: 0 4px 14px rgb(var(--reading-ink) / 0.08);
+    transform: translateY(-1px);
   }
 
   a.hub-cat-card:focus-visible {
@@ -435,32 +431,34 @@ const audiografEscalation = {
 
   .hub-cat-card--gap {
     color: rgb(var(--reading-ink-secondary));
+    opacity: 0.92;
   }
 
   .hub-cat-card__icon {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 2.85rem;
-    height: 2.85rem;
+    width: 3.25rem;
+    height: 3.25rem;
     flex-shrink: 0;
-    border: 1px solid rgb(var(--border) / 0.28);
+    border: 1px solid rgb(var(--border) / 0.38);
     border-radius: var(--radius-md);
-    background: rgb(var(--border) / 0.08);
+    background: rgb(var(--reading-paper));
+    box-shadow: 0 1px 2px rgb(var(--reading-ink) / 0.06);
     color: rgb(var(--reading-ink));
   }
 
   .hub-cat-card--gap .hub-cat-card__icon {
-    color: rgb(var(--reading-ink-secondary) / 0.7);
+    color: rgb(var(--reading-ink-secondary) / 0.75);
   }
 
   .hub-cat-card__icon svg {
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1.65rem;
+    height: 1.65rem;
   }
 
   .hub-cat-card__title {
-    font-size: 0.98rem;
+    font-size: 1rem;
     font-weight: 650;
     letter-spacing: -0.02em;
     line-height: 1.28;
@@ -468,34 +466,19 @@ const audiografEscalation = {
   }
 
   .hub-cat-card--gap .hub-cat-card__title {
-    color: rgb(var(--reading-ink-secondary) / 0.75);
+    color: rgb(var(--reading-ink-secondary) / 0.78);
   }
 
   .hub-cat-card__hint {
-    font-size: 0.8rem;
-    line-height: 1.4;
+    margin-top: auto;
+    font-size: 0.82rem;
+    line-height: 1.42;
     color: rgb(var(--reading-ink-secondary));
-  }
-
-  .hub-cat-card__arrow {
-    position: absolute;
-    right: 1.1rem;
-    bottom: 1.05rem;
-    font-size: 0.9rem;
-    color: rgb(var(--reading-ink-secondary) / 0.45);
-    transition: color 100ms ease, transform 100ms ease;
-  }
-
-  a.hub-cat-card:hover .hub-cat-card__arrow {
-    color: rgb(var(--reading-ink-secondary));
-    transform: translateX(2px);
   }
 
   .hub-cat-card__badge {
-    position: absolute;
-    right: 1.1rem;
-    bottom: 1.05rem;
-    flex-shrink: 0;
+    margin-top: auto;
+    align-self: flex-start;
     font-size: 0.62rem;
     font-weight: 700;
     letter-spacing: 0.08em;

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Hjelp hub (A3) — praktisk hjelpehub for konkrete problemer.
-   #125I-D-R7 — tekststerke kort, nøytral hover #F5F6F5; good-enough polish.
+   #125I-D-R8 — editorial card hover på kategorikort (shadow + lift, ikke grå fill).
    Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
@@ -155,7 +155,7 @@ const audiografEscalation = {
 </BaseLayout>
 
 <style>
-  /* #125I-D-R7 — nøytral hub-hover; tekststerke kategorikort */
+  /* #125I-D-R8 — editorial card hover på kategori-kort; #F5F6F5 kun på liste-rader */
   [data-hub-help] {
     --hub-hover: #f5f6f5;
   }
@@ -364,22 +364,23 @@ const audiografEscalation = {
     gap: 0.45rem;
     min-height: 7.5rem;
     padding: 1.3rem 1.25rem;
-    border: 1px solid rgb(var(--border) / 0.3);
+    border: 1px solid rgb(var(--border) / 0.22);
     border-radius: var(--radius-md);
     background: rgb(var(--reading-paper));
     box-shadow: 0 1px 2px rgb(var(--reading-ink) / 0.04);
     color: inherit;
     text-decoration: none;
+    cursor: pointer;
     transition:
       border-color 150ms ease,
       box-shadow 150ms ease,
-      background-color 150ms ease;
+      transform 150ms ease;
   }
 
   a.hub-cat-card:hover {
-    background: var(--hub-hover);
-    border-color: rgb(var(--border) / 0.38);
-    box-shadow: 0 2px 8px rgb(var(--reading-ink) / 0.05);
+    border-color: rgb(var(--border) / 0.28);
+    box-shadow: 0 4px 18px rgb(var(--reading-ink) / 0.05);
+    transform: translateY(-2px);
   }
 
   a.hub-cat-card:focus-visible {

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Hjelp hub (A3) — praktisk hjelpehub for konkrete problemer.
-   #125D applied slice; #125I-D-R2b — composer-inngang speiler artikkelsidens inline compose.
+   #125I-D-R3 — hvit content surface, composer, kategorikort med enkle glyphs.
    Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
@@ -11,29 +11,58 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
 const hubTitle = "Få høreapparatet til å fungere";
 const hubSupport = "Vanlige problemer og rask hjelp — velg det som passer, eller spør Hørehjelpen.";
 
-type TaskStatus = "finnes" | "gap";
+type CategoryIcon = "piping" | "bluetooth" | "app" | "filter" | "battery" | "sound";
 
-const commonProblems: Array<{
+const categoryCards: Array<{
   title: string;
+  hint: string;
   href?: string;
-  status?: TaskStatus;
+  icon: CategoryIcon;
+  status?: "gap";
 }> = [
-  { title: "Stoppe piping", href: "/no/artikkel/fa-slutt-pa-pipingen" },
-  { title: "Koble til mobilen", href: "/no/artikkel/koble-horeapparatet-til-mobilen" },
-  { title: "Appen finner ikke høreapparatet", href: "/no/artikkel/appen-finner-ikke-horeapparatet" },
-  { title: "Bytte filter", href: "/no/artikkel/bytte-filter-uten-stress" },
-  { title: "Fikse app eller Bluetooth", href: "/no/artikkel/appen-finner-ikke-horeapparatet" },
-  { title: "Sjekke batteri og lading", status: "gap" },
-  { title: "Forstå om lyden er feil eller normal", href: "/no/artikkel/lyden-blir-slitsom-utpa-dagen" },
-  { title: "Vite når audiograf bør kontaktes", href: "/no/artikkel/audiograf-nar-det-haster" },
+  {
+    title: "Piping og ulyd",
+    hint: "Slutt på piping og ulyd i øret",
+    href: "/no/artikkel/fa-slutt-pa-pipingen",
+    icon: "piping",
+  },
+  {
+    title: "Mobil og Bluetooth",
+    hint: "Koble høreapparatet til mobilen",
+    href: "/no/artikkel/koble-horeapparatet-til-mobilen",
+    icon: "bluetooth",
+  },
+  {
+    title: "App og tilkobling",
+    hint: "Når appen ikke finner apparatet",
+    href: "/no/artikkel/appen-finner-ikke-horeapparatet",
+    icon: "app",
+  },
+  {
+    title: "Filter og vedlikehold",
+    hint: "Bytte filter og enkel vedlikehold",
+    href: "/no/artikkel/bytte-filter-uten-stress",
+    icon: "filter",
+  },
+  {
+    title: "Batteri og lading",
+    hint: "Sjekke batteri og lading",
+    icon: "battery",
+    status: "gap",
+  },
+  {
+    title: "Lyd og tilpasning",
+    hint: "Når lyden føles feil eller slitsom",
+    href: "/no/artikkel/lyden-blir-slitsom-utpa-dagen",
+    icon: "sound",
+  },
 ];
 
 const shortGuides = [
   { title: "Få slutt på pipingen", href: "/no/artikkel/fa-slutt-pa-pipingen" },
-  { title: "Koble høreapparatet til mobilen", href: "/no/artikkel/koble-horeapparatet-til-mobilen" },
   { title: "Appen finner ikke høreapparatet", href: "/no/artikkel/appen-finner-ikke-horeapparatet" },
-  { title: "Bytte filter uten stress", href: "/no/artikkel/bytte-filter-uten-stress" },
   { title: "Lyden blir slitsom utpå dagen", href: "/no/artikkel/lyden-blir-slitsom-utpa-dagen" },
+  { title: "Audiograf når det haster", href: "/no/artikkel/audiograf-nar-det-haster" },
 ];
 
 const audiografEscalation = {
@@ -48,90 +77,131 @@ const audiografEscalation = {
 
   <main class="hub-page" data-hub-help>
     <div class="hub-container">
-      <header class="hub-header">
-        <nav class="hub-breadcrumb" aria-label="Du er her">
-          <a href="/no">Forside</a>
-          <span aria-hidden="true">/</span>
-          <span>Hjelp</span>
-        </nav>
-        <h1>{hubTitle}</h1>
-        <p class="hub-lead">{hubSupport}</p>
-      </header>
+      <div class="hub-surface">
+        <header class="hub-header">
+          <nav class="hub-breadcrumb" aria-label="Du er her">
+            <a href="/no">Forside</a>
+            <span aria-hidden="true">/</span>
+            <span>Hjelp</span>
+          </nav>
+          <h1>{hubTitle}</h1>
+          <p class="hub-lead">{hubSupport}</p>
+        </header>
 
-      <div class="hub-inner">
-        <!-- 1. Primærvei: composer (speiler artikkel inline compose) -->
-        <section class="hub-primary" aria-labelledby="ai-ask-heading">
-          <h2 id="ai-ask-heading">Hva trenger du hjelp med?</h2>
-          <form class="hub-compose" action="/no/chat" method="get">
-            <label class="sr-only" for="hub-compose-input">Hva trenger du hjelp med?</label>
-            <div class="hub-compose__input-wrap">
-              <input
-                id="hub-compose-input"
-                type="search"
-                name="seed"
-                class="hub-compose__input"
-                required
-                autocomplete="off"
-                enterkeyhint="search"
-                placeholder="F.eks. piping, Bluetooth, filter…"
-              />
-            </div>
-            <input type="hidden" name="from" value="hub" />
-            <button type="submit" class="hub-compose__send" aria-label="Send spørsmål">
-              <span aria-hidden="true">↑</span>
-            </button>
-          </form>
-        </section>
+        <div class="hub-body">
+          <section class="hub-primary" aria-labelledby="ai-ask-heading">
+            <h2 id="ai-ask-heading">Hva trenger du hjelp med?</h2>
+            <form class="hub-compose" action="/no/chat" method="get">
+              <label class="sr-only" for="hub-compose-input">Hva trenger du hjelp med?</label>
+              <div class="hub-compose__input-wrap">
+                <input
+                  id="hub-compose-input"
+                  type="search"
+                  name="seed"
+                  class="hub-compose__input"
+                  required
+                  autocomplete="off"
+                  enterkeyhint="search"
+                  placeholder="F.eks. piping, Bluetooth, filter…"
+                />
+              </div>
+              <input type="hidden" name="from" value="hub" />
+              <button type="submit" class="hub-compose__send" aria-label="Send spørsmål">
+                <span aria-hidden="true">↑</span>
+              </button>
+            </form>
+          </section>
 
-        <!-- 2. Vanlige problemer — samme link-familie -->
-        <section class="hub-block" aria-labelledby="problems-heading">
-          <h2 id="problems-heading">Vanlige problemer</h2>
-          <ul class="hub-link-list" role="list">
-            {commonProblems.map((item) => (
-              <li class:list={["hub-link-row", item.status === "gap" && "hub-link-row--gap"]}>
-                {item.href ? (
-                  <a href={item.href} class="hub-link-row__action">
-                    <span class="hub-link-row__title">{item.title}</span>
+          <section class="hub-block" aria-labelledby="categories-heading">
+            <h2 id="categories-heading">Velg problemområde</h2>
+            <ul class="hub-cat-grid" role="list">
+              {categoryCards.map((card) => (
+                <li>
+                  {card.href ? (
+                    <a href={card.href} class="hub-cat-card">
+                      <span class="hub-cat-card__icon" aria-hidden="true" data-icon={card.icon}>
+                        {card.icon === "piping" && (
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                            <path d="M4 12c2-4 4-4 6 0s4 4 6 0 4-4 6 0" />
+                          </svg>
+                        )}
+                        {card.icon === "bluetooth" && (
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round">
+                            <path d="M8 7l8 5-8 5V7z" /><path d="M16 7v10" />
+                          </svg>
+                        )}
+                        {card.icon === "app" && (
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                            <rect x="5" y="3" width="14" height="18" rx="2" /><path d="M10 17h4" />
+                          </svg>
+                        )}
+                        {card.icon === "filter" && (
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                            <path d="M4 6h16M7 12h10M10 18h4" />
+                          </svg>
+                        )}
+                        {card.icon === "battery" && (
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="3" y="7" width="16" height="10" rx="2" /><path d="M21 10v4" /><path d="M7 11v2" />
+                          </svg>
+                        )}
+                        {card.icon === "sound" && (
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                            <path d="M6 10v4h3l4 3V7L9 10H6z" /><path d="M17 9a3 3 0 010 6" />
+                          </svg>
+                        )}
+                      </span>
+                      <span class="hub-cat-card__body">
+                        <span class="hub-cat-card__title">{card.title}</span>
+                        <span class="hub-cat-card__hint">{card.hint}</span>
+                      </span>
+                      <span class="hub-cat-card__arrow" aria-hidden="true">→</span>
+                    </a>
+                  ) : (
+                    <span class="hub-cat-card hub-cat-card--gap">
+                      <span class="hub-cat-card__icon" aria-hidden="true" data-icon={card.icon}>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                          <rect x="3" y="7" width="16" height="10" rx="2" /><path d="M21 10v4" /><path d="M7 11v2" />
+                        </svg>
+                      </span>
+                      <span class="hub-cat-card__body">
+                        <span class="hub-cat-card__title">{card.title}</span>
+                        <span class="hub-cat-card__hint">{card.hint}</span>
+                      </span>
+                      <span class="hub-cat-card__badge">Kommer</span>
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section class="hub-block" aria-labelledby="guides-heading">
+            <h2 id="guides-heading">Korte guider</h2>
+            <ul class="hub-link-list" role="list">
+              {shortGuides.map((guide) => (
+                <li class="hub-link-row">
+                  <a href={guide.href} class="hub-link-row__action">
+                    <span class="hub-link-row__title">{guide.title}</span>
                     <span class="hub-link-row__arrow" aria-hidden="true">→</span>
                   </a>
-                ) : (
-                  <span class="hub-link-row__static">
-                    <span class="hub-link-row__title">{item.title}</span>
-                    <span class="hub-link-row__badge">Kommer</span>
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
-        </section>
+                </li>
+              ))}
+            </ul>
+          </section>
 
-        <!-- 3. Korte guider — samme radmønster -->
-        <section class="hub-block" aria-labelledby="guides-heading">
-          <h2 id="guides-heading">Korte guider</h2>
-          <ul class="hub-link-list" role="list">
-            {shortGuides.map((guide) => (
-              <li class="hub-link-row">
-                <a href={guide.href} class="hub-link-row__action">
-                  <span class="hub-link-row__title">{guide.title}</span>
-                  <span class="hub-link-row__arrow" aria-hidden="true">→</span>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
-
-        <!-- 4. Eskalering — rolig avslutningskort -->
-        <section class="hub-block hub-block--escalation" aria-labelledby="escalation-heading">
-          <h2 id="escalation-heading" class="sr-only">Videre hjelp</h2>
-          <a href={audiografEscalation.href} class="hub-escalation-card">
-            <span class="hub-escalation-card__title">{audiografEscalation.title}</span>
-            <span class="hub-escalation-card__deck">{audiografEscalation.deck}</span>
-            <span class="hub-escalation-card__arrow" aria-hidden="true">→</span>
-          </a>
-          <p class="hub-escalation-fallback">
-            <a href="/no/chat?from=hub">Fant du ikke svaret? Spør Hørehjelpen</a>
-          </p>
-        </section>
+          <section class="hub-block hub-block--escalation" aria-labelledby="escalation-heading">
+            <h2 id="escalation-heading" class="sr-only">Videre hjelp</h2>
+            <a href={audiografEscalation.href} class="hub-escalation-card">
+              <span class="hub-escalation-card__title">{audiografEscalation.title}</span>
+              <span class="hub-escalation-card__deck">{audiografEscalation.deck}</span>
+              <span class="hub-escalation-card__arrow" aria-hidden="true">→</span>
+            </a>
+            <p class="hub-escalation-fallback">
+              <a href="/no/chat?from=hub">Fant du ikke svaret? Spør Hørehjelpen</a>
+            </p>
+          </section>
+        </div>
       </div>
     </div>
   </main>
@@ -140,9 +210,9 @@ const audiografEscalation = {
 </BaseLayout>
 
 <style>
-  /* #125I-D-R2 — praktisk hjelpehub: én primærvei, ett link-mønster, smalere innholdsflate */
+  /* #125I-D-R3 — hvit content surface; ambient shell utenfor flaten */
   .hub-page {
-    padding: 0;
+    padding: clamp(0.5rem, 1.5vw, 0.85rem) 0 0;
   }
 
   .hub-container {
@@ -163,20 +233,16 @@ const audiografEscalation = {
     }
   }
 
-  .hub-inner {
-    max-width: 44rem;
-    margin: 0 auto;
-    padding-top: clamp(1.1rem, 2.8vw, 1.45rem);
-    display: flex;
-    flex-direction: column;
-    gap: clamp(1.35rem, 3.2vw, 1.75rem);
+  .hub-surface {
+    background: rgb(var(--reading-paper));
+    border: 1px solid rgb(var(--border) / 0.16);
+    border-radius: 12px;
+    padding: clamp(1rem, 2.4vw, 1.35rem);
   }
 
   .hub-header {
-    max-width: 44rem;
-    margin: 0 auto;
-    padding: clamp(2rem, 6vw, 3rem) 0 clamp(0.85rem, 2vw, 1.1rem);
-    border-bottom: 1px solid rgb(var(--border) / 0.2);
+    padding-bottom: clamp(0.85rem, 2vw, 1.1rem);
+    border-bottom: 1px solid rgb(var(--border) / 0.14);
   }
 
   .hub-breadcrumb {
@@ -215,10 +281,18 @@ const audiografEscalation = {
     color: rgb(var(--reading-ink-secondary));
   }
 
-  /* Section headings — én rolig nivå, ikke uppercase micro-labels */
+  .hub-body {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding-top: clamp(1rem, 2.5vw, 1.25rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.25rem, 3vw, 1.6rem);
+  }
+
   .hub-block h2,
   .hub-primary h2 {
-    margin: 0 0 0.6rem;
+    margin: 0 0 0.65rem;
     font-family: var(--font-body, inherit);
     font-size: 1rem;
     font-weight: 650;
@@ -227,7 +301,7 @@ const audiografEscalation = {
     color: rgb(var(--reading-ink));
   }
 
-  /* ── Primærvei: composer — speiler ArticleInlineChatShell compose, roligere skygge ── */
+  /* ── Composer (R2b) på hvit flate ── */
   .hub-primary {
     display: flex;
     flex-direction: column;
@@ -242,7 +316,7 @@ const audiografEscalation = {
     padding: 0.62rem;
     border: 1px solid rgb(var(--border) / 0.46);
     border-radius: 1.15rem;
-    background: rgb(var(--surface) / 0.97);
+    background: rgb(var(--reading-paper));
     transition:
       border-color 150ms ease,
       box-shadow 150ms ease;
@@ -303,12 +377,134 @@ const audiografEscalation = {
     outline-offset: 3px;
   }
 
-  .hub-compose__send:disabled {
-    cursor: not-allowed;
-    opacity: 0.46;
+  /* ── Kategorikort med enkle line-glyphs ── */
+  .hub-cat-grid {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
   }
 
-  /* ── Felles link-liste for problemer og guider ── */
+  @media (min-width: 540px) {
+    .hub-cat-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 900px) {
+    .hub-cat-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .hub-cat-card {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.7rem;
+    min-height: 4.25rem;
+    padding: 0.85rem 0.9rem;
+    border: 1px solid rgb(var(--border) / 0.22);
+    border-radius: 10px;
+    background: rgb(var(--reading-paper));
+    color: inherit;
+    text-decoration: none;
+    transition:
+      border-color 150ms ease,
+      box-shadow 150ms ease;
+  }
+
+  a.hub-cat-card:hover {
+    border-color: rgb(var(--border) / 0.36);
+    box-shadow: 0 2px 10px rgb(var(--reading-ink) / 0.05);
+  }
+
+  a.hub-cat-card:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
+  }
+
+  .hub-cat-card--gap {
+    color: rgb(var(--reading-ink-secondary));
+  }
+
+  .hub-cat-card__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.35rem;
+    height: 2.35rem;
+    flex-shrink: 0;
+    border: 1px solid rgb(var(--border) / 0.28);
+    border-radius: 8px;
+    background: rgb(var(--border) / 0.08);
+    color: rgb(var(--reading-ink));
+  }
+
+  .hub-cat-card--gap .hub-cat-card__icon {
+    color: rgb(var(--reading-ink-secondary) / 0.7);
+  }
+
+  .hub-cat-card__icon svg {
+    width: 1.15rem;
+    height: 1.15rem;
+  }
+
+  .hub-cat-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+  }
+
+  .hub-cat-card__title {
+    font-size: 0.92rem;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    line-height: 1.28;
+    color: rgb(var(--reading-ink));
+  }
+
+  .hub-cat-card--gap .hub-cat-card__title {
+    color: rgb(var(--reading-ink-secondary) / 0.75);
+  }
+
+  .hub-cat-card__hint {
+    font-size: 0.78rem;
+    line-height: 1.35;
+    color: rgb(var(--reading-ink-secondary));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .hub-cat-card__arrow {
+    flex-shrink: 0;
+    font-size: 0.88rem;
+    color: rgb(var(--reading-ink-secondary) / 0.45);
+    transition: color 100ms ease, transform 100ms ease;
+  }
+
+  a.hub-cat-card:hover .hub-cat-card__arrow {
+    color: rgb(var(--reading-ink-secondary));
+    transform: translateX(2px);
+  }
+
+  .hub-cat-card__badge {
+    flex-shrink: 0;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgb(var(--muted));
+    border: 1px solid rgb(var(--border) / 0.35);
+    border-radius: 3px;
+    padding: 0.12rem 0.38rem;
+  }
+
+  /* ── Sekundær guide-liste ── */
   .hub-link-list {
     margin: 0;
     padding: 0;
@@ -327,18 +523,14 @@ const audiografEscalation = {
     border-bottom: 0;
   }
 
-  .hub-link-row__action,
-  .hub-link-row__static {
+  .hub-link-row__action {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
     padding: 0.82rem 0.95rem;
-    text-decoration: none;
-  }
-
-  .hub-link-row__action {
     color: rgb(var(--reading-ink));
+    text-decoration: none;
     transition: background-color 100ms ease;
   }
 
@@ -349,14 +541,6 @@ const audiografEscalation = {
   .hub-link-row__action:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 2px rgb(14 165 233 / 0.35);
-  }
-
-  .hub-link-row__static {
-    color: rgb(var(--reading-ink-secondary));
-  }
-
-  .hub-link-row--gap .hub-link-row__title {
-    color: rgb(var(--reading-ink-secondary) / 0.65);
   }
 
   .hub-link-row__title {
@@ -378,21 +562,9 @@ const audiografEscalation = {
     transform: translateX(2px);
   }
 
-  .hub-link-row__badge {
-    flex-shrink: 0;
-    font-size: 0.62rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: rgb(var(--muted));
-    border: 1px solid rgb(var(--border) / 0.35);
-    border-radius: 3px;
-    padding: 0.12rem 0.38rem;
-  }
-
   /* ── Eskalering ── */
   .hub-block--escalation {
-    padding-top: 0.15rem;
+    padding-top: 0.1rem;
   }
 
   .hub-escalation-card {
@@ -444,14 +616,14 @@ const audiografEscalation = {
   }
 
   .hub-escalation-fallback {
-    margin: 0.65rem 0 0;
-    font-size: 0.84rem;
+    margin: 0.6rem 0 0;
+    font-size: 0.82rem;
     line-height: 1.4;
   }
 
   .hub-escalation-fallback a {
-    color: rgb(var(--reading-ink-secondary));
-    font-weight: 550;
+    color: rgb(var(--reading-ink-secondary) / 0.85);
+    font-weight: 500;
     text-decoration: underline;
     text-underline-offset: 3px;
   }
@@ -485,6 +657,10 @@ const audiografEscalation = {
 
     .hub-escalation-card__arrow {
       display: none;
+    }
+
+    .hub-cat-card__hint {
+      white-space: normal;
     }
   }
 </style>

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,7 +1,8 @@
 ---
 /* CONTRACT: Hjelp hub (A3) — «Få høreapparatet til å fungere».
    Utility-first: AI ask → problem cards → short guides → escalation.
-   #125D applied slice on /no/hub only. Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
+   #125D applied slice; #125I-D-R1 polish — layout family aligned with /no/ (#125I-C).
+   Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import Footer from "../../components/nav/Footer.astro";
@@ -15,13 +16,12 @@ type TaskStatus = "finnes" | "gap";
 
 const problemCards: Array<{
   title: string;
-  thumb: string;
   href: string;
 }> = [
-  { title: "Stoppe piping", thumb: "piping", href: "/no/artikkel/fa-slutt-pa-pipingen" },
-  { title: "Koble til mobilen", thumb: "bluetooth", href: "/no/artikkel/koble-horeapparatet-til-mobilen" },
-  { title: "Appen finner ikke høreapparatet", thumb: "app", href: "/no/artikkel/appen-finner-ikke-horeapparatet" },
-  { title: "Bytte filter", thumb: "filter", href: "/no/artikkel/bytte-filter-uten-stress" },
+  { title: "Stoppe piping", href: "/no/artikkel/fa-slutt-pa-pipingen" },
+  { title: "Koble til mobilen", href: "/no/artikkel/koble-horeapparatet-til-mobilen" },
+  { title: "Appen finner ikke høreapparatet", href: "/no/artikkel/appen-finner-ikke-horeapparatet" },
+  { title: "Bytte filter", href: "/no/artikkel/bytte-filter-uten-stress" },
 ];
 
 const moreProblems: Array<{
@@ -87,11 +87,26 @@ const audiografEscalation = {
         <p class="hub-lead">{hubSupport}</p>
       </header>
 
-      <div class="hub-help-core">
+      <div class="hub-module">
 
-        <!-- AI ask — first step -->
-        <section class="hub-block hub-block--ai" aria-labelledby="ai-ask-heading">
-          <h2 id="ai-ask-heading" class="hub-block__title">Hva fungerer ikke?</h2>
+        <!-- Problem cards — primary paths first -->
+        <section class="hub-section" aria-labelledby="problems-heading">
+          <h2 id="problems-heading" class="hub-section__title">Dette kan du prøve først</h2>
+          <ul class="hub-problem-grid" role="list">
+            {problemCards.map((card) => (
+              <li>
+                <a href={card.href} class="hub-problem-card">
+                  <span class="hub-problem-card__title">{card.title}</span>
+                  <span class="hub-problem-card__arrow" aria-hidden="true">→</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <!-- AI ask — compact utility row -->
+        <section class="hub-section hub-section--ai" aria-labelledby="ai-ask-heading">
+          <h2 id="ai-ask-heading" class="hub-section__title">Hva fungerer ikke?</h2>
           <p class="hub-ai-ask__lead">
             Beskriv problemet — Hørehjelpen åpnes med spørsmålet ditt og hjelper deg videre.
           </p>
@@ -112,26 +127,9 @@ const audiografEscalation = {
           </form>
         </section>
 
-        <!-- Problem cards -->
-        <section class="hub-block" aria-labelledby="problems-heading">
-          <h2 id="problems-heading" class="hub-block__title">Dette kan du prøve først</h2>
-          <ul class="hub-problem-grid" role="list">
-            {problemCards.map((card) => (
-              <li>
-                <a href={card.href} class="hub-problem-card" data-thumb={card.thumb}>
-                  <span class="hub-problem-card__visual" aria-hidden="true">
-                    <span class="hub-problem-card__shape"></span>
-                  </span>
-                  <span class="hub-problem-card__title">{card.title}</span>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
-
         <!-- More problems — compact list -->
-        <section class="hub-block" aria-labelledby="more-problems-heading">
-          <h2 id="more-problems-heading" class="hub-block__title">Flere vanlige problemer</h2>
+        <section class="hub-section" aria-labelledby="more-problems-heading">
+          <h2 id="more-problems-heading" class="hub-section__title">Flere vanlige problemer</h2>
           <ul class="hub-task-list" role="list">
             {moreProblems.map((task) => (
               <li class:list={["hub-task-row", task.status === "gap" && "hub-task-row--gap"]}>
@@ -152,8 +150,8 @@ const audiografEscalation = {
         </section>
 
         <!-- Short guides -->
-        <section class="hub-block" aria-labelledby="guides-heading">
-          <h2 id="guides-heading" class="hub-block__title">Korte guider</h2>
+        <section class="hub-section" aria-labelledby="guides-heading">
+          <h2 id="guides-heading" class="hub-section__title">Korte guider</h2>
           <ul class="hub-guide-rows" role="list">
             {shortGuides.map((guide) => (
               <li>
@@ -168,7 +166,7 @@ const audiografEscalation = {
         </section>
 
         <!-- Escalation -->
-        <section class="hub-block hub-block--escalation" aria-labelledby="escalation-heading">
+        <section class="hub-section hub-section--escalation" aria-labelledby="escalation-heading">
           <h2 id="escalation-heading" class="sr-only">Videre hjelp</h2>
           <a href="/no/chat?from=hub" class="hub-escalation-chat">
             Fant du ikke svaret? Spør Hørehjelpen
@@ -186,31 +184,43 @@ const audiografEscalation = {
     </div>
   </main>
 
-  <Footer variant="article" />
+  <Footer />
 </BaseLayout>
 
 <style>
-  [data-hub-help] {
-    background: rgb(var(--article-page-canvas));
-    min-height: 100vh;
+  /* #125I-D-R1 — layout family aligned with /no/ (#125I-C): 60rem module, calm surfaces */
+  .hub-page {
+    padding: 0;
   }
 
   .hub-container {
-    max-width: min(100%, 52rem);
+    max-width: min(100%, 60rem);
     margin: 0 auto;
-    padding: 0 1rem 4rem;
+    padding: 0 1rem clamp(3.75rem, 7vw, 5rem);
+  }
+
+  @media (min-width: 640px) {
+    .hub-container {
+      padding-inline: 1.25rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .hub-container {
+      padding-inline: 1.75rem;
+    }
   }
 
   .hub-header {
-    padding: clamp(2rem, 6vw, 3.5rem) 0 clamp(1.5rem, 4vw, 2.25rem);
-    border-bottom: 1px solid rgb(var(--border) / 0.22);
+    padding: clamp(2rem, 6vw, 3rem) 0 clamp(1rem, 2.5vw, 1.3rem);
+    border-bottom: 1px solid rgb(var(--border) / 0.2);
   }
 
   .hub-breadcrumb {
     display: flex;
     align-items: center;
     gap: 0.45rem;
-    margin-bottom: 1.25rem;
+    margin-bottom: 0.85rem;
     font-size: 0.68rem;
     font-weight: 600;
     letter-spacing: 0.12em;
@@ -225,83 +235,88 @@ const audiografEscalation = {
   }
 
   .hub-kicker {
-    margin: 0 0 0.55rem;
+    margin: 0 0 0.45rem;
     font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.16em;
+    font-weight: 800;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: rgb(var(--reading-accent-iris));
+    color: rgb(var(--reading-ink-secondary));
   }
 
   [data-hub-help] h1 {
     margin: 0;
     font-family: var(--font-display);
-    font-size: clamp(2.4rem, 8vw, 4.2rem);
+    font-size: clamp(2rem, 5.8vw, 2.6rem);
     font-weight: 650;
-    line-height: 0.99;
-    letter-spacing: -0.065em;
+    line-height: 1.05;
+    letter-spacing: -0.055em;
     text-wrap: balance;
     color: rgb(var(--reading-ink));
+    max-width: 42rem;
   }
 
   .hub-lead {
-    margin: clamp(0.9rem, 2.5vw, 1.35rem) 0 0;
-    font-size: clamp(1rem, 2.5vw, 1.2rem);
-    line-height: 1.48;
-    letter-spacing: -0.01em;
+    margin: clamp(0.65rem, 1.8vw, 0.85rem) 0 0;
+    max-width: 38rem;
+    font-size: clamp(0.93rem, 2.1vw, 1.02rem);
+    line-height: 1.5;
     color: rgb(var(--reading-ink-secondary));
   }
 
-  .hub-help-core {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
+  .hub-module {
+    margin-top: clamp(1rem, 2.5vw, 1.2rem);
+    padding: clamp(0.9rem, 2.2vw, 1.05rem);
+    border: 1px solid rgb(var(--border) / 0.16);
+    border-radius: 12px;
   }
 
-  .hub-block {
-    padding: clamp(1.5rem, 4vw, 2rem) 0;
-    border-bottom: 1px solid rgb(var(--border) / 0.15);
+  .hub-section {
+    padding: clamp(0.85rem, 2vw, 1rem) 0;
   }
 
-  .hub-block:last-child {
-    border-bottom: 0;
+  .hub-section + .hub-section {
+    border-top: 1px solid rgb(var(--border) / 0.14);
   }
 
-  .hub-block__title {
-    margin: 0 0 0.85rem;
+  .hub-section:first-child {
+    padding-top: 0;
+  }
+
+  .hub-section:last-child {
+    padding-bottom: 0;
+  }
+
+  .hub-section__title {
+    margin: 0 0 0.65rem;
     font-size: 0.68rem;
     font-weight: 800;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: rgb(var(--reading-accent-iris));
+    color: rgb(var(--reading-ink-secondary));
   }
 
-  /* ── AI ask ── */
-  .hub-block--ai {
-    padding-top: clamp(1.75rem, 4vw, 2.25rem);
-  }
-
+  /* ── AI ask — compact utility, not dominant widget ── */
   .hub-ai-ask__lead {
-    margin: 0 0 1rem;
-    font-size: 0.88rem;
-    line-height: 1.6;
+    margin: 0 0 0.75rem;
+    font-size: 0.84rem;
+    line-height: 1.48;
     color: rgb(var(--reading-ink-secondary));
   }
 
   .hub-ai-form {
     display: flex;
     flex-direction: column;
-    gap: 0.65rem;
+    gap: 0.55rem;
   }
 
   .hub-ai-form__field input {
     width: 100%;
-    padding: 0.75rem 1rem;
-    border: 1px solid rgb(var(--border) / 0.35);
+    padding: 0.62rem 0.95rem;
+    border: 1px solid rgb(var(--border) / 0.28);
     border-radius: 999px;
     background: rgb(var(--reading-paper));
     color: rgb(var(--reading-ink));
-    font-size: 0.9rem;
+    font-size: 0.86rem;
     line-height: 1.4;
   }
 
@@ -317,7 +332,7 @@ const audiografEscalation = {
 
   .hub-ai-form__submit {
     align-self: flex-start;
-    padding: 0.6rem 1.1rem;
+    padding: 0.52rem 0.95rem;
     border: 0;
     border-radius: 999px;
     background: rgb(var(--reading-ink));
@@ -326,11 +341,11 @@ const audiografEscalation = {
     font-weight: 650;
     letter-spacing: -0.01em;
     cursor: pointer;
-    transition: opacity 120ms ease;
+    transition: opacity 150ms ease;
   }
 
   .hub-ai-form__submit:hover {
-    opacity: 0.88;
+    opacity: 0.9;
   }
 
   .hub-ai-form__submit:focus-visible {
@@ -338,34 +353,44 @@ const audiografEscalation = {
     box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
   }
 
-  /* ── Problem cards ── */
+  /* ── Problem cards — same calm surface family as forside entry cards ── */
   .hub-problem-grid {
     margin: 0;
     padding: 0;
     list-style: none;
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.65rem;
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  @media (min-width: 640px) {
+    .hub-problem-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.7rem;
+    }
   }
 
   .hub-problem-card {
+    position: relative;
     display: flex;
     flex-direction: column;
-    gap: 0.55rem;
-    min-height: 6.75rem;
-    padding: 0.7rem;
-    border: 1px solid rgb(var(--border) / 0.28);
+    justify-content: center;
+    gap: 0.25rem;
+    min-height: 4.5rem;
+    padding: 0.95rem 1rem 2rem;
+    border: 1px solid rgb(var(--border) / 0.22);
     border-radius: 10px;
     background: rgb(var(--reading-paper));
     color: inherit;
     text-decoration: none;
-    transition: box-shadow 150ms ease, border-color 150ms ease, transform 150ms ease;
+    transition:
+      border-color 150ms ease,
+      box-shadow 150ms ease;
   }
 
   .hub-problem-card:hover {
-    border-color: rgb(var(--border) / 0.5);
-    box-shadow: 0 3px 14px rgb(var(--reading-ink) / 0.06);
-    transform: translateY(-1px);
+    border-color: rgb(var(--border) / 0.36);
+    box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
   }
 
   .hub-problem-card:focus-visible {
@@ -373,49 +398,27 @@ const audiografEscalation = {
     box-shadow: 0 0 0 3px rgb(14 165 233 / 0.32);
   }
 
-  .hub-problem-card__visual {
-    position: relative;
-    display: block;
-    height: 2.5rem;
-    border-radius: 6px;
-    overflow: hidden;
-  }
-
-  .hub-problem-card__shape {
-    position: absolute;
-    inset: 0;
-  }
-
-  [data-thumb="piping"] .hub-problem-card__visual {
-    background:
-      radial-gradient(ellipse 55% 55% at 18% 75%, rgb(95 82 220 / 0.15) 0%, transparent 65%),
-      linear-gradient(145deg, rgb(238 235 255) 0%, rgb(252 252 255) 100%);
-  }
-
-  [data-thumb="bluetooth"] .hub-problem-card__visual {
-    background:
-      radial-gradient(ellipse 60% 50% at 60% 50%, rgb(14 165 233 / 0.13) 0%, transparent 65%),
-      linear-gradient(155deg, rgb(234 246 255) 0%, rgb(252 252 255) 100%);
-  }
-
-  [data-thumb="app"] .hub-problem-card__visual {
-    background:
-      radial-gradient(ellipse 50% 65% at 75% 30%, rgb(95 82 220 / 0.11) 0%, transparent 60%),
-      linear-gradient(160deg, rgb(240 239 255) 0%, rgb(252 253 255) 100%);
-  }
-
-  [data-thumb="filter"] .hub-problem-card__visual {
-    background:
-      radial-gradient(ellipse 65% 55% at 55% 60%, rgb(200 192 176 / 0.28) 0%, transparent 65%),
-      linear-gradient(130deg, rgb(252 250 245) 0%, rgb(255 253 250) 100%);
-  }
-
   .hub-problem-card__title {
-    font-size: 0.84rem;
+    font-size: 0.98rem;
     font-weight: 650;
     letter-spacing: -0.025em;
-    line-height: 1.25;
+    line-height: 1.28;
     color: rgb(var(--reading-ink));
+  }
+
+  .hub-problem-card__arrow {
+    position: absolute;
+    right: 1rem;
+    bottom: 0.85rem;
+    font-size: 0.88rem;
+    line-height: 1;
+    color: rgb(var(--reading-ink-secondary) / 0.5);
+    transition: color 150ms ease, transform 150ms ease;
+  }
+
+  .hub-problem-card:hover .hub-problem-card__arrow {
+    color: rgb(var(--reading-ink-secondary));
+    transform: translateX(2px);
   }
 
   /* ── Compact task list ── */
@@ -423,14 +426,14 @@ const audiografEscalation = {
     margin: 0;
     padding: 0;
     list-style: none;
-    border: 1px solid rgb(var(--border) / 0.28);
+    border: 1px solid rgb(var(--border) / 0.22);
     border-radius: 10px;
     overflow: hidden;
     background: rgb(var(--reading-paper));
   }
 
   .hub-task-row {
-    border-bottom: 1px solid rgb(var(--border) / 0.18);
+    border-bottom: 1px solid rgb(var(--border) / 0.14);
   }
 
   .hub-task-row:last-child {
@@ -443,7 +446,7 @@ const audiografEscalation = {
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
-    padding: 0.85rem 1rem;
+    padding: 0.8rem 0.95rem;
     text-decoration: none;
   }
 
@@ -453,7 +456,7 @@ const audiografEscalation = {
   }
 
   .hub-task-row__link:hover {
-    background: rgb(var(--border) / 0.18);
+    background: rgb(var(--border) / 0.12);
   }
 
   .hub-task-row__link:focus-visible {
@@ -470,15 +473,15 @@ const audiografEscalation = {
   }
 
   .hub-task-row__label {
-    font-size: 0.9rem;
+    font-size: 0.88rem;
     line-height: 1.4;
     font-weight: 500;
   }
 
   .hub-task-row__arrow {
     flex-shrink: 0;
-    color: rgb(var(--reading-accent-iris));
-    font-size: 0.9rem;
+    color: rgb(var(--reading-ink-secondary) / 0.5);
+    font-size: 0.88rem;
   }
 
   .hub-task-row__badge {
@@ -488,7 +491,7 @@ const audiografEscalation = {
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: rgb(var(--muted));
-    border: 1px solid rgb(var(--border) / 0.4);
+    border: 1px solid rgb(var(--border) / 0.35);
     border-radius: 3px;
     padding: 0.12rem 0.38rem;
   }
@@ -499,26 +502,28 @@ const audiografEscalation = {
     padding: 0;
     list-style: none;
     display: grid;
-    gap: 0.4rem;
+    gap: 0.55rem;
   }
 
   .hub-guide-row {
     display: grid;
     grid-template-columns: auto 1fr auto;
-    gap: 0.4rem 0.75rem;
+    gap: 0.35rem 0.75rem;
     align-items: baseline;
-    padding: 0.65rem 0.75rem;
-    border-radius: 8px;
+    padding: 0.85rem 0.95rem;
+    border-radius: 10px;
     background: rgb(var(--reading-paper));
-    border: 1px solid rgb(var(--border) / 0.2);
+    border: 1px solid rgb(var(--border) / 0.22);
     color: inherit;
     text-decoration: none;
-    transition: background-color 120ms ease, border-color 120ms ease;
+    transition:
+      border-color 150ms ease,
+      box-shadow 150ms ease;
   }
 
   .hub-guide-row:hover {
-    background: rgb(var(--border) / 0.12);
-    border-color: rgb(var(--border) / 0.35);
+    border-color: rgb(var(--border) / 0.36);
+    box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
   }
 
   .hub-guide-row:focus-visible {
@@ -527,41 +532,40 @@ const audiografEscalation = {
   }
 
   .hub-guide-row__label {
-    font-size: 0.6rem;
-    font-weight: 700;
-    letter-spacing: 0.1em;
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: rgb(var(--reading-accent-iris));
+    color: rgb(var(--reading-ink-secondary));
   }
 
   .hub-guide-row__title {
     font-size: 0.88rem;
-    font-weight: 600;
+    font-weight: 650;
     letter-spacing: -0.02em;
     line-height: 1.3;
     color: rgb(var(--reading-ink));
   }
 
   .hub-guide-row__arrow {
-    color: rgb(var(--muted));
-    font-size: 0.85rem;
+    color: rgb(var(--reading-ink-secondary) / 0.5);
+    font-size: 0.88rem;
   }
 
   /* ── Escalation ── */
-  .hub-block--escalation {
+  .hub-section--escalation {
     display: flex;
     flex-direction: column;
-    gap: 0.85rem;
-    padding-bottom: 0.5rem;
+    gap: 0.75rem;
   }
 
   .hub-escalation-chat {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    font-size: 0.9rem;
+    font-size: 0.84rem;
     font-weight: 650;
-    color: rgb(var(--reading-accent-iris));
+    color: rgb(var(--reading-ink-secondary));
     text-decoration: underline;
     text-underline-offset: 3px;
   }
@@ -580,18 +584,20 @@ const audiografEscalation = {
     display: grid;
     grid-template-columns: 1fr auto;
     gap: 0.25rem 0.75rem;
-    padding: 0.9rem 1rem;
-    border: 1px solid rgb(var(--border) / 0.25);
+    padding: 0.95rem 1rem;
+    border: 1px solid rgb(var(--border) / 0.22);
     border-radius: 10px;
-    background: rgb(252 250 247);
+    background: rgb(var(--reading-paper));
     color: inherit;
     text-decoration: none;
-    transition: background-color 120ms ease, border-color 120ms ease;
+    transition:
+      border-color 150ms ease,
+      box-shadow 150ms ease;
   }
 
   .hub-escalation-audiograf:hover {
-    background: rgb(250 247 242);
-    border-color: rgb(var(--border) / 0.4);
+    border-color: rgb(var(--border) / 0.36);
+    box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
   }
 
   .hub-escalation-audiograf:focus-visible {
@@ -601,27 +607,26 @@ const audiografEscalation = {
 
   .hub-escalation-audiograf__label {
     grid-column: 1;
-    font-size: 0.6rem;
-    font-weight: 700;
-    letter-spacing: 0.1em;
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: rgb(var(--muted));
+    color: rgb(var(--reading-ink-secondary));
   }
 
   .hub-escalation-audiograf__title {
     grid-column: 1;
-    font-family: var(--font-display);
-    font-size: 0.95rem;
+    font-size: 0.98rem;
     font-weight: 650;
     letter-spacing: -0.025em;
-    line-height: 1.2;
+    line-height: 1.28;
     color: rgb(var(--reading-ink));
   }
 
   .hub-escalation-audiograf__deck {
     grid-column: 1;
-    font-size: 0.8rem;
-    line-height: 1.55;
+    font-size: 0.82rem;
+    line-height: 1.48;
     color: rgb(var(--reading-ink-secondary));
   }
 
@@ -629,7 +634,7 @@ const audiografEscalation = {
     grid-column: 2;
     grid-row: 1 / span 3;
     align-self: center;
-    color: rgb(var(--muted));
+    color: rgb(var(--reading-ink-secondary) / 0.5);
   }
 
   .sr-only {
@@ -644,25 +649,7 @@ const audiografEscalation = {
     border: 0;
   }
 
-  @media (max-width: 479px) {
-    .hub-problem-grid {
-      grid-template-columns: 1fr;
-    }
-
-    .hub-escalation-audiograf {
-      grid-template-columns: 1fr;
-    }
-
-    .hub-escalation-audiograf__arrow {
-      display: none;
-    }
-  }
-
   @media (min-width: 480px) {
-    .hub-container {
-      padding: 0 1.25rem 4.5rem;
-    }
-
     .hub-ai-form {
       flex-direction: row;
       align-items: stretch;
@@ -673,9 +660,13 @@ const audiografEscalation = {
     }
   }
 
-  @media (min-width: 640px) {
-    .hub-container {
-      padding: 0 1.75rem 5.5rem;
+  @media (max-width: 479px) {
+    .hub-escalation-audiograf {
+      grid-template-columns: 1fr;
+    }
+
+    .hub-escalation-audiograf__arrow {
+      display: none;
     }
   }
 </style>

--- a/src/pages/no/hub.astro
+++ b/src/pages/no/hub.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Hjelp hub (A3) — praktisk hjelpehub for konkrete problemer.
-   #125I-D-R3 — hvit content surface, composer, kategorikort med enkle glyphs.
+   #125I-D-R4 — artikkel-paritet surface (46rem/radius-md), større kategorikort, copy-justeringer.
    Mandate: docs/project/VIDDEL_HUB_MANDATE_v0_1.md / #112.
 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
@@ -9,7 +9,7 @@ import Footer from "../../components/nav/Footer.astro";
 Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
 
 const hubTitle = "Få høreapparatet til å fungere";
-const hubSupport = "Vanlige problemer og rask hjelp — velg det som passer, eller spør Hørehjelpen.";
+const hubSupport = "Vanlige problemer og hjelp, velg det som passer, eller spør Hørehjelpen.";
 
 type CategoryIcon = "piping" | "bluetooth" | "app" | "filter" | "battery" | "sound";
 
@@ -112,8 +112,7 @@ const audiografEscalation = {
             </form>
           </section>
 
-          <section class="hub-block" aria-labelledby="categories-heading">
-            <h2 id="categories-heading">Velg problemområde</h2>
+          <section class="hub-block hub-block--categories" aria-label="Problemområder">
             <ul class="hub-cat-grid" role="list">
               {categoryCards.map((card) => (
                 <li>
@@ -151,10 +150,8 @@ const audiografEscalation = {
                           </svg>
                         )}
                       </span>
-                      <span class="hub-cat-card__body">
-                        <span class="hub-cat-card__title">{card.title}</span>
-                        <span class="hub-cat-card__hint">{card.hint}</span>
-                      </span>
+                      <span class="hub-cat-card__title">{card.title}</span>
+                      <span class="hub-cat-card__hint">{card.hint}</span>
                       <span class="hub-cat-card__arrow" aria-hidden="true">→</span>
                     </a>
                   ) : (
@@ -164,10 +161,8 @@ const audiografEscalation = {
                           <rect x="3" y="7" width="16" height="10" rx="2" /><path d="M21 10v4" /><path d="M7 11v2" />
                         </svg>
                       </span>
-                      <span class="hub-cat-card__body">
-                        <span class="hub-cat-card__title">{card.title}</span>
-                        <span class="hub-cat-card__hint">{card.hint}</span>
-                      </span>
+                      <span class="hub-cat-card__title">{card.title}</span>
+                      <span class="hub-cat-card__hint">{card.hint}</span>
                       <span class="hub-cat-card__badge">Kommer</span>
                     </span>
                   )}
@@ -177,7 +172,7 @@ const audiografEscalation = {
           </section>
 
           <section class="hub-block" aria-labelledby="guides-heading">
-            <h2 id="guides-heading">Korte guider</h2>
+            <h2 id="guides-heading">Hjelp meg med</h2>
             <ul class="hub-link-list" role="list">
               {shortGuides.map((guide) => (
                 <li class="hub-link-row">
@@ -210,34 +205,42 @@ const audiografEscalation = {
 </BaseLayout>
 
 <style>
-  /* #125I-D-R3 — hvit content surface; ambient shell utenfor flaten */
+  /* #125I-D-R4 — surface paritet med artikkel (46rem, --radius-md); større kategorikort */
   .hub-page {
-    padding: clamp(0.5rem, 1.5vw, 0.85rem) 0 0;
+    background: rgb(var(--article-page-canvas));
+    padding: 0.5rem 0 clamp(3rem, 6vw, 4rem);
+  }
+
+  @media (min-width: 640px) {
+    .hub-page {
+      padding-top: 0.75rem;
+    }
   }
 
   .hub-container {
-    max-width: min(100%, 60rem);
     margin: 0 auto;
-    padding: 0 1rem clamp(3.75rem, 7vw, 5rem);
+    padding: 0 1rem;
   }
 
   @media (min-width: 640px) {
     .hub-container {
-      padding-inline: 1.25rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .hub-container {
-      padding-inline: 1.75rem;
+      padding-inline: 1.5rem;
     }
   }
 
   .hub-surface {
+    max-width: min(100%, 46rem);
+    margin: 0 auto;
     background: rgb(var(--reading-paper));
-    border: 1px solid rgb(var(--border) / 0.16);
-    border-radius: 12px;
-    padding: clamp(1rem, 2.4vw, 1.35rem);
+    border-radius: var(--radius-md);
+    padding: 2.5rem 1.75rem;
+    color: rgb(var(--reading-ink));
+  }
+
+  @media (min-width: 640px) {
+    .hub-surface {
+      padding: 3rem 2.5rem;
+    }
   }
 
   .hub-header {
@@ -282,12 +285,10 @@ const audiografEscalation = {
   }
 
   .hub-body {
-    max-width: 48rem;
-    margin: 0 auto;
     padding-top: clamp(1rem, 2.5vw, 1.25rem);
     display: flex;
     flex-direction: column;
-    gap: clamp(1.25rem, 3vw, 1.6rem);
+    gap: clamp(1.35rem, 3.2vw, 1.75rem);
   }
 
   .hub-block h2,
@@ -377,37 +378,43 @@ const audiografEscalation = {
     outline-offset: 3px;
   }
 
-  /* ── Kategorikort med enkle line-glyphs ── */
+  .hub-block--categories {
+    margin-top: -0.15rem;
+  }
+
+  /* ── Kategorikort — ikon over tekst, midlertidige line-glyphs (R4) ── */
   .hub-cat-grid {
     margin: 0;
     padding: 0;
     list-style: none;
     display: grid;
     grid-template-columns: 1fr;
-    gap: 0.6rem;
+    gap: 0.75rem;
   }
 
   @media (min-width: 540px) {
     .hub-cat-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.85rem;
     }
   }
 
-  @media (min-width: 900px) {
+  @media (min-width: 960px) {
     .hub-cat-grid {
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 
   .hub-cat-card {
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
-    gap: 0.7rem;
-    min-height: 4.25rem;
-    padding: 0.85rem 0.9rem;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.45rem;
+    min-height: 8.25rem;
+    padding: 1.2rem 1.15rem 2.35rem;
     border: 1px solid rgb(var(--border) / 0.22);
-    border-radius: 10px;
+    border-radius: var(--radius-md);
     background: rgb(var(--reading-paper));
     color: inherit;
     text-decoration: none;
@@ -434,11 +441,11 @@ const audiografEscalation = {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 2.35rem;
-    height: 2.35rem;
+    width: 2.85rem;
+    height: 2.85rem;
     flex-shrink: 0;
     border: 1px solid rgb(var(--border) / 0.28);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     background: rgb(var(--border) / 0.08);
     color: rgb(var(--reading-ink));
   }
@@ -448,19 +455,12 @@ const audiografEscalation = {
   }
 
   .hub-cat-card__icon svg {
-    width: 1.15rem;
-    height: 1.15rem;
-  }
-
-  .hub-cat-card__body {
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-    min-width: 0;
+    width: 1.25rem;
+    height: 1.25rem;
   }
 
   .hub-cat-card__title {
-    font-size: 0.92rem;
+    font-size: 0.98rem;
     font-weight: 650;
     letter-spacing: -0.02em;
     line-height: 1.28;
@@ -472,17 +472,16 @@ const audiografEscalation = {
   }
 
   .hub-cat-card__hint {
-    font-size: 0.78rem;
-    line-height: 1.35;
+    font-size: 0.8rem;
+    line-height: 1.4;
     color: rgb(var(--reading-ink-secondary));
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .hub-cat-card__arrow {
-    flex-shrink: 0;
-    font-size: 0.88rem;
+    position: absolute;
+    right: 1.1rem;
+    bottom: 1.05rem;
+    font-size: 0.9rem;
     color: rgb(var(--reading-ink-secondary) / 0.45);
     transition: color 100ms ease, transform 100ms ease;
   }
@@ -493,6 +492,9 @@ const audiografEscalation = {
   }
 
   .hub-cat-card__badge {
+    position: absolute;
+    right: 1.1rem;
+    bottom: 1.05rem;
     flex-shrink: 0;
     font-size: 0.62rem;
     font-weight: 700;
@@ -657,10 +659,6 @@ const audiografEscalation = {
 
     .hub-escalation-card__arrow {
       display: none;
-    }
-
-    .hub-cat-card__hint {
-      white-space: normal;
     }
   }
 </style>

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -136,10 +136,10 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     sprint: "2026-W21",
     issue: "#125I-D",
     type: "reference",
-    status: "decision-candidate",
+    status: "closed",
     stakeholderSafe: true,
     description:
-      "R8: kategori-kort = editorial hover (hvit flate, shadow, lift). #F5F6F5 kun liste-rader. CBA for help-hub IXD — ikke design lock. QA pending.",
+      "QA-godkjent — CBA v0.1 / god nok for nå (R1–R8). Editorial card-hover på kategori-kort; #F5F6F5 kun liste-rader. Follow-ups: ikonpass, composer-paritet, footer/shell, FOUC (#125I-B), copy/nav (#125J).",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -139,7 +139,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "decision-candidate",
     stakeholderSafe: true,
     description:
-      "R5: direkte H1, tyngre kort/ikoner, tydelig gestalt. Midlertidige større line-icons — ikke endelig design lock. QA pending — ikke merge.",
+      "R6: hvite kategorikort, ingen ikonbokser/offwhite på interactive cards. Ikoner midlertidig fjernet — eget ikonpass senere, ikke design lock. QA pending.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -139,7 +139,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "decision-candidate",
     stakeholderSafe: true,
     description:
-      "R1: Hjelp-hub samlet med forside-layoutfamilie (60rem, modulramme, rolige kort, kompakt AI). FOUC ikke adressert. QA pending.",
+      "R2: én primærvei (AI først), smalere innholdsflate, felles link-liste, færre visuelle nivåer. R1 ikke merget. FOUC ikke adressert. QA pending.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -139,7 +139,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "decision-candidate",
     stakeholderSafe: true,
     description:
-      "R2: én primærvei (AI først), smalere innholdsflate, felles link-liste, færre visuelle nivåer. R1 ikke merget. FOUC ikke adressert. QA pending.",
+      "R2b: composer-inngang (pilknapp inne i felt, speiler artikkel). R2: én primærvei, felles link-liste. FOUC ikke adressert. QA pending.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -139,7 +139,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "decision-candidate",
     stakeholderSafe: true,
     description:
-      "R3: hvit content surface, kategorikort (line-glyphs), composer beholdt, kortere guide-liste. FOUC ikke adressert. QA pending — ikke merge.",
+      "R4: artikkel-paritet surface, større kategorikort, copy-justeringer. Midlertidige line-glyphs — ikke endelig ikonstil; eget pass senere. QA pending — ikke merge.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -115,7 +115,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "closed",
     stakeholderSafe: true,
     description:
-      "Diagnose completed — horizontal layout shift / FOUC not solved. Parkert som known issue / teknisk gjeld.",
+      "Diagnose completed — horizontal layout shift / FOUC not solved (#125I-B). Thomas QA (2026-05): hopper ved lasting av hub/ordbok/om, ikke forside; route-spesifikk CSS sannsynlig. Parkert — ta med i #125I-D / spike.",
   },
   {
     id: "frontpage-polish-125i-c",
@@ -127,7 +127,19 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "closed",
     stakeholderSafe: true,
     description:
-      "QA-godkjent — god nok for nå (R1–R3 forside + felles footer). FOUC/layout shift forblir known issue (#125I-B). Copy/nav wording parkert til senere pass (#125J). Neste: #125I-D hub polish.",
+      "QA-godkjent — god nok for nå (R1–R3 forside + felles footer). FOUC/layout shift forblir known issue (#125I-B). Copy/nav wording parkert til senere pass (#125J).",
+  },
+  {
+    id: "hub-polish-125i-d",
+    title: "Hub polish",
+    href: "/no/hub/",
+    sprint: "2026-W21",
+    issue: "#125I-D",
+    type: "reference",
+    status: "decision-candidate",
+    stakeholderSafe: true,
+    description:
+      "R1: Hjelp-hub samlet med forside-layoutfamilie (60rem, modulramme, rolige kort, kompakt AI). FOUC ikke adressert. QA pending.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -139,7 +139,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "decision-candidate",
     stakeholderSafe: true,
     description:
-      "R6: hvite kategorikort, ingen ikonbokser/offwhite på interactive cards. Ikoner midlertidig fjernet — eget ikonpass senere, ikke design lock. QA pending.",
+      "R7: tekststerke hvite kort, hover #F5F6F5 (ikke fersken). Good-enough for QA. Follow-ups: ikonsett, full composer-paritet, footer/shell — ikke i #125I-D.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -139,7 +139,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "decision-candidate",
     stakeholderSafe: true,
     description:
-      "R7: tekststerke hvite kort, hover #F5F6F5 (ikke fersken). Good-enough for QA. Follow-ups: ikonsett, full composer-paritet, footer/shell — ikke i #125I-D.",
+      "R8: kategori-kort = editorial hover (hvit flate, shadow, lift). #F5F6F5 kun liste-rader. CBA for help-hub IXD — ikke design lock. QA pending.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -139,7 +139,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "decision-candidate",
     stakeholderSafe: true,
     description:
-      "R2b: composer-inngang (pilknapp inne i felt, speiler artikkel). R2: én primærvei, felles link-liste. FOUC ikke adressert. QA pending.",
+      "R3: hvit content surface, kategorikort (line-glyphs), composer beholdt, kortere guide-liste. FOUC ikke adressert. QA pending — ikke merge.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -139,7 +139,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "decision-candidate",
     stakeholderSafe: true,
     description:
-      "R4: artikkel-paritet surface, større kategorikort, copy-justeringer. Midlertidige line-glyphs — ikke endelig ikonstil; eget pass senere. QA pending — ikke merge.",
+      "R5: direkte H1, tyngre kort/ikoner, tydelig gestalt. Midlertidige større line-icons — ikke endelig design lock. QA pending — ikke merge.",
   },
   {
     id: "forside-routing",

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -451,7 +451,7 @@ const typographyLabDirections = [
           <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
         </p>
         <p class="sprint-preview__typo-sans">
-          R6: hvite kategorikort uten ikonbokser; varm/offwhite fjernet fra interactive cards. Ikoner midlertidig fjernet — eget pass senere.
+          R7: nøytral hover #F5F6F5, tekststerke korttitler — good enough for QA. Follow-ups: ikonsett, composer-paritet, footer/shell.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify hub polish on production →

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -451,9 +451,8 @@ const typographyLabDirections = [
           <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
         </p>
         <p class="sprint-preview__typo-sans">
-          R2: én primærvei («Hva fungerer ikke?» først), smalere innholdsflate (44rem), felles link-liste
-          for problemer og guider, fjernet micro-labels og kort-grid, rolig eskalering nederst.
-          FOUC/layout shift observert men ikke adressert.
+          R2b: AI-inngang som composer (pilknapp inne i felt, speiler artikkel compose). R2: én primærvei,
+          felles link-liste. FOUC/layout shift observert men ikke adressert.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify hub polish on production →

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -451,7 +451,7 @@ const typographyLabDirections = [
           <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
         </p>
         <p class="sprint-preview__typo-sans">
-          R5: direkte H1, tyngre kategorikort/ikoner, uten «Hørehjelpen» i hub-innhold. Midlertidige line-icons — eget pass senere.
+          R6: hvite kategorikort uten ikonbokser; varm/offwhite fjernet fra interactive cards. Ikoner midlertidig fjernet — eget pass senere.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify hub polish on production →

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -451,8 +451,7 @@ const typographyLabDirections = [
           <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
         </p>
         <p class="sprint-preview__typo-sans">
-          R4: artikkel-paritet surface (46rem, radius-md), større kategorikort (ikon over tekst), copy-justeringer.
-          Midlertidige line-glyphs — eget ikonpass senere. FOUC ikke adressert.
+          R5: direkte H1, tyngre kategorikort/ikoner, uten «Hørehjelpen» i hub-innhold. Midlertidige line-icons — eget pass senere.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify hub polish on production →

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -11,7 +11,7 @@
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
    #125I-C: Frontpage/footer polish — QA accepted, closed.
-   #125I-D: Hub polish R1 on /no/hub/ — in progress.
+   #125I-D: Hub polish R2 on /no/hub/ — in progress (R1 not merged).
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -125,7 +125,7 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
         <li><strong>Applied:</strong> #125I-C Forside/footer polish på <code>/no/</code> — QA-godkjent, closed</li>
-        <li><strong>In progress:</strong> #125I-D Hub polish R1 på <code>/no/hub/</code></li>
+        <li><strong>In progress:</strong> #125I-D Hub polish R2 på <code>/no/hub/</code> (R1 ikke merget)</li>
         <li><strong>Parked:</strong> #125I-B Layout shift / FOUC — known issue</li>
         <li><strong>Senere:</strong> #125I-D R2 (Lyd i hverdagen) · #125J Copy/nav pass</li>
       </ul>
@@ -448,11 +448,11 @@ const typographyLabDirections = [
       </div>
       <div class="sprint-preview__typo-summary">
         <p class="sprint-preview__typo-status">
-          <strong>Status:</strong> R1 in progress — QA pending
+          <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
         </p>
         <p class="sprint-preview__typo-sans">
-          R1: 60rem container (match forside/footer), modulramme som <code>land-choices</code>, roligere
-          problemkort uten gradient-thumbs, kompakt AI-inngang etter primærkort, enhetlig surface-familie.
+          R2: én primærvei («Hva fungerer ikke?» først), smalere innholdsflate (44rem), felles link-liste
+          for problemer og guider, fjernet micro-labels og kort-grid, rolig eskalering nederst.
           FOUC/layout shift observert men ikke adressert.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -11,7 +11,7 @@
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
    #125I-C: Frontpage/footer polish — QA accepted, closed.
-   #125I-D: Hub polish R2 on /no/hub/ — in progress (R1 not merged).
+   #125I-D: Hub polish on /no/hub/ — QA accepted, closed (CBA v0.1).
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -125,9 +125,9 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
         <li><strong>Applied:</strong> #125I-C Forside/footer polish på <code>/no/</code> — QA-godkjent, closed</li>
-        <li><strong>In progress:</strong> #125I-D Hub polish R2 på <code>/no/hub/</code> (R1 ikke merget)</li>
+        <li><strong>Applied:</strong> #125I-D Hub polish på <code>/no/hub/</code> — QA-godkjent, closed (CBA v0.1)</li>
         <li><strong>Parked:</strong> #125I-B Layout shift / FOUC — known issue</li>
-        <li><strong>Senere:</strong> #125I-D R2 (Lyd i hverdagen) · #125J Copy/nav pass</li>
+        <li><strong>Senere:</strong> hub ikonpass · composer-paritet · footer/shell · #125J Copy/nav pass</li>
       </ul>
     </section>
 
@@ -439,7 +439,7 @@ const typographyLabDirections = [
       </div>
     </section>
 
-    <!-- Hub polish (#125I-D — R1 in progress) -->
+    <!-- Hub polish (#125I-D — QA accepted, closed) -->
     <section class="sprint-preview__section" aria-labelledby="hub-polish-heading">
       <div class="sprint-preview__section-head">
         <p class="sprint-preview__kicker">17 · #125I-D</p>
@@ -448,10 +448,11 @@ const typographyLabDirections = [
       </div>
       <div class="sprint-preview__typo-summary">
         <p class="sprint-preview__typo-status">
-          <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
+          <strong>Status:</strong> QA accepted — CBA v0.1 / closed
         </p>
         <p class="sprint-preview__typo-sans">
-          R8: editorial card hover på kategori-kort (shadow + lift). #F5F6F5 kun på liste-rader — CBA, ikke design lock.
+          R8 godkjent: hvite kategori-kort, editorial hover (shadow + lift), #F5F6F5 kun på liste-rader.
+          Follow-ups: ikonpass, composer-paritet, footer/shell, FOUC (#125I-B), copy/nav (#125J).
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify hub polish on production →

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -451,8 +451,8 @@ const typographyLabDirections = [
           <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
         </p>
         <p class="sprint-preview__typo-sans">
-          R2b: AI-inngang som composer (pilknapp inne i felt, speiler artikkel compose). R2: én primærvei,
-          felles link-liste. FOUC/layout shift observert men ikke adressert.
+          R3: hvit content surface, kategorikort med line-glyphs, composer beholdt. R2b: composer-inngang.
+          FOUC/layout shift observert men ikke adressert.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify hub polish on production →

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -10,7 +10,8 @@
    #125G: Forside/routing at /no/ — QA accepted, closed (#125G-R3 triage mandate).
    #125G-R2: Frontpage mandate decision surface — mandate accepted, applied R3.
    #125H: Navigation / top menu pass — QA accepted, closed (IA/nav-sync). Layout jump → #125I.
-   #125I-C: Frontpage/footer polish — QA accepted, closed. Neste: #125I-D.
+   #125I-C: Frontpage/footer polish — QA accepted, closed.
+   #125I-D: Hub polish R1 on /no/hub/ — in progress.
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
@@ -124,8 +125,9 @@ const typographyLabDirections = [
         <li><strong>Applied:</strong> #125G Forside/routing på <code>/no/</code> — QA-godkjent, closed</li>
         <li><strong>Applied:</strong> #125H Nav/toppmeny — QA-godkjent, closed (IA/nav-sync)</li>
         <li><strong>Applied:</strong> #125I-C Forside/footer polish på <code>/no/</code> — QA-godkjent, closed</li>
+        <li><strong>In progress:</strong> #125I-D Hub polish R1 på <code>/no/hub/</code></li>
         <li><strong>Parked:</strong> #125I-B Layout shift / FOUC — known issue</li>
-        <li><strong>Neste:</strong> #125I-D Hub polish · alternativt senere #125J Copy/nav naming pass</li>
+        <li><strong>Senere:</strong> #125I-D R2 (Lyd i hverdagen) · #125J Copy/nav pass</li>
       </ul>
     </section>
 
@@ -437,6 +439,28 @@ const typographyLabDirections = [
       </div>
     </section>
 
+    <!-- Hub polish (#125I-D — R1 in progress) -->
+    <section class="sprint-preview__section" aria-labelledby="hub-polish-heading">
+      <div class="sprint-preview__section-head">
+        <p class="sprint-preview__kicker">17 · #125I-D</p>
+        <h2 id="hub-polish-heading">Hub polish</h2>
+        <p>Hjelp-huben samles visuelt med godkjent forside — uten bred redesign eller FOUC-fix.</p>
+      </div>
+      <div class="sprint-preview__typo-summary">
+        <p class="sprint-preview__typo-status">
+          <strong>Status:</strong> R1 in progress — QA pending
+        </p>
+        <p class="sprint-preview__typo-sans">
+          R1: 60rem container (match forside/footer), modulramme som <code>land-choices</code>, roligere
+          problemkort uten gradient-thumbs, kompakt AI-inngang etter primærkort, enhetlig surface-familie.
+          FOUC/layout shift observert men ikke adressert.
+        </p>
+        <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
+          Verify hub polish on production →
+        </a>
+      </div>
+    </section>
+
     <!-- Layout stability / FOUC (#125I-B — parked) -->
     <section class="sprint-preview__section" aria-labelledby="layout-stability-heading">
       <div class="sprint-preview__section-head">
@@ -449,8 +473,9 @@ const typographyLabDirections = [
           <strong>Status:</strong> Diagnose completed / parked
         </p>
         <p class="sprint-preview__typo-sans">
-          R2 identifiserte horisontal shift (body margin 8→0, container layout ved Tailwind-load). R3 first-paint CSS
-          ga bedre målinger men ingen synlig QA-forbedring — revertet. FOUC beholdes som teknisk gjeld. Neste: #125I-D.
+          R2: horisontal shift ved Tailwind-load. R3 first-paint CSS revertet (ingen synlig QA-gevinst). Thomas QA
+          (2026-05): rykk ved <em>lasting</em> av hub/ordbok/om — forside stabil. Tolkning: route-spesifikk
+          layout/CSS-arv. Ingen ny FOUC-fix nå; observasjon tas med i #125I-D (felles shell/container) og evt. spike.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify layout stability on production →

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -451,8 +451,8 @@ const typographyLabDirections = [
           <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
         </p>
         <p class="sprint-preview__typo-sans">
-          R3: hvit content surface, kategorikort med line-glyphs, composer beholdt. R2b: composer-inngang.
-          FOUC/layout shift observert men ikke adressert.
+          R4: artikkel-paritet surface (46rem, radius-md), større kategorikort (ikon over tekst), copy-justeringer.
+          Midlertidige line-glyphs — eget ikonpass senere. FOUC ikke adressert.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify hub polish on production →

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -451,7 +451,7 @@ const typographyLabDirections = [
           <strong>Status:</strong> R2 in progress — QA pending (R1 not merged)
         </p>
         <p class="sprint-preview__typo-sans">
-          R7: nøytral hover #F5F6F5, tekststerke korttitler — good enough for QA. Follow-ups: ikonsett, composer-paritet, footer/shell.
+          R8: editorial card hover på kategori-kort (shadow + lift). #F5F6F5 kun på liste-rader — CBA, ikke design lock.
         </p>
         <a href={`${base}no/hub/`} class="sprint-preview__typo-link">
           Verify hub polish on production →


### PR DESCRIPTION
## Summary
- Polishes `/no/hub/` as practical help hub (R1–R8): H1 + composer primary, white text-strong category cards, editorial card hover, neutral row hover on list items.
- Closes #125I-D as **QA accepted / CBA v0.1** with decision doc and VIS updates.
- FOUC/layout shift remains known issue (#125I-B); icon pass, composer parity, footer/shell documented as follow-ups.

## Test plan
- [x] `npm run build` green on branch
- [ ] Verify production `/no/hub/` after merge: H1, composer, white cards, editorial hover, no «Hørehjelpen» in hub content
- [ ] Confirm `/no/` unchanged
- [ ] VIS review shows #125I-D closed / CBA v0.1


Made with [Cursor](https://cursor.com)