### PR TITLE
#125K Surface alignment R1

### DIFF
--- a/src/pages/no/artikkel/[slug].astro
+++ b/src/pages/no/artikkel/[slug].astro
@@ -230,7 +230,7 @@ const firstObservationCalloutIndex = article.moduleBlocks.findIndex((b) => b.com
           {article.moduleBlocks.map((block, modIndex) => {
             if (block.component === "module_phrase_cards") {
               return (
-                <section class="space-y-4 border-l-2 border-[rgb(var(--reading-accent-iris))/0.45] pl-5">
+                <section class="space-y-4 border-l-2 border-[rgb(var(--reading-ink-secondary))/0.24] pl-5">
                   <h3 class="font-display text-lg font-semibold tracking-[-0.03em] text-[rgb(var(--reading-ink))]">
                     {block.title || "Eksempelfraser"}
                   </h3>
@@ -273,7 +273,7 @@ const firstObservationCalloutIndex = article.moduleBlocks.findIndex((b) => b.com
             if (isObservationCallout) {
               return (
                 <aside class="vox-reading-inline" aria-label="Observasjon">
-                  <p class="text-xs font-semibold uppercase tracking-[0.12em] text-[rgb(var(--reading-accent-iris))]">
+                  <p class="text-xs font-semibold uppercase tracking-[0.12em] text-[rgb(var(--reading-ink-secondary))]">
                     {moduleToneLabel[block.component]}
                   </p>
                   {block.title ? (
@@ -297,7 +297,7 @@ const firstObservationCalloutIndex = article.moduleBlocks.findIndex((b) => b.com
 
             return (
               <section class="space-y-3">
-                <p class="text-xs font-semibold uppercase tracking-[0.12em] text-[rgb(var(--reading-accent-iris))]">
+                <p class="text-xs font-semibold uppercase tracking-[0.12em] text-[rgb(var(--reading-ink-secondary))]">
                   {moduleToneLabel[block.component]}
                 </p>
                 {block.title ? (

--- a/src/pages/no/index.astro
+++ b/src/pages/no/index.astro
@@ -151,7 +151,8 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
     text-decoration: none;
     transition:
       border-color 150ms ease,
-      box-shadow 150ms ease;
+      box-shadow 150ms ease,
+      transform 150ms ease;
   }
 
   .land-entry:focus-visible {
@@ -194,7 +195,8 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
 
   .land-entry:hover {
     border-color: rgb(var(--border) / 0.36);
-    box-shadow: 0 2px 12px rgb(var(--reading-ink) / 0.05);
+    box-shadow: 0 8px 26px rgb(var(--reading-ink) / 0.055);
+    transform: translateY(-1px);
   }
 
   .land-entry:hover .land-entry__arrow {

--- a/src/styles/r1-dialog-article.css
+++ b/src/styles/r1-dialog-article.css
@@ -57,7 +57,7 @@
       flex-wrap: wrap;
       align-items: center;
       gap: 0.45rem;
-      color: rgb(var(--reading-accent-iris));
+      color: rgb(var(--reading-ink-secondary));
     }
 
     [data-r1-editorial] .r1-storyblok-kicker-row p {
@@ -221,6 +221,10 @@
       display: flex;
       flex-direction: column;
       gap: 2.5rem;
+    }
+
+    [data-r1-editorial] .vox-reading-inline {
+      border-left-color: rgb(var(--reading-ink-secondary) / 0.24);
     }
 
     @media (max-width: 560px) {
@@ -486,7 +490,7 @@
       color: rgb(var(--reading-ink));
       margin: 0;
       padding-bottom: 0.4rem;
-      border-bottom: 1px solid rgb(var(--reading-accent-iris) / 0.22);
+      border-bottom: 1px solid rgb(var(--reading-ink-secondary) / 0.18);
       display: inline-block;
       max-width: 100%;
     }
@@ -517,7 +521,7 @@
       width: 0.28rem;
       height: 0.28rem;
       border-radius: 999px;
-      background: rgb(var(--reading-accent-iris) / 0.5);
+      background: rgb(var(--reading-ink-secondary) / 0.45);
     }
 
     [data-r1-editorial] .r1-orientation {


### PR DESCRIPTION
## Audit note
- Frontpage already has neutral labels and white card surfaces; R1 only adds a softer editorial hover lift to match Bedre lyd card behavior.
- Storyblok article pages still had visible iris/purple editorial labels and callout markers; R1 tones those down to neutral grey/ink-secondary.
- Larger image strategy, frontpage editorial imagery, edge-to-edge article media, and Editorial Image Library usage are deferred.

## Summary
- Aligns `/no/` entry card hover with Bedre lyd editorial card motion.
- Changes visible article labels/callout accents from iris/purple to neutral grey.
- Keeps IA, routes, `/no/hjelp/`, `/no/bedre-lyd/`, and public page structure unchanged.

## Test plan
- `npm run build`
- ReadLints on touched files: no errors.

## QA
Do not merge before Thomas QA.

Made with [Cursor](https://cursor.com)