### PR TITLE
VIS Asset Browser v0.1

### DIFF
--- a/docs/assets/editorial-image-library-v01.md
+++ b/docs/assets/editorial-image-library-v01.md
@@ -72,6 +72,7 @@ src/data/assets/editorial-image-library.ts
 ```
 
 VIS Asset Browser v0.1 finnes på `/vis/assets/editorial/` og leser manifestet.
+VIS-forsiden er oppdatert med inngang til browseren og dagens MVP-flater. Senere bør `/vis/` genereres fra et lite registry i stedet for manuelt kuraterte kort.
 
 Hver entry har:
 

--- a/docs/assets/editorial-image-library-v01.md
+++ b/docs/assets/editorial-image-library-v01.md
@@ -22,15 +22,17 @@ Bildene i v0.1 er importert fra Thomas' sorterte lokale Drive-synkede mappe:
 
 Kun disse sorterte undermappene er importert:
 
-| Gruppe | Antall |
-|--------|--------|
-| `car` | 5 |
-| `city-life-cafe` | 73 |
-| `hearing-aid-box` | 6 |
-| `listening-music` | 4 |
-| `quiet-home` | 24 |
-| `social` | 6 |
-| `tv` | 55 |
+
+| Gruppe            | Antall |
+| ----------------- | ------ |
+| `car`             | 5      |
+| `city-life-cafe`  | 73     |
+| `hearing-aid-box` | 6      |
+| `listening-music` | 4      |
+| `quiet-home`      | 24     |
+| `social`          | 6      |
+| `tv`              | 55     |
+
 
 ## Mappestruktur i repo
 
@@ -69,6 +71,8 @@ Manifestet ligger her:
 src/data/assets/editorial-image-library.ts
 ```
 
+VIS Asset Browser v0.1 finnes på `/vis/assets/editorial/` og leser manifestet.
+
 Hver entry har:
 
 - `id`
@@ -85,9 +89,11 @@ Hver entry har:
 
 Foreløpig finnes bare én status:
 
-| Status | Betydning |
-|--------|-----------|
+
+| Status      | Betydning                                                                        |
+| ----------- | -------------------------------------------------------------------------------- |
 | `candidate` | Webklart kandidatbilde. Må QA-es visuelt før publisering i artikkel eller flate. |
+
 
 ## Importregler v0.1
 

--- a/src/pages/vis/assets/editorial.astro
+++ b/src/pages/vis/assets/editorial.astro
@@ -1,0 +1,385 @@
+---
+/* CONTRACT: VIS-only asset browser for Editorial Image Library v0.1 candidates. */
+import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import {
+  editorialImageLibrary,
+  type EditorialImageGroup,
+  type EditorialImageLibraryEntry,
+} from "../../../data/assets/editorial-image-library";
+
+const base = import.meta.env.BASE_URL;
+
+const groupOrder: Array<EditorialImageGroup> = [
+  "car",
+  "city-life-cafe",
+  "hearing-aid-box",
+  "listening-music",
+  "quiet-home",
+  "social",
+  "tv",
+];
+
+const groupLabels: Record<EditorialImageGroup, string> = {
+  car: "Car",
+  "city-life-cafe": "City Life Cafe",
+  "hearing-aid-box": "Hearing Aid Box",
+  "listening-music": "Listening Music",
+  "quiet-home": "Quiet home",
+  social: "Social",
+  tv: "TV",
+};
+
+const groupedImages = groupOrder
+  .map((group) => ({
+    group,
+    label: groupLabels[group],
+    items: editorialImageLibrary.filter((image) => image.group === group),
+  }))
+  .filter((section) => section.items.length > 0);
+
+const totalImages = editorialImageLibrary.length;
+
+const pathForImage = (entry: EditorialImageLibraryEntry) =>
+  entry.webPath.startsWith("/") ? entry.webPath : `/${entry.webPath}`;
+---
+
+<PrototypeLayout title="Editorial Image Library">
+  <main class="asset-page">
+    <nav class="asset-breadcrumb" aria-label="Du er her">
+      <a href={`${base}vis`}>VIS</a>
+      <span aria-hidden="true">/</span>
+      <span>Assets</span>
+      <span aria-hidden="true">/</span>
+      <span>Editorial</span>
+    </nav>
+
+    <header class="asset-hero">
+      <p class="asset-kicker">VIS Asset Browser v0.1</p>
+      <h1>Editorial Image Library</h1>
+      <p>
+        Editorial Image Library viser webklare kandidatbilder for MVP-artikler. Originaler og
+        arbeidsmateriale ligger utenfor repo. Dette er ikke en DAM.
+      </p>
+      <dl class="asset-stats" aria-label="Bibliotekstatus">
+        <div>
+          <dt>Bilder</dt>
+          <dd>{totalImages}</dd>
+        </div>
+        <div>
+          <dt>Grupper</dt>
+          <dd>{groupedImages.length}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>candidate</dd>
+        </div>
+      </dl>
+    </header>
+
+    <section class="asset-nav" aria-label="Grupper">
+      {groupedImages.map(({ group, label, items }) => (
+        <a href={`#${group}`}>
+          <span>{label}</span>
+          <strong>{items.length}</strong>
+        </a>
+      ))}
+    </section>
+
+    <div class="asset-groups">
+      {groupedImages.map(({ group, label, items }) => (
+        <section class="asset-group" id={group} aria-labelledby={`${group}-heading`}>
+          <header class="asset-group__header">
+            <div>
+              <p class="asset-kicker">Group</p>
+              <h2 id={`${group}-heading`}>{label}</h2>
+            </div>
+            <span>{items.length} bilder</span>
+          </header>
+
+          <ul class="asset-grid" role="list">
+            {items.map((entry) => (
+              <li class="asset-card">
+                <figure>
+                  <img src={pathForImage(entry)} alt={entry.alt} loading="lazy" decoding="async" />
+                </figure>
+                <div class="asset-card__body">
+                  <div class="asset-card__meta">
+                    <span>{entry.id}</span>
+                    <span>{entry.group}</span>
+                    <span>{entry.status}</span>
+                  </div>
+                  <p class="asset-card__label">Mulig bruk</p>
+                  <ul class="asset-uses" role="list">
+                    {entry.possibleUses.map((use) => (
+                      <li>{use}</li>
+                    ))}
+                  </ul>
+                  <p class="asset-card__label">Alt</p>
+                  <p class="asset-card__text">{entry.alt}</p>
+                  <p class="asset-card__label">Web path</p>
+                  <code class="asset-path">{entry.webPath}</code>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  </main>
+</PrototypeLayout>
+
+<style>
+  .asset-page {
+    min-height: 100vh;
+    background: #f4f5f5;
+    color: #17202c;
+    padding: 1.25rem;
+  }
+
+  @media (min-width: 720px) {
+    .asset-page {
+      padding: 2rem;
+    }
+  }
+
+  .asset-breadcrumb {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    color: #647084;
+    font-size: 0.75rem;
+  }
+
+  .asset-breadcrumb a {
+    color: #17202c;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .asset-hero {
+    margin-top: 1.25rem;
+    max-width: 62rem;
+    border: 1px solid #d8dde5;
+    border-radius: 0.75rem;
+    background: #fff;
+    padding: clamp(1rem, 2vw, 1.5rem);
+  }
+
+  .asset-kicker {
+    margin: 0;
+    color: #647084;
+    font-size: 0.68rem;
+    font-weight: 750;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .asset-hero h1,
+  .asset-group h2 {
+    margin: 0;
+    color: #111827;
+    font-size: clamp(1.45rem, 3vw, 2.15rem);
+    letter-spacing: -0.04em;
+    line-height: 1.05;
+  }
+
+  .asset-hero h1 {
+    margin-top: 0.35rem;
+  }
+
+  .asset-hero > p:not(.asset-kicker) {
+    max-width: 44rem;
+    margin: 0.7rem 0 0;
+    color: #4b5563;
+    font-size: 0.95rem;
+    line-height: 1.6;
+  }
+
+  .asset-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.65rem;
+    margin: 1rem 0 0;
+  }
+
+  .asset-stats div {
+    border: 1px solid #e1e5eb;
+    border-radius: 0.55rem;
+    background: #f8fafc;
+    padding: 0.75rem;
+  }
+
+  .asset-stats dt {
+    color: #647084;
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .asset-stats dd {
+    margin: 0.2rem 0 0;
+    color: #111827;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+
+  .asset-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-top: 1rem;
+    max-width: 72rem;
+  }
+
+  .asset-nav a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border: 1px solid #cfd5df;
+    border-radius: 999px;
+    background: #fff;
+    padding: 0.42rem 0.7rem;
+    color: #243042;
+    font-size: 0.78rem;
+    text-decoration: none;
+  }
+
+  .asset-nav strong {
+    color: #647084;
+    font-size: 0.72rem;
+  }
+
+  .asset-groups {
+    display: grid;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+  }
+
+  .asset-group {
+    max-width: 92rem;
+    scroll-margin-top: 1rem;
+  }
+
+  .asset-group__header {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid #d8dde5;
+    padding-bottom: 0.7rem;
+  }
+
+  .asset-group__header span {
+    flex: 0 0 auto;
+    color: #647084;
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+
+  .asset-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    margin: 1rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  @media (min-width: 720px) {
+    .asset-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 1100px) {
+    .asset-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 1440px) {
+    .asset-grid {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+
+  .asset-card {
+    overflow: hidden;
+    border: 1px solid #d8dde5;
+    border-radius: 0.75rem;
+    background: #fff;
+  }
+
+  .asset-card figure {
+    aspect-ratio: 16 / 11;
+    margin: 0;
+    background: #e9edf2;
+  }
+
+  .asset-card img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .asset-card__body {
+    padding: 0.85rem;
+  }
+
+  .asset-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .asset-card__meta span,
+  .asset-uses li {
+    border: 1px solid #d8dde5;
+    border-radius: 999px;
+    background: #f8fafc;
+    padding: 0.2rem 0.45rem;
+    color: #334155;
+    font-size: 0.68rem;
+    line-height: 1.2;
+  }
+
+  .asset-card__label {
+    margin: 0.8rem 0 0.35rem;
+    color: #647084;
+    font-size: 0.66rem;
+    font-weight: 750;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .asset-uses {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .asset-card__text {
+    margin: 0;
+    color: #4b5563;
+    font-size: 0.78rem;
+    line-height: 1.45;
+  }
+
+  .asset-path {
+    display: block;
+    overflow-wrap: anywhere;
+    border: 1px solid #d8dde5;
+    border-radius: 0.45rem;
+    background: #f8fafc;
+    padding: 0.5rem;
+    color: #1f2937;
+    font-size: 0.7rem;
+    line-height: 1.4;
+  }
+</style>

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -28,53 +28,47 @@ const chipClassByType = (kind: string) => {
   return "border-gray-300 bg-gray-50 text-gray-600 font-medium tracking-[0.06em]";
 };
 
-const topIngress = [
-  {
-    title: "Viddel Control Center",
-    description: "Felles inngang til canonical prosjektkunnskap, agentroller, standarder og aktive spor.",
-    href: `${base}vis/system/control-center`,
-    ready: true,
-  },
-  {
-    title: "Sprint preview — 2026-W21",
-    description: "VIS testbenk for #126 / MVP Design Lock — typography, tokens og primitives.",
-    href: `${base}vis/sprints/2026-w21`,
-    ready: true,
-  },
-  {
-    title: "Designsystem v0.1",
-    description: "Visuelt arbeidskart for tokens, surfaces, editorial patterns og Action-AI.",
-    href: `${base}vis/system/design-system-v01`,
-    ready: true,
-  },
-  {
-    title: "Roadmap (canonical)",
-    description: "Primar roadmapflate i VIS med spor, initiativ og oppgaver fra GitHub-bussen.",
-    href: `${base}vis/system/roadmap-timeline-v01`,
-    ready: true,
-  },
-  {
-    title: "GitHub runtime (@navigator)",
-    description: "Automatisk statusfeed (epics, 24t, blockers) fra GitHub — ikke kuratert VIS.",
-    href: `${base}vis/system/github-runtime-status`,
-    ready: true,
-  },
-  {
-    title: "System",
-    description: "Lettvekts referanseflater for landede systemsnitt.",
-    href: `${base}vis/system`,
-    ready: true,
-  },
+const mvpNowEntries = [
   {
     title: "Editorial Image Library",
-    description: "Intern asset browser for webklare kandidatbilder til MVP-artikler.",
-    href: `${base}vis/assets/editorial`,
+    description: "Webklare kandidatbilder for MVP-artikler og flater.",
+    href: `${base}vis/assets/editorial/`,
     ready: true,
   },
   {
-    title: "Siste endringer",
-    description: "Nylig oppdaterte artefakter i VIS-laget.",
-    href: "#siste-endringer",
+    title: "Review registry",
+    description: "Status og QA for pågående surface-arbeid.",
+    href: `${base}vis/review/`,
+    ready: true,
+  },
+  {
+    title: "Sprint preview 2026-W21",
+    description: "MVP Design Lock / surface work.",
+    href: `${base}vis/sprints/2026-w21/`,
+    ready: true,
+  },
+  {
+    title: "Forside production",
+    description: "Offentlig forside.",
+    href: `${base}no/`,
+    ready: true,
+  },
+  {
+    title: "Hjelp production",
+    description: "Praktisk hjelpeflate.",
+    href: `${base}no/hjelp/`,
+    ready: true,
+  },
+  {
+    title: "Bedre lyd production",
+    description: "Editorial/magasinflate.",
+    href: `${base}no/bedre-lyd/`,
+    ready: true,
+  },
+  {
+    title: "Spør Viddel production",
+    description: "Standalone AI-inngang.",
+    href: `${base}no/chat/`,
     ready: true,
   },
 ];
@@ -84,48 +78,48 @@ const topIngress = [
   <main class="px-4 py-6 sm:px-6 sm:py-8">
     <h1 class="text-lg font-semibold text-gray-900">VIS operativ oversikt</h1>
     <p class="mt-2 max-w-prose text-sm text-gray-600">
-      KURATERT visningslag over viktige artefakter i{" "}
-      <code class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs">public/vis/raw/</code>. GitHub Projects er fortsatt source of truth for oppgaveflyt.
+      VIS er intern visnings- og reviewflate for Viddel MVP. GitHub Projects er fortsatt oppgavebuss.
     </p>
+
+    <section class="mt-6 rounded-md border border-gray-300 bg-gray-50 px-3 py-3">
+      <div class="flex items-center justify-between gap-3">
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-800">MVP nå</h2>
+        <span class="text-[10px] font-medium uppercase tracking-wide text-gray-500">Aktuelle flater</span>
+      </div>
+      <div class="mt-3 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+        {mvpNowEntries.map((item) => (
+          <a
+            href={item.href}
+            class="border-l-2 border-gray-300 px-2 py-1.5 hover:border-gray-500"
+          >
+            <p class="text-sm font-semibold text-gray-900">{item.title}</p>
+            <p class="mt-1 text-xs leading-relaxed text-gray-600">{item.description}</p>
+            {!item.ready ? (
+              <span class="mt-2 inline-flex rounded-sm border border-gray-300 bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600">
+                Klargjøres
+              </span>
+            ) : null}
+          </a>
+        ))}
+      </div>
+      <p class="mt-3 text-xs text-gray-500">
+        Follow-up: VIS frontpage should later be generated from a small registry rather than manually curated cards.
+      </p>
+    </section>
 
     {
       entries.length === 0 ? (
         <p class="mt-6 text-sm text-gray-500">
-          Ingen <code class="font-mono">.html</code>-filer funnet. Legg filer i{" "}
-          <code class="font-mono">public/vis/raw/</code> og bygg på nytt.
+          Ingen historiske <code class="font-mono">.html</code>-artefakter funnet i{" "}
+          <code class="font-mono">public/vis/raw/</code>.
         </p>
       ) : (
         <>
-          <section class="mt-6 rounded-md border border-gray-300 bg-gray-50 px-3 py-3">
-            <div class="flex items-center justify-between gap-3">
-              <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-800">Operativt nå</h2>
-              <span class="text-[10px] font-medium uppercase tracking-wide text-gray-500">Kontrollsenter</span>
-            </div>
-            <div class="mt-3 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
-              {topIngress.map((item) => (
-                <a
-                  href={item.href}
-                  class="border-l-2 border-gray-300 px-2 py-1.5 hover:border-gray-500"
-                >
-                  <p class="text-sm font-semibold text-gray-900">{item.title}</p>
-                  <p class="mt-1 text-xs leading-relaxed text-gray-600">{item.description}</p>
-                  {!item.ready ? (
-                    <span class="mt-2 inline-flex rounded-sm border border-gray-300 bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600">
-                      Klargjøres
-                    </span>
-                  ) : null}
-                </a>
-              ))}
-            </div>
-            <p class="mt-3 text-xs text-gray-500">
-              Pensjonert fra aktiv bruk: <code class="font-mono">/vis/KlarLyd_Live_Board_Roadmap_v01</code> og{" "}
-              <code class="font-mono">/vis/system/task-bus-live</code>. Bruk{" "}
-              <code class="font-mono">/vis/system/roadmap-timeline-v01</code> som canonical roadmap.
+          <section class="mt-8">
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-800">Arkiv / eldre prototyper</h2>
+            <p class="mt-1 max-w-prose text-xs leading-relaxed text-gray-600">
+              Historiske wireframes og eldre VIS-dokumenter er fortsatt tilgjengelige, men de er ikke primær inngang til dagens MVP-arbeid.
             </p>
-          </section>
-
-          <section class="mt-7">
-            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-800">Fremhevet nå</h2>
             <ul class="mt-2.5 grid gap-2.5 p-0 sm:grid-cols-2">
               {featured.map(({ filename: name, slug, displayTitle, description, visType }) => {
                 const view = `${base}vis/${encodeURIComponent(slug)}`;
@@ -153,7 +147,7 @@ const topIngress = [
           </section>
 
           <section class="mt-8">
-            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-700">Kategorisert oversikt</h2>
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-700">Historiske wireframes og dokumenter</h2>
             <div class="mt-2.5 space-y-2.5">
               {grouped.map((group) => (
                 <section class="rounded-md border border-gray-300 bg-white">
@@ -203,7 +197,7 @@ const topIngress = [
           </section>
 
           <section id="siste-endringer" class="mt-8">
-            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-700">Siste endringer</h2>
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-700">Siste endringer i arkivet</h2>
             {recent.length > 0 ? (
               <ul class="mt-2.5 rounded-md border border-gray-300 bg-white">
                 {recent.map(({ filename: name, slug, displayTitle, visUpdatedRaw }) => {

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -66,6 +66,12 @@ const topIngress = [
     ready: true,
   },
   {
+    title: "Editorial Image Library",
+    description: "Intern asset browser for webklare kandidatbilder til MVP-artikler.",
+    href: `${base}vis/assets/editorial`,
+    ready: true,
+  },
+  {
     title: "Siste endringer",
     description: "Nylig oppdaterte artefakter i VIS-laget.",
     href: "#siste-endringer",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -178,6 +178,18 @@ export const reviewRegistry: ReviewRegistryItem[] = [
       "Bedre lyd R5: magazine top, edge-to-edge card images, grey editorial labels, CTA/copy cleanup. Bedre lyd beholdes som CBA; Tips/Life hacks parkert.",
   },
   {
+    id: "editorial-image-library-browser",
+    title: "Editorial Image Library browser",
+    href: "/vis/assets/editorial/",
+    sprint: "2026-W21",
+    issue: "#125K",
+    type: "active",
+    status: "in-review",
+    stakeholderSafe: true,
+    description:
+      "VIS Asset Browser v0.1: intern reviewflate for 173 webklare editorial image-kandidater fra manifestet.",
+  },
+  {
     id: "interaction-states",
     title: "Interaction states",
     href: "/vis/sprints/2026-w21/primitives/interaction-states/",

--- a/src/pages/vis/review/_data.ts
+++ b/src/pages/vis/review/_data.ts
@@ -187,7 +187,7 @@ export const reviewRegistry: ReviewRegistryItem[] = [
     status: "in-review",
     stakeholderSafe: true,
     description:
-      "VIS Asset Browser v0.1: intern reviewflate for 173 webklare editorial image-kandidater fra manifestet.",
+      "VIS Asset Browser v0.1 added and /vis/ refreshed for current MVP work. Follow-up: more automatic VIS index/registry.",
   },
   {
     id: "interaction-states",


### PR DESCRIPTION
## Summary
- Adds `/vis/assets/editorial/`, an internal VIS browser for Editorial Image Library candidates.
- Groups 173 manifest entries by asset group with thumbnails, counts, possible uses, alt text and webPath.
- Links the browser from `/vis`, adds a review registry entry, and documents the route in `docs/assets/editorial-image-library-v01.md`.

## Test plan
- `npm run build`
- Verified generated `/vis/assets/editorial/` contains 173 asset cards.
- ReadLints on touched VIS/data files: no errors.

## Scope
- No public pages changed.
- No image files moved, recompressed or edited.
- No upload/edit/tagging/Drive sync or full VIS Asset Registry.


Made with [Cursor](https://cursor.com)