### PR TITLE
Test Access Gate v0.1 (#181)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ GOOGLE_SERVICE_ACCOUNT_JSON=
 # Create at https://console.upstash.com/ — REST API URL + token.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+
+# Test access gate (#181) — server-side only; required in Vercel Production before public AI testing.
+# Set a shared test code for invited testers on /no/chat/. Never commit the real value.
+VIDDEL_CHAT_ACCESS_CODE=

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -49,7 +49,7 @@ export type RecentChange = {
 export const mvpCurrentState = {
   updatedAt: "2026-05-30",
   currentFocus:
-    "Public AI guard v0.1 implementert på /api/chat (#180). Neste: QA guard, deretter Upstash + CES production env-vars før AI aktivering.",
+    "Test Access Gate v0.1 (#181) — enkel testkode før CES production env-vars og offentlig AI-test.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -83,10 +83,10 @@ export const mvpCurrentState = {
       label: "Spør Viddel",
       route: "/no/chat/",
       status: "Applied",
-      note: "Production UI live. Public AI guard v0.1 on /api/chat (Needs QA). AI blocked until Upstash + CES prod env-vars.",
+      note: "Production UI live. Public AI guard v0.1 applied (#180). Test Access Gate v0.1 (#181) — Needs QA. AI blocked until access code + CES prod env-vars.",
       visFrontpage: true,
       kind: "public",
-      frontpageDescription: "Standalone headless AI — guard på plass, prod AI venter Upstash + CES.",
+      frontpageDescription: "Standalone headless AI — guard + test access gate, prod AI venter CES.",
     },
     {
       id: "designsystem",
@@ -126,19 +126,14 @@ export const mvpCurrentState = {
   ] satisfies CanonicalReference[],
   nextRisks: [
     {
-      id: "public-ai-guard-qa",
-      label: "Public AI guard v0.1 — QA",
-      detail: "Rate limit + origin guard implementert (#180). QA på preview før prod Upstash + CES.",
-    },
-    {
-      id: "upstash-prod-env",
-      label: "Upstash Redis (production)",
-      detail: "UPSTASH_REDIS_REST_URL + TOKEN i Vercel Production — påkrevd før public AI.",
+      id: "test-access-gate-qa",
+      label: "Test Access Gate v0.1 — QA",
+      detail: "Sett VIDDEL_CHAT_ACCESS_CODE i Vercel Production etter merge. QA gate + guard før CES prod env-vars (#181).",
     },
     {
       id: "ces-prod-env",
       label: "CES production env-vars",
-      detail: "Sett CES i Vercel Production etter guard QA og Upstash — aktiverer ikke AI alene uten Upstash.",
+      detail: "Sett CES i Vercel Production etter Test Access Gate QA — aktiverer ikke AI alene uten Upstash + access code.",
     },
     {
       id: "transcript-qa",
@@ -157,6 +152,12 @@ export const mvpCurrentState = {
     },
   ] satisfies NextRisk[],
   recentChanges: [
+    {
+      date: "2026-05-30",
+      summary: "Test Access Gate v0.1 — testkode for /no/chat/ og /api/chat (#181)",
+      issue: "#181",
+      commit: "—",
+    },
     {
       date: "2026-05-30",
       summary: "Public AI guard v0.1 — rate limit + origin guard on /api/chat (#180)",

--- a/src/lib/chat-api-access-gate.ts
+++ b/src/lib/chat-api-access-gate.ts
@@ -1,0 +1,73 @@
+/* CONTRACT: Server-side test access gate for POST /api/chat (#181). */
+
+import { timingSafeEqual } from "node:crypto";
+
+export const CHAT_ACCESS_ENV_KEY = "VIDDEL_CHAT_ACCESS_CODE";
+
+export const CHAT_ACCESS_MESSAGES = {
+  denied: "Du trenger en gyldig testkode for å bruke Spør Viddel.",
+  unavailable: "Spør Viddel er ikke åpnet for testing akkurat nå.",
+} as const;
+
+function readEnv(name: string): string {
+  return (process.env[name] ?? import.meta.env[name] ?? "").trim();
+}
+
+function isVercelProduction(): boolean {
+  return readEnv("VERCEL_ENV") === "production";
+}
+
+/** Production always enforces; preview/dev enforce only when env code is set (for local/preview QA). */
+export function isChatAccessGateEnforced(): boolean {
+  if (isVercelProduction()) return true;
+  return Boolean(readEnv(CHAT_ACCESS_ENV_KEY));
+}
+
+function getConfiguredAccessCode(): string {
+  return readEnv(CHAT_ACCESS_ENV_KEY);
+}
+
+function safeCompare(provided: string, expected: string): boolean {
+  if (!provided || !expected) return false;
+  const providedBuf = Buffer.from(provided, "utf8");
+  const expectedBuf = Buffer.from(expected, "utf8");
+  if (providedBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(providedBuf, expectedBuf);
+}
+
+export type AccessGateCheckResult =
+  | { ok: true; skipped?: boolean }
+  | { ok: false; status: 403 | 503; error: string; message: string };
+
+/** Fail closed in production when access code env is missing. */
+export function checkChatAccessCode(accessCode: unknown): AccessGateCheckResult {
+  if (!isChatAccessGateEnforced()) {
+    return { ok: true, skipped: true };
+  }
+
+  const configured = getConfiguredAccessCode();
+  if (!configured) {
+    if (isVercelProduction()) {
+      console.error("[api/chat] access_gate_unconfigured");
+      return {
+        ok: false,
+        status: 503,
+        error: "access_unavailable",
+        message: CHAT_ACCESS_MESSAGES.unavailable,
+      };
+    }
+    return { ok: true, skipped: true };
+  }
+
+  const provided = typeof accessCode === "string" ? accessCode.trim() : "";
+  if (!provided || !safeCompare(provided, configured)) {
+    return {
+      ok: false,
+      status: 403,
+      error: "access_denied",
+      message: CHAT_ACCESS_MESSAGES.denied,
+    };
+  }
+
+  return { ok: true };
+}

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,5 +1,6 @@
 /* CONTRACT: Server proxy for CES runSession — validates input, guards, never exposes credentials or diagnosticInfo. */
 import type { APIRoute } from "astro";
+import { checkChatAccessCode } from "../../lib/chat-api-access-gate";
 import {
   CHAT_GUARD_MESSAGES,
   CHAT_MAX_MESSAGE_LENGTH,
@@ -16,6 +17,7 @@ const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-_]{4,62}$/;
 type ChatRequestBody = {
   message?: unknown;
   sessionId?: unknown;
+  accessCode?: unknown;
 };
 
 function jsonResponse(body: Record<string, unknown>, status: number): Response {
@@ -34,6 +36,11 @@ export const POST: APIRoute = async ({ request }) => {
       { error: "invalid_json", message: CHAT_GUARD_MESSAGES.invalidRequest },
       400,
     );
+  }
+
+  const accessCheck = checkChatAccessCode(body.accessCode);
+  if (!accessCheck.ok) {
+    return jsonResponse({ error: accessCheck.error, message: accessCheck.message }, accessCheck.status);
   }
 
   const message = typeof body.message === "string" ? body.message.trim() : "";

--- a/src/pages/no/chat.astro
+++ b/src/pages/no/chat.astro
@@ -1,10 +1,13 @@
 ---
 /* CONTRACT: Standalone Viddel AI chat — headless CES via /api/chat, no widget. #125M-C R1 */
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { isChatAccessGateEnforced } from "../../lib/chat-api-access-gate";
 import "../../styles/r1-dialog-article.css";
 import "../../styles/viddel-standalone-chat.css";
 
 Astro.response.headers.set("X-Robots-Tag", "noindex, follow");
+
+const accessGateEnforced = isChatAccessGateEnforced();
 
 const exampleQuestions = [
   "Hvordan kobler jeg høreapparatet til mobilen?",
@@ -26,7 +29,7 @@ const aiHeadingId = "viddel-standalone-chat-ai";
 >
   <meta slot="head" name="robots" content="noindex,follow" />
 
-  <main class="viddel-chat-standalone" data-viddel-chat>
+  <main class="viddel-chat-standalone" data-viddel-chat data-access-gate-enforced={accessGateEnforced ? "true" : "false"}>
     <div class="r1-editorial-container">
       <div data-r1-editorial class="viddel-chat-standalone__editorial">
         <header class="viddel-chat-standalone__intro" data-viddel-chat-intro aria-labelledby="viddel-chat-title">
@@ -41,7 +44,32 @@ const aiHeadingId = "viddel-standalone-chat-ai";
           </p>
         </header>
 
-        <section class="r1-ai-bridge px-0.5 py-1">
+        <section
+          class="viddel-chat-standalone__access-gate hidden"
+          data-viddel-chat-access-gate
+          aria-labelledby="viddel-chat-access-title"
+        >
+          <h2 id="viddel-chat-access-title" class="viddel-chat-standalone__access-title">Testtilgang</h2>
+          <p class="viddel-chat-standalone__access-lede">Skriv inn testkoden for å prøve Spør Viddel.</p>
+          <form class="viddel-chat-standalone__access-form" data-viddel-chat-access-form>
+            <label class="viddel-chat-standalone__access-label" for="viddel-chat-access-input">Testkode</label>
+            <input
+              id="viddel-chat-access-input"
+              data-viddel-chat-access-input
+              class="viddel-chat-standalone__access-input"
+              type="password"
+              autocomplete="off"
+              placeholder="Testkode"
+              required
+            />
+            <button type="submit" class="viddel-chat-standalone__access-submit" data-viddel-chat-access-submit>
+              Åpne Spør Viddel
+            </button>
+          </form>
+          <p class="viddel-chat-standalone__access-error hidden" data-viddel-chat-access-error role="alert"></p>
+        </section>
+
+        <section class="r1-ai-bridge px-0.5 py-1" data-viddel-chat-panel>
           <section
             class="inline-chat-shell"
             aria-labelledby={aiHeadingId}
@@ -138,6 +166,13 @@ const aiHeadingId = "viddel-standalone-chat-ai";
   <script is:inline>
     (() => {
       const root = document.querySelector("[data-viddel-chat]");
+      const accessGateEnforced = root?.getAttribute("data-access-gate-enforced") === "true";
+      const accessGate = document.querySelector("[data-viddel-chat-access-gate]");
+      const accessForm = document.querySelector("[data-viddel-chat-access-form]");
+      const accessInput = document.querySelector("[data-viddel-chat-access-input]");
+      const accessSubmit = document.querySelector("[data-viddel-chat-access-submit]");
+      const accessError = document.querySelector("[data-viddel-chat-access-error]");
+      const chatPanel = document.querySelector("[data-viddel-chat-panel]");
       const shell = document.querySelector("[data-viddel-chat-shell]");
       const intro = document.querySelector("[data-viddel-chat-intro]");
       const header = shell?.querySelector("[data-inline-chat-header]");
@@ -154,6 +189,7 @@ const aiHeadingId = "viddel-standalone-chat-ai";
 
       if (
         !root ||
+        !chatPanel ||
         !shell ||
         !intro ||
         !header ||
@@ -171,7 +207,9 @@ const aiHeadingId = "viddel-standalone-chat-ai";
       }
 
       const SESSION_KEY = "viddel-chat-session";
+      const ACCESS_KEY = "viddel-chat-access";
       const SESSION_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-_]{4,62}$/;
+      const ACCESS_VERIFY_SESSION = "viddel-access-verify";
       const params = new URLSearchParams(window.location.search);
       const seedFromUrl = (params.get("seed") || params.get("q") || "").trim();
 
@@ -179,6 +217,71 @@ const aiHeadingId = "viddel-standalone-chat-ai";
       let hasConversation = false;
       let pendingSeed = seedFromUrl;
       let activeTurn = null;
+      let storedAccessCode = "";
+
+      const readStoredAccessCode = () => {
+        try {
+          const value = localStorage.getItem(ACCESS_KEY);
+          return typeof value === "string" ? value.trim() : "";
+        } catch (_) {
+          return "";
+        }
+      };
+
+      const writeStoredAccessCode = (value) => {
+        try {
+          localStorage.setItem(ACCESS_KEY, value);
+        } catch (_) {}
+      };
+
+      const showAccessGate = () => {
+        accessGate?.classList.remove("hidden");
+        chatPanel.classList.add("hidden");
+      };
+
+      const hideAccessGate = () => {
+        accessGate?.classList.add("hidden");
+        chatPanel.classList.remove("hidden");
+      };
+
+      const showAccessError = (message) => {
+        if (!accessError) return;
+        accessError.textContent = message;
+        accessError.classList.remove("hidden");
+      };
+
+      const clearAccessError = () => {
+        if (!accessError) return;
+        accessError.textContent = "";
+        accessError.classList.add("hidden");
+      };
+
+      const isAccessGrantedResponse = (response, payload) => {
+        if (response.ok) return true;
+        if (payload?.error === "configuration_missing") return true;
+        if (payload?.error === "guard_unavailable") return true;
+        return false;
+      };
+
+      const verifyAccessCode = async (accessCode) => {
+        const response = await fetch("/api/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            message: "test",
+            sessionId: ACCESS_VERIFY_SESSION,
+            accessCode,
+          }),
+        });
+        const payload = await response.json().catch(() => ({}));
+        return { response, payload };
+      };
+
+      const grantAccess = (accessCode) => {
+        storedAccessCode = accessCode;
+        writeStoredAccessCode(accessCode);
+        hideAccessGate();
+      };
 
       const ensureSessionId = () => {
         try {
@@ -269,6 +372,12 @@ const aiHeadingId = "viddel-standalone-chat-ai";
         if (typeof payload?.message === "string" && payload.message.trim()) {
           return payload.message.trim();
         }
+        if (payload?.error === "access_denied") {
+          return "Du trenger en gyldig testkode for å bruke Spør Viddel.";
+        }
+        if (payload?.error === "access_unavailable") {
+          return "Spør Viddel er ikke åpnet for testing akkurat nå.";
+        }
         if (payload?.error === "configuration_missing") {
           return "Viddel er ikke tilgjengelig akkurat nå. Prøv igjen om litt.";
         }
@@ -292,14 +401,19 @@ const aiHeadingId = "viddel-standalone-chat-ai";
         input.disabled = true;
         setLoading(true);
 
+        const requestBody = {
+          message,
+          sessionId: ensureSessionId(),
+        };
+        if (accessGateEnforced && storedAccessCode) {
+          requestBody.accessCode = storedAccessCode;
+        }
+
         try {
           const response = await fetch("/api/chat", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              message,
-              sessionId: ensureSessionId(),
-            }),
+            body: JSON.stringify(requestBody),
           });
 
           const payload = await response.json().catch(() => ({}));
@@ -354,19 +468,75 @@ const aiHeadingId = "viddel-standalone-chat-ai";
 
       window.addEventListener("resize", syncComposeReserve, { passive: true });
 
-      if (pendingSeed) {
-        input.value = pendingSeed;
-        window.setTimeout(() => {
-          if (pendingSeed) {
-            sendMessage(pendingSeed);
-            pendingSeed = "";
-          }
-        }, 120);
-      } else {
-        input.focus();
-      }
+      const initChat = () => {
+        if (pendingSeed) {
+          input.value = pendingSeed;
+          window.setTimeout(() => {
+            if (pendingSeed) {
+              sendMessage(pendingSeed);
+              pendingSeed = "";
+            }
+          }, 120);
+        } else {
+          input.focus();
+        }
 
-      syncComposeReserve();
+        syncComposeReserve();
+      };
+
+      if (accessGateEnforced) {
+        storedAccessCode = readStoredAccessCode();
+        if (storedAccessCode) {
+          hideAccessGate();
+          initChat();
+        } else if (accessForm && accessInput && accessSubmit) {
+          showAccessGate();
+          accessForm.addEventListener("submit", async (event) => {
+            event.preventDefault();
+            clearAccessError();
+            const code = (accessInput.value || "").trim();
+            if (!code) {
+              showAccessError("Koden stemmer ikke. Prøv igjen.");
+              return;
+            }
+
+            accessSubmit.disabled = true;
+            accessInput.disabled = true;
+
+            try {
+              const { response, payload } = await verifyAccessCode(code);
+              if (payload?.error === "access_denied") {
+                showAccessError("Koden stemmer ikke. Prøv igjen.");
+                return;
+              }
+              if (payload?.error === "access_unavailable") {
+                showAccessError(
+                  typeof payload.message === "string" && payload.message.trim()
+                    ? payload.message.trim()
+                    : "Spør Viddel er ikke åpnet for testing akkurat nå.",
+                );
+                return;
+              }
+              if (!isAccessGrantedResponse(response, payload)) {
+                showAccessError("Vi fikk ikke tak i svaret akkurat nå. Prøv igjen.");
+                return;
+              }
+
+              grantAccess(code);
+              initChat();
+            } catch (_) {
+              showAccessError("Nettverksfeil. Sjekk tilkoblingen og prøv igjen.");
+            } finally {
+              accessSubmit.disabled = false;
+              accessInput.disabled = false;
+            }
+          });
+        } else {
+          initChat();
+        }
+      } else {
+        initChat();
+      }
     })();
   </script>
 </BaseLayout>

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -45,6 +45,91 @@ body.vox-shell--standalone-chat #ces-widget {
   color: rgb(var(--text));
 }
 
+.viddel-chat-standalone__access-gate {
+  margin-top: 1.25rem;
+  max-width: 24rem;
+}
+
+.viddel-chat-standalone__access-title {
+  font-family: var(--font-display, inherit);
+  font-size: 1.05rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  color: rgb(var(--text));
+}
+
+.viddel-chat-standalone__access-lede {
+  margin-top: 0.45rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: rgb(var(--muted));
+}
+
+.viddel-chat-standalone__access-form {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.9rem;
+}
+
+.viddel-chat-standalone__access-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgb(var(--text));
+}
+
+.viddel-chat-standalone__access-input {
+  background: rgb(var(--surface));
+  border: 1px solid rgb(var(--border) / 0.55);
+  border-radius: 0.75rem;
+  color: rgb(var(--text));
+  font: inherit;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  padding: 0.55rem 0.75rem;
+  width: 100%;
+}
+
+.viddel-chat-standalone__access-input::placeholder {
+  color: rgb(var(--reading-ink-secondary) / 0.72);
+}
+
+.viddel-chat-standalone__access-input:focus-visible {
+  border-color: rgb(var(--reading-accent-iris) / 0.46);
+  outline: 2px solid rgb(var(--reading-accent-iris) / 0.28);
+  outline-offset: 2px;
+}
+
+.viddel-chat-standalone__access-submit {
+  align-self: start;
+  background: rgb(var(--reading-ink));
+  border: 0;
+  border-radius: 999px;
+  color: rgb(var(--surface));
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 650;
+  padding: 0.62rem 1.05rem;
+}
+
+.viddel-chat-standalone__access-submit:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.viddel-chat-standalone__access-submit:focus-visible {
+  outline: 2px solid rgb(var(--reading-accent-iris) / 0.42);
+  outline-offset: 3px;
+}
+
+.viddel-chat-standalone__access-error {
+  margin: 0.65rem 0 0;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: rgb(var(--text));
+}
+
 /* --- ArticleInlineChatShell.astro global styles (progressive + compose) --- */
 
 .inline-chat-shell__transcript {


### PR DESCRIPTION
## Summary
- Server-side test access gate on `/api/chat` before existing guards (#181)
- Simple test code UI on `/no/chat/` with localStorage persistence for UX
- New env var `VIDDEL_CHAT_ACCESS_CODE` documented in `.env.example`

## Test plan
- [ ] Set `VIDDEL_CHAT_ACCESS_CODE` in Vercel Preview
- [ ] `/no/chat/` shows Testtilgang gate without stored code
- [ ] Wrong code → «Koden stemmer ikke. Prøv igjen.»
- [ ] Valid code → chat visible; POST passes access check → `configuration_missing` (no CES yet)
- [ ] Direct POST without code → `403 access_denied`
- [ ] Rate limit + max length still work after valid access
- [ ] Other surfaces unchanged


Made with [Cursor](https://cursor.com)