### PR TITLE
VIS IA / Frontpage mandate v0.1

### DIFF
--- a/docs/project/OPERATING_RULES.md
+++ b/docs/project/OPERATING_RULES.md
@@ -7,8 +7,8 @@ Operative regler for Cursor, Codex og menneskelig HITL i Viddel Lab.
 | Flate | Rolle |
 |-------|--------|
 | `/designsystem/` | Gjeldende designsystem-sannhet (mønstre, primitives, applied surfaces) |
-| `src/data/mvp-current-state.ts` | Gjeldende operativ MVP-status |
-| `/vis/sprints/...` | Historikk og beslutningsgrunnlag |
+| `src/data/mvp-current-state.ts` | Gjeldende operativ MVP-status og `currentSprint` |
+| `/vis/sprints/...` | Aktiv sprint (control room) eller historikk (arkiv) — avhenger av `currentSprint.status` |
 | GitHub Projects / issues | Oppgavebuss |
 | VIS (`/vis/`) | Intern reviewflate — leser MVP-status fra registry |
 
@@ -26,6 +26,21 @@ Hvis en oppgave endrer **MVP-status**, public flater, designmønstre, AI-status,
 → oppdater `src/data/mvp-current-state.ts`
 
 VIS-forsiden (`/vis/`) henter «MVP nå» fra denne filen. Ikke hardkod statuskort i VIS-forsiden.
+
+## B2. VIS sprint guard (maskinlesbar)
+
+Aktiv sprint styres av `mvpCurrentState.currentSprint` i `src/data/mvp-current-state.ts`:
+
+- `status: "active"` → vises som **Denne sprinten** i kontrollrom og som primær hub. **Ikke** i «Historikk / arkiv».
+- `status: "closed"` → flytt til `closedSprints[]` og vis kun i arkiv.
+
+Ved sprintskifte:
+
+1. Sett gammel sprint til `closed` og legg den i `closedSprints`.
+2. Oppdater `currentSprint` med ny id, route, label og `status: "active"`.
+3. Kjør `npm run verify:vis-sprint-guard` (kjøres automatisk før `npm run build`).
+
+Validering: `src/lib/vis-sprint-guard.ts` — aktiv sprint kan ikke ligge i `closedSprints` eller eksponeres som `historikk`-hub.
 
 ## C. VIS frontpage-regel
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs && astro build",
+    "verify:vis-sprint-guard": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "storyblok:bootstrap:slice01": "node scripts/storyblok-bootstrap-slice-01.mjs",

--- a/scripts/verify-vis-sprint-guard.mjs
+++ b/scripts/verify-vis-sprint-guard.mjs
@@ -1,0 +1,14 @@
+/* CONTRACT: Build-time check — active sprint must not be archived on VIS. */
+import { validateVisSprintGuard } from "../src/lib/vis-sprint-guard.ts";
+
+const errors = validateVisSprintGuard();
+
+if (errors.length > 0) {
+  console.error("VIS sprint guard failed:\n");
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log("VIS sprint guard OK");

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -112,7 +112,7 @@ export const mvpCurrentState = {
       label: "Review registry",
       route: "/vis/review/",
       role: "Stakeholder review og surface QA",
-      visFrontpage: true,
+      visFrontpage: false,
       frontpageDescription: "Status og QA for pågående surface-arbeid.",
     },
     {
@@ -120,7 +120,7 @@ export const mvpCurrentState = {
       label: "Sprint preview 2026-W21",
       route: "/vis/sprints/2026-w21/",
       role: "Historikk · guardrails · produktanatomi",
-      visFrontpage: true,
+      visFrontpage: false,
       frontpageDescription: "MVP Design Lock — historikk og beslutningsgrunnlag.",
     },
   ] satisfies CanonicalReference[],
@@ -164,8 +164,8 @@ export const mvpCurrentState = {
   recentChanges: [
     {
       date: "2026-05-30",
-      summary: "CES production env-vars aktivert — /no/chat/ live AI i production (intern test)",
-      issue: "#180",
+      summary: "VIS IA / frontpage mandate v0.1 — hub & spoke struktur på /vis/",
+      issue: "—",
       commit: "—",
     },
     {

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -46,8 +46,36 @@ export type RecentChange = {
   commit?: string;
 };
 
+export type SprintStatus = "active" | "closed";
+
+/** Canonical active sprint — VIS control room reads this; never label active sprint as historikk. */
+export type CurrentSprint = {
+  id: string;
+  label: string;
+  route: string;
+  status: SprintStatus;
+  weekFocus: string;
+  issue?: string;
+};
+
+export type ClosedSprint = {
+  id: string;
+  label: string;
+  route: string;
+  closedAt?: string;
+};
+
 export const mvpCurrentState = {
   updatedAt: "2026-05-30",
+  currentSprint: {
+    id: "2026-w21",
+    label: "2026-W21",
+    route: "/vis/sprints/2026-w21/",
+    status: "active",
+    weekFocus: "MVP Design Lock v0.1 — intern AI-test, backstage og monitoring før ekstern deling.",
+    issue: "#126",
+  } satisfies CurrentSprint,
+  closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
     "CES production live på /no/chat/ — intern test med Thomas og Vibeke. Upstash guard aktiv (#180). Access Gate (#181) parkert/revertet. Neste: AI usage monitoring v0.1 og Backstage v0.1 før ekstern deling.",
   mvpSurfaces: [
@@ -119,9 +147,9 @@ export const mvpCurrentState = {
       id: "sprint-w21",
       label: "Sprint preview 2026-W21",
       route: "/vis/sprints/2026-w21/",
-      role: "Historikk · guardrails · produktanatomi",
+      role: "Aktiv sprint — labs, guardrails og beslutningsgrunnlag",
       visFrontpage: false,
-      frontpageDescription: "MVP Design Lock — historikk og beslutningsgrunnlag.",
+      frontpageDescription: "Operativ sprintflate for 2026-W21.",
     },
   ] satisfies CanonicalReference[],
   nextRisks: [
@@ -164,8 +192,8 @@ export const mvpCurrentState = {
   recentChanges: [
     {
       date: "2026-05-30",
-      summary: "VIS IA / frontpage mandate v0.1 — hub & spoke struktur på /vis/",
-      issue: "—",
+      summary: "VIS sprint guard — currentSprint registry; W21 aktiv i kontrollrom",
+      issue: "#185",
       commit: "—",
     },
     {
@@ -225,9 +253,29 @@ export function getVisFrontpageEntries(baseUrl: string): VisFrontpageEntry[] {
     title: r.label,
     description: r.frontpageDescription ?? r.role,
     href: `${base}${r.route.replace(/^\//, "")}`,
-    status: r.id === "sprint-w21" ? "Historikk" : "Reference",
+    status:
+      r.id === "sprint-w21"
+        ? mvpCurrentState.currentSprint.status === "active"
+          ? "Aktiv sprint"
+          : "Historikk"
+        : "Reference",
     kind: "reference" as const,
   }));
 
   return [...surfaceEntries, ...refEntries];
+}
+
+/** Active sprint for VIS control room — derived from registry. */
+export function getCurrentSprintVisEntry(baseUrl: string) {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const sprint = mvpCurrentState.currentSprint;
+  return {
+    id: sprint.id,
+    title: `Sprint ${sprint.label}`,
+    href: `${base}${sprint.route.replace(/^\//, "")}`,
+    status: sprint.status === "active" ? "Aktiv sprint" : "Historikk",
+    weekFocus: sprint.weekFocus,
+    issue: sprint.issue,
+    isActive: sprint.status === "active",
+  };
 }

--- a/src/data/vis-frontpage-hubs-v01.ts
+++ b/src/data/vis-frontpage-hubs-v01.ts
@@ -1,0 +1,101 @@
+/* CONTRACT: VIS frontpage hub definitions v0.1 — mandate, links and active/planned status for /vis/ IA. */
+
+export type VisHubAvailability = "active" | "planned" | "historikk";
+
+export type VisFrontpageHub = {
+  id: string;
+  title: string;
+  mandate: string;
+  href?: string;
+  availability: VisHubAvailability;
+  statusLabel: string;
+  issue?: string;
+};
+
+/** Main hubs on VIS frontpage — hub & spoke model, not backlog. */
+export function getVisFrontpageHubs(baseUrl: string): VisFrontpageHub[] {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+
+  return [
+    {
+      id: "designsystem",
+      title: "Designsystem",
+      mandate: "Gjeldende UI-mønstre, komponenter og applied surfaces.",
+      href: `${base}designsystem/`,
+      availability: "active",
+      statusLabel: "Applied / Canonical",
+    },
+    {
+      id: "backstage",
+      title: "Backstage",
+      mandate: "Hvordan AI, API, guards, env-vars, feilstater og production fungerer.",
+      availability: "planned",
+      statusLabel: "Planned · Next",
+      issue: "#184",
+    },
+    {
+      id: "gitbuss",
+      title: "Gitbuss",
+      mandate:
+        "Operativ oversikt over GitHub issues, arbeidsspor og Return Tickets. GitHub er source of truth for oppgaver — VIS viser inngang og status.",
+      href: `${base}vis/system/github-runtime-status`,
+      availability: "active",
+      statusLabel: "Runtime feed",
+    },
+    {
+      id: "roadmap",
+      title: "Roadmap",
+      mandate: "Retning og kommende faser for MVP. Viser neste større bevegelse, ikke alle småoppgaver.",
+      href: `${base}vis/system/roadmap-timeline-v01`,
+      availability: "active",
+      statusLabel: "Retning / faser",
+    },
+    {
+      id: "dam",
+      title: "DAM / bildebank",
+      mandate: "Visuelle assets, bildebruk, prompt-/asset-kilder og hvilke bilder som er aktuelle for MVP.",
+      href: `${base}vis/assets/editorial`,
+      availability: "active",
+      statusLabel: "Editorial library v0.2",
+    },
+    {
+      id: "review",
+      title: "Review",
+      mandate: "Flater for QA, sammenligning og godkjenning.",
+      href: `${base}vis/review/`,
+      availability: "active",
+      statusLabel: "Review registry",
+    },
+    {
+      id: "sprint",
+      title: "Sprint / historikk",
+      mandate: "Hvordan vi kom hit. Ikke gjeldende sannhet.",
+      href: `${base}vis/sprints/2026-w21/`,
+      availability: "historikk",
+      statusLabel: "Historikk · W21",
+    },
+  ] satisfies VisFrontpageHub[];
+}
+
+export const visFrontpageMandate = {
+  title: "VIS kontrollrom",
+  lead: "VIS-forsiden gir rask oversikt over hva som er sant nå, hvilke interne huber som finnes, og hva som er neste arbeid. Den er ikke backlog.",
+  bullets: [
+    "VIS er intern visnings- og reviewflate",
+    "GitHub Projects/issues er oppgavebuss",
+    "/designsystem/ er UI/mønster-sannhet",
+    "/backstage/ blir system/API/guard-sannhet (#184)",
+    "Roadmap viser retning, ikke detaljerte oppgaver",
+    "DAM/bildebank viser visuelle assets og kildebruk",
+  ],
+} as const;
+
+export const visSourceOfTruthNotes = [
+  { label: "src/data/mvp-current-state.ts", role: "Gjeldende MVP-status" },
+  { label: "/designsystem/", role: "Gjeldende UI/mønstre" },
+  { label: "/backstage/", role: "System/API/guard når etablert (#184)" },
+  { label: "GitHub issues/projects", role: "Oppgavebuss" },
+  { label: "Roadmap", role: "Retning / faser" },
+  { label: "DAM / bildebank", role: "Assetoversikt" },
+  { label: "Sprint-sider", role: "Historikk" },
+] as const;

--- a/src/data/vis-frontpage-hubs-v01.ts
+++ b/src/data/vis-frontpage-hubs-v01.ts
@@ -1,5 +1,7 @@
 /* CONTRACT: VIS frontpage hub definitions v0.1 — mandate, links and active/planned status for /vis/ IA. */
 
+import { mvpCurrentState } from "./mvp-current-state.ts";
+
 export type VisHubAvailability = "active" | "planned" | "historikk";
 
 export type VisHubTier = "primary" | "secondary";
@@ -17,8 +19,10 @@ export type VisFrontpageHub = {
 /** Main hubs on VIS frontpage — hub & spoke model, not backlog. */
 export function getVisFrontpageHubs(baseUrl: string): VisFrontpageHub[] {
   const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const sprint = mvpCurrentState.currentSprint;
+  const sprintActive = sprint.status === "active";
 
-  return [
+  const staticHubs: VisFrontpageHub[] = [
     {
       id: "designsystem",
       title: "Designsystem",
@@ -67,15 +71,27 @@ export function getVisFrontpageHubs(baseUrl: string): VisFrontpageHub[] {
       availability: "active",
       tier: "secondary",
     },
-    {
-      id: "sprint",
-      title: "Sprint / historikk",
-      mandate: "Hvordan vi kom hit — ikke gjeldende sannhet.",
-      href: `${base}vis/sprints/2026-w21/`,
-      availability: "historikk",
-      tier: "secondary",
-    },
-  ] satisfies VisFrontpageHub[];
+  ];
+
+  const sprintHub: VisFrontpageHub = {
+    id: "sprint",
+    title: sprintActive ? `Sprint ${sprint.label}` : "Sprint / historikk",
+    mandate: sprintActive
+      ? "Operativ sprintflate — labs, guardrails og beslutningsgrunnlag."
+      : "Hvordan vi kom hit — ikke gjeldende sannhet.",
+    href: `${base}${sprint.route.replace(/^\//, "")}`,
+    availability: sprintActive ? "active" : "historikk",
+    tier: sprintActive ? "primary" : "secondary",
+    issue: sprint.issue,
+  };
+
+  if (sprintActive) {
+    const primaryHubs = staticHubs.filter((h) => h.tier === "primary");
+    const secondaryHubs = staticHubs.filter((h) => h.tier === "secondary");
+    return [...primaryHubs, sprintHub, ...secondaryHubs];
+  }
+
+  return [...staticHubs, sprintHub];
 }
 
 export const visFrontpageMandate = {
@@ -96,5 +112,5 @@ export const visSourceOfTruthNotes = [
   { label: "GitHub issues/projects", role: "Oppgavebuss" },
   { label: "Roadmap", role: "Retning / faser" },
   { label: "DAM / bildebank", role: "Assetoversikt" },
-  { label: "Sprint-sider", role: "Historikk" },
+  { label: "Sprint-sider", role: "Aktiv sprint (currentSprint) · lukkede i arkiv" },
 ] as const;

--- a/src/data/vis-frontpage-hubs-v01.ts
+++ b/src/data/vis-frontpage-hubs-v01.ts
@@ -2,13 +2,15 @@
 
 export type VisHubAvailability = "active" | "planned" | "historikk";
 
+export type VisHubTier = "primary" | "secondary";
+
 export type VisFrontpageHub = {
   id: string;
   title: string;
   mandate: string;
   href?: string;
   availability: VisHubAvailability;
-  statusLabel: string;
+  tier: VisHubTier;
   issue?: string;
 };
 
@@ -20,75 +22,72 @@ export function getVisFrontpageHubs(baseUrl: string): VisFrontpageHub[] {
     {
       id: "designsystem",
       title: "Designsystem",
-      mandate: "Gjeldende UI-mønstre, komponenter og applied surfaces.",
+      mandate: "UI-mønstre, komponenter og applied surfaces.",
       href: `${base}designsystem/`,
       availability: "active",
-      statusLabel: "Applied / Canonical",
+      tier: "primary",
     },
     {
       id: "backstage",
       title: "Backstage",
-      mandate: "Hvordan AI, API, guards, env-vars, feilstater og production fungerer.",
+      mandate: "AI, API, guards, env-vars og production.",
       availability: "planned",
-      statusLabel: "Planned · Next",
+      tier: "primary",
       issue: "#184",
     },
     {
       id: "gitbuss",
       title: "Gitbuss",
-      mandate:
-        "Operativ oversikt over GitHub issues, arbeidsspor og Return Tickets. GitHub er source of truth for oppgaver — VIS viser inngang og status.",
+      mandate: "GitHub issues, arbeidsspor og Return Tickets.",
       href: `${base}vis/system/github-runtime-status`,
       availability: "active",
-      statusLabel: "Runtime feed",
+      tier: "primary",
     },
     {
       id: "roadmap",
       title: "Roadmap",
-      mandate: "Retning og kommende faser for MVP. Viser neste større bevegelse, ikke alle småoppgaver.",
+      mandate: "Retning og kommende faser — ikke alle småoppgaver.",
       href: `${base}vis/system/roadmap-timeline-v01`,
       availability: "active",
-      statusLabel: "Retning / faser",
+      tier: "primary",
     },
     {
       id: "dam",
       title: "DAM / bildebank",
-      mandate: "Visuelle assets, bildebruk, prompt-/asset-kilder og hvilke bilder som er aktuelle for MVP.",
+      mandate: "Visuelle assets og bildebruk for MVP.",
       href: `${base}vis/assets/editorial`,
       availability: "active",
-      statusLabel: "Editorial library v0.2",
+      tier: "secondary",
     },
     {
       id: "review",
       title: "Review",
-      mandate: "Flater for QA, sammenligning og godkjenning.",
+      mandate: "QA, sammenligning og godkjenning.",
       href: `${base}vis/review/`,
       availability: "active",
-      statusLabel: "Review registry",
+      tier: "secondary",
     },
     {
       id: "sprint",
       title: "Sprint / historikk",
-      mandate: "Hvordan vi kom hit. Ikke gjeldende sannhet.",
+      mandate: "Hvordan vi kom hit — ikke gjeldende sannhet.",
       href: `${base}vis/sprints/2026-w21/`,
       availability: "historikk",
-      statusLabel: "Historikk · W21",
+      tier: "secondary",
     },
   ] satisfies VisFrontpageHub[];
 }
 
 export const visFrontpageMandate = {
   title: "VIS kontrollrom",
-  lead: "VIS-forsiden gir rask oversikt over hva som er sant nå, hvilke interne huber som finnes, og hva som er neste arbeid. Den er ikke backlog.",
-  bullets: [
-    "VIS er intern visnings- og reviewflate",
-    "GitHub Projects/issues er oppgavebuss",
-    "/designsystem/ er UI/mønster-sannhet",
-    "/backstage/ blir system/API/guard-sannhet (#184)",
-    "Roadmap viser retning, ikke detaljerte oppgaver",
-    "DAM/bildebank viser visuelle assets og kildebruk",
-  ],
+  lead: "Rask oversikt over hva som er sant nå, neste steg og hvor du går videre. Ikke backlog.",
 } as const;
+
+export const visPrimaryNextWorkIds = [
+  "internal-ai-test-qa",
+  "ai-usage-monitoring",
+  "backstage-v01",
+] as const;
 
 export const visSourceOfTruthNotes = [
   { label: "src/data/mvp-current-state.ts", role: "Gjeldende MVP-status" },

--- a/src/lib/vis-sprint-guard.ts
+++ b/src/lib/vis-sprint-guard.ts
@@ -1,0 +1,75 @@
+/* CONTRACT: VIS sprint guard — machine-readable rules for active vs closed sprint placement. */
+
+import { mvpCurrentState, type ClosedSprint } from "../data/mvp-current-state.ts";
+import { getVisFrontpageHubs } from "../data/vis-frontpage-hubs-v01.ts";
+
+export type VisSprintPlacement = "control-room" | "hub-primary" | "archive";
+
+/** Where an active sprint must appear on VIS — never archive. */
+export function getVisSprintPlacement(sprintId: string): VisSprintPlacement {
+  const current = mvpCurrentState.currentSprint;
+  if (current.id === sprintId && current.status === "active") {
+    return "control-room";
+  }
+  if (mvpCurrentState.closedSprints.some((s) => s.id === sprintId)) {
+    return "archive";
+  }
+  if (current.id === sprintId && current.status === "closed") {
+    return "archive";
+  }
+  return "hub-primary";
+}
+
+export function isActiveSprint(sprint: Pick<CurrentSprint, "status">): boolean {
+  return sprint.status === "active";
+}
+
+/** Fail build if registry breaks sprint guard rules. */
+export function validateVisSprintGuard(): string[] {
+  const errors: string[] = [];
+  const current = mvpCurrentState.currentSprint;
+
+  if (!current.id || !current.route || !current.label) {
+    errors.push("currentSprint must have id, route and label");
+  }
+
+  if (current.status === "active") {
+    if (mvpCurrentState.closedSprints.some((s) => s.id === current.id)) {
+      errors.push(`Active sprint "${current.id}" must not also appear in closedSprints`);
+    }
+    if (getVisSprintPlacement(current.id) === "archive") {
+      errors.push(`Active sprint "${current.id}" must not resolve to archive placement`);
+    }
+  }
+
+  if (current.status === "closed" && getVisSprintPlacement(current.id) !== "archive") {
+    errors.push(`Closed currentSprint "${current.id}" must resolve to archive placement`);
+  }
+
+  for (const closed of mvpCurrentState.closedSprints) {
+    if (closed.id === current.id && current.status === "active") {
+      errors.push(`Sprint "${closed.id}" cannot be both active and closed`);
+    }
+  }
+
+  const sprintHub = getVisFrontpageHubs("/").find((h) => h.id === "sprint");
+  if (current.status === "active") {
+    if (sprintHub?.availability === "historikk") {
+      errors.push(`Active sprint "${current.id}" must not be exposed as historikk hub`);
+    }
+    if (sprintHub?.tier !== "primary") {
+      errors.push(`Active sprint "${current.id}" must be a primary hub`);
+    }
+  }
+
+  return errors;
+}
+
+export function getClosedSprintArchiveLinks(baseUrl: string): Array<{ id: string; label: string; href: string }> {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return mvpCurrentState.closedSprints.map((s: ClosedSprint) => ({
+    id: s.id,
+    label: s.label,
+    href: `${base}${s.route.replace(/^\//, "")}`,
+  }));
+}

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -1,208 +1,654 @@
 ---
-/* CONTRACT: VIS frontpage v0.1 — kontrollrom / hub inngang; MVP status from registry, hubs from vis-frontpage-hubs-v01. */
+/* CONTRACT: VIS frontpage v0.1 — kontrollrom med visuell prioritet; MVP from registry, hubs from vis-frontpage-hubs-v01. */
 import PrototypeLayout from "../../layouts/PrototypeLayout.astro";
-import {
-  featuredVisEntries,
-  groupedVisEntries,
-  visTypeLabelNo,
-  wireframeIndexEntries,
-} from "../../lib/vis-wireframes";
+import { groupedVisEntries, visTypeLabelNo, wireframeIndexEntries } from "../../lib/vis-wireframes";
 import { getVisFrontpageEntries, mvpCurrentState } from "../../data/mvp-current-state.ts";
 import {
   getVisFrontpageHubs,
   visFrontpageMandate,
+  visPrimaryNextWorkIds,
   visSourceOfTruthNotes,
 } from "../../data/vis-frontpage-hubs-v01.ts";
 
 const base = import.meta.env.BASE_URL;
 const mvpNowEntries = getVisFrontpageEntries(base);
 const hubs = getVisFrontpageHubs(base);
-const nextWork = mvpCurrentState.nextRisks.slice(0, 6);
+const primaryHubs = hubs.filter((h) => h.tier === "primary");
+const secondaryHubs = hubs.filter((h) => h.tier === "secondary");
+
+const chatEntry = mvpNowEntries.find((e) => e.title === "Spør Viddel production");
+const designsystemEntry = mvpNowEntries.find((e) => e.title === "Designsystem");
+const otherMvpEntries = mvpNowEntries.filter(
+  (e) => e.title !== "Spør Viddel production" && e.title !== "Designsystem",
+);
+
+const primaryNextWork = visPrimaryNextWorkIds
+  .map((id) => mvpCurrentState.nextRisks.find((r) => r.id === id))
+  .filter((r): r is (typeof mvpCurrentState.nextRisks)[number] => !!r);
+const laterNextWork = mvpCurrentState.nextRisks.filter((r) => !visPrimaryNextWorkIds.includes(r.id as (typeof visPrimaryNextWorkIds)[number]));
 
 const archiveEntries = wireframeIndexEntries();
-const archiveFeatured = featuredVisEntries(archiveEntries, 3);
 const archiveGrouped = groupedVisEntries(archiveEntries);
 
-const statusClass = (status: string) => {
-  if (status.includes("Canonical")) return "text-blue-700";
-  if (status === "Applied") return "text-emerald-700";
-  return "text-gray-600";
-};
-
-const hubAvailabilityClass = (availability: string) => {
-  if (availability === "active") return "border-emerald-200 bg-emerald-50/60 text-emerald-800";
-  if (availability === "planned") return "border-amber-200 bg-amber-50/50 text-amber-900";
-  return "border-gray-200 bg-gray-50 text-gray-600";
-};
+const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
 ---
 
 <PrototypeLayout title="VIS kontrollrom">
-  <main class="px-4 py-6 sm:px-6 sm:py-8">
-    <header class="max-w-prose">
-      <h1 class="text-lg font-semibold text-gray-900">{visFrontpageMandate.title}</h1>
-      <p class="mt-2 text-sm leading-relaxed text-gray-600">{visFrontpageMandate.lead}</p>
-      <ul class="mt-3 space-y-1 p-0 text-xs leading-relaxed text-gray-600">
-        {visFrontpageMandate.bullets.map((item) => (
-          <li class="list-none pl-0">{item}</li>
-        ))}
-      </ul>
+  <main class="vis-room">
+    <header class="vis-room__header">
+      <p class="vis-room__kicker">Intern · VIS</p>
+      <h1>{visFrontpageMandate.title}</h1>
+      <p class="vis-room__lead">{visFrontpageMandate.lead}</p>
     </header>
 
-    <section class="mt-8" aria-labelledby="vis-mvp-now">
-      <div class="flex flex-wrap items-baseline justify-between gap-2">
-        <h2 id="vis-mvp-now" class="text-sm font-semibold uppercase tracking-wide text-gray-800">MVP nå</h2>
-        <span class="text-[10px] text-gray-500">Oppdatert {mvpCurrentState.updatedAt}</span>
-      </div>
-      <p class="mt-1 max-w-prose text-xs leading-relaxed text-gray-600">{mvpCurrentState.currentFocus}</p>
-      <ul class="mt-4 grid gap-3 p-0 sm:grid-cols-2 lg:grid-cols-3">
-        {mvpNowEntries.map((item) => (
-          <li class="list-none">
-            <a href={item.href} class="group block rounded-md border border-gray-200 bg-white px-3 py-3 hover:border-gray-300 hover:bg-gray-50/80">
-              <span class={`text-[10px] font-semibold uppercase tracking-wide ${statusClass(item.status)}`}>
-                {item.status}
-              </span>
-              <p class="mt-1.5 text-sm font-semibold text-gray-900 group-hover:text-gray-950">{item.title}</p>
-              <p class="mt-0.5 line-clamp-2 text-xs leading-relaxed text-gray-600">{item.description}</p>
-              {item.note ? <p class="mt-1.5 line-clamp-2 text-[11px] leading-snug text-amber-800/90">{item.note}</p> : null}
+    <section class="vis-room__hero" aria-label="Kontrollrom-status">
+      <div class="vis-room__hero-grid">
+        <article class="vis-room__panel vis-room__panel--primary" aria-labelledby="vis-now-status">
+          <p id="vis-now-status" class="vis-room__panel-label">Nå-status</p>
+          {chatEntry ? (
+            <a href={chatEntry.href} class="vis-room__hero-link">
+              <span class="vis-room__live-dot" aria-hidden="true"></span>
+              <span class="vis-room__hero-title">Spør Viddel — live i production</span>
+              <span class="vis-room__hero-meta">CES aktiv · Upstash guard · intern test</span>
             </a>
-          </li>
-        ))}
-      </ul>
+          ) : (
+            <p class="vis-room__hero-title">MVP-status utilgjengelig</p>
+          )}
+          <p class="vis-room__focus">{mvpCurrentState.currentFocus}</p>
+          <p class="vis-room__updated">Oppdatert {mvpCurrentState.updatedAt}</p>
+        </article>
+
+        <article class="vis-room__panel" aria-labelledby="vis-next-priority">
+          <p id="vis-next-priority" class="vis-room__panel-label">Neste arbeid</p>
+          <ol class="vis-room__priority-list">
+            {primaryNextWork.map((item, index) => (
+              <li>
+                <span class="vis-room__priority-index">{index + 1}</span>
+                <span class="vis-room__priority-label">{item.label}</span>
+              </li>
+            ))}
+          </ol>
+        </article>
+
+        <nav class="vis-room__panel" aria-labelledby="vis-go-next">
+          <p id="vis-go-next" class="vis-room__panel-label">Gå videre</p>
+          <ul class="vis-room__go-list">
+            {quickHubLinks.map((hub) => (
+              <li>
+                <a href={hub.href}>{hub.title}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
     </section>
 
-    <section class="mt-10" aria-labelledby="vis-hubs">
-      <h2 id="vis-hubs" class="text-sm font-semibold uppercase tracking-wide text-gray-800">Hovedhuber</h2>
-      <p class="mt-1 max-w-prose text-xs text-gray-600">Faste kunnskapsområder — huber med mandat, ikke backlog.</p>
-      <ul class="mt-4 grid gap-3 p-0 sm:grid-cols-2 lg:grid-cols-3">
-        {hubs.map((hub) => {
-          const chipClass = hubAvailabilityClass(hub.availability);
-          const inner = (
-            <>
-              <div class="flex flex-wrap items-center gap-2">
-                <span class={`inline-flex rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${chipClass}`}>
-                  {hub.statusLabel}
-                </span>
-                {hub.issue ? <span class="text-[10px] text-gray-500">{hub.issue}</span> : null}
-              </div>
-              <p class="mt-2 text-sm font-semibold text-gray-900">{hub.title}</p>
-              <p class="mt-1 text-xs leading-relaxed text-gray-600">{hub.mandate}</p>
-              {!hub.href ? (
-                <p class="mt-2 text-[11px] font-medium text-gray-500">Kommer — ikke implementert ennå</p>
-              ) : null}
-            </>
-          );
+    <section class="vis-room__section" aria-labelledby="vis-mvp-now">
+      <h2 id="vis-mvp-now" class="vis-room__section-title">MVP nå</h2>
+      <div class="vis-room__mvp">
+        {chatEntry ? (
+          <a href={chatEntry.href} class="vis-room__mvp-primary">
+            <span class="vis-room__mvp-primary-label">Hovedstatus</span>
+            <span class="vis-room__mvp-primary-title">{chatEntry.title}</span>
+            <span class="vis-room__mvp-primary-desc">{chatEntry.description}</span>
+          </a>
+        ) : null}
+        <ul class="vis-room__mvp-secondary">
+          {otherMvpEntries.map((item) => (
+            <li>
+              <a href={item.href}>
+                <span class="vis-room__mvp-secondary-title">{item.title.replace(" production", "")}</span>
+                <span class="vis-room__mvp-secondary-status">{item.status}</span>
+              </a>
+            </li>
+          ))}
+          {designsystemEntry ? (
+            <li class="vis-room__mvp-secondary--ref">
+              <a href={designsystemEntry.href}>
+                <span class="vis-room__mvp-secondary-title">Designsystem</span>
+                <span class="vis-room__mvp-secondary-status">Canonical referanse</span>
+              </a>
+            </li>
+          ) : null}
+        </ul>
+      </div>
+    </section>
 
-          return (
-            <li class="list-none">
+    <section class="vis-room__section" aria-labelledby="vis-hubs">
+      <h2 id="vis-hubs" class="vis-room__section-title">Huber</h2>
+      <p class="vis-room__section-lead">Innganger til faste kunnskapsområder — ikke backlog.</p>
+
+      <div class="vis-room__hub-group">
+        <h3 class="vis-room__hub-group-title">Primære</h3>
+        <ul class="vis-room__hub-list vis-room__hub-list--primary">
+          {primaryHubs.map((hub) => (
+            <li class:list={[!hub.href && "vis-room__hub-item--planned"]}>
               {hub.href ? (
-                <a
-                  href={hub.href}
-                  class="block h-full rounded-md border border-gray-200 bg-white px-3 py-3 hover:border-gray-300 hover:bg-gray-50/80"
-                >
-                  {inner}
+                <a href={hub.href}>
+                  <span class="vis-room__hub-title">{hub.title}</span>
+                  <span class="vis-room__hub-mandate">{hub.mandate}</span>
                 </a>
               ) : (
-                <div class="h-full rounded-md border border-dashed border-gray-300 bg-gray-50/50 px-3 py-3">{inner}</div>
+                <div>
+                  <span class="vis-room__hub-title">{hub.title}</span>
+                  <span class="vis-room__hub-planned">Kommer {hub.issue ?? ""}</span>
+                  <span class="vis-room__hub-mandate">{hub.mandate}</span>
+                </div>
               )}
             </li>
-          );
-        })}
-      </ul>
+          ))}
+        </ul>
+      </div>
+
+      <div class="vis-room__hub-group vis-room__hub-group--secondary">
+        <h3 class="vis-room__hub-group-title">Sekundære</h3>
+        <ul class="vis-room__hub-list vis-room__hub-list--secondary">
+          {secondaryHubs.map((hub) => (
+            <li>
+              <a href={hub.href}>
+                <span class="vis-room__hub-title">{hub.title}</span>
+                <span class="vis-room__hub-mandate">{hub.mandate}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
     </section>
 
-    <section class="mt-10 max-w-prose" aria-labelledby="vis-next-work">
-      <h2 id="vis-next-work" class="text-sm font-semibold uppercase tracking-wide text-gray-800">Neste arbeid</h2>
-      <p class="mt-1 text-xs text-gray-600">Kort liste fra current-state — ikke full oppgavebuss.</p>
-      <ul class="mt-3 space-y-2 p-0 text-xs text-gray-600">
-        {nextWork.map((item) => (
-          <li class="list-none rounded-md border border-gray-200 bg-white px-3 py-2">
-            <span class="font-medium text-gray-900">{item.label}</span>
-            {item.detail ? <p class="mt-0.5 leading-relaxed">{item.detail}</p> : null}
-          </li>
-        ))}
-      </ul>
-    </section>
+    {
+      laterNextWork.length > 0 ? (
+        <details class="vis-room__details">
+          <summary>Senere / parkert ({laterNextWork.length})</summary>
+          <ul class="vis-room__later-list">
+            {laterNextWork.map((item) => (
+              <li>
+                <span class="vis-room__later-label">{item.label}</span>
+                {item.detail ? <span class="vis-room__later-detail">{item.detail}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null
+    }
 
-    <section class="mt-10 border-t border-gray-200 pt-8" aria-labelledby="vis-archive">
-      <h2 id="vis-archive" class="text-xs font-semibold uppercase tracking-wide text-gray-500">Historikk / arkiv</h2>
-      <p class="mt-1 max-w-prose text-xs text-gray-500">Lavere vekt — ikke gjeldende operativ sannhet.</p>
-      <ul class="mt-3 flex flex-wrap gap-2 p-0 text-xs">
-        <li class="list-none">
-          <a href={`${base}vis/sprints/2026-w21/`} class="rounded-sm border border-gray-200 bg-white px-2.5 py-1.5 text-gray-700 hover:bg-gray-50">
-            Sprint W21
-          </a>
-        </li>
-        <li class="list-none">
-          <a href={`${base}vis/system/`} class="rounded-sm border border-gray-200 bg-white px-2.5 py-1.5 text-gray-700 hover:bg-gray-50">
-            System legacy
-          </a>
-        </li>
+    <details class="vis-room__details vis-room__details--archive">
+      <summary>Historikk / arkiv</summary>
+      <ul class="vis-room__archive-links">
+        <li><a href={`${base}vis/sprints/2026-w21/`}>Sprint W21</a></li>
+        <li><a href={`${base}vis/system/`}>System legacy</a></li>
       </ul>
-
       {
         archiveEntries.length > 0 ? (
-          <div class="mt-5 space-y-4">
-            {archiveFeatured.length > 0 ? (
-              <ul class="grid gap-2 p-0 sm:grid-cols-2 lg:grid-cols-3">
-                {archiveFeatured.map(({ filename: name, slug, displayTitle, visType }) => {
-                  const view = `${base}vis/${encodeURIComponent(slug)}`;
-                  const typeLabel = visTypeLabelNo(visType);
-                  return (
-                    <li class="list-none">
-                      <a href={view} class="block rounded-sm border border-gray-200 bg-gray-50/80 px-2.5 py-2 hover:bg-gray-100">
-                        <span class="text-[10px] uppercase tracking-wide text-gray-500">{typeLabel}</span>
-                        <p class="mt-1 text-xs font-medium text-gray-800">{displayTitle}</p>
-                        <p class="mt-0.5 truncate font-mono text-[10px] text-gray-400">{name}</p>
-                      </a>
+          <div class="vis-room__archive-groups">
+            {archiveGrouped.map((group) => (
+              <section>
+                <h3>{group.section}</h3>
+                <ul>
+                  {group.items.map(({ filename: name, slug, displayTitle }) => (
+                    <li>
+                      <a href={`${base}vis/${encodeURIComponent(slug)}`}>{displayTitle}</a>
+                      <span class="vis-room__archive-file">{name}</span>
                     </li>
-                  );
-                })}
-              </ul>
-            ) : null}
-
-            <details class="rounded-md border border-gray-200 bg-white">
-              <summary class="cursor-pointer px-3 py-2 text-xs font-medium text-gray-700">
-                Eldre wireframes og VIS-dokumenter ({archiveEntries.length})
-              </summary>
-              <div class="border-t border-gray-200 px-1 py-2">
-                {archiveGrouped.map((group) => (
-                  <section class="mb-3 last:mb-0">
-                    <h3 class="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-gray-500">{group.section}</h3>
-                    <ul class="divide-y divide-gray-100">
-                      {group.items.map(({ filename: name, slug, displayTitle }) => {
-                        const view = `${base}vis/${encodeURIComponent(slug)}`;
-                        return (
-                          <li class="flex items-center justify-between gap-2 px-2 py-1.5">
-                            <div class="min-w-0">
-                              <p class="truncate text-xs text-gray-800">{displayTitle}</p>
-                              <p class="truncate font-mono text-[10px] text-gray-400">{name}</p>
-                            </div>
-                            <a href={view} class="shrink-0 text-[11px] text-gray-600 underline underline-offset-2">
-                              Åpne
-                            </a>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </section>
-                ))}
-              </div>
-            </details>
+                  ))}
+                </ul>
+              </section>
+            ))}
           </div>
         ) : null
       }
-    </section>
+    </details>
 
-    <section class="mt-10 max-w-prose border-t border-gray-200 pt-6" aria-labelledby="vis-sot">
-      <h2 id="vis-sot" class="text-xs font-semibold uppercase tracking-wide text-gray-500">Source of truth</h2>
-      <ul class="mt-2 space-y-1.5 p-0 text-xs text-gray-600">
-        {visSourceOfTruthNotes.map((note) => (
-          <li class="list-none">
-            <code class="font-mono text-[11px] text-gray-800">{note.label}</code>
-            <span> — {note.role}</span>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <footer class="vis-room__sot">
+      <p class="vis-room__sot-title">Source of truth</p>
+      <p class="vis-room__sot-line">
+        {visSourceOfTruthNotes.map((note) => `${note.label} (${note.role})`).join(" · ")}
+      </p>
+    </footer>
   </main>
+
+  <style>
+    .vis-room {
+      max-width: 56rem;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+      color: rgb(17 24 39);
+    }
+
+    .vis-room__kicker {
+      margin: 0;
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__header h1 {
+      margin: 0.35rem 0 0;
+      font-size: clamp(1.5rem, 3vw, 1.85rem);
+      font-weight: 650;
+      letter-spacing: -0.03em;
+      line-height: 1.15;
+    }
+
+    .vis-room__lead {
+      margin: 0.55rem 0 0;
+      max-width: 34rem;
+      font-size: 0.92rem;
+      line-height: 1.55;
+      color: rgb(75 85 99);
+    }
+
+    .vis-room__hero {
+      margin-top: 2rem;
+    }
+
+    .vis-room__hero-grid {
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .vis-room__panel {
+      padding: 0.15rem 0;
+    }
+
+    .vis-room__panel-label {
+      margin: 0 0 0.65rem;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__panel--primary {
+      padding-bottom: 0.25rem;
+    }
+
+    .vis-room__hero-link {
+      display: block;
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .vis-room__hero-link:hover .vis-room__hero-title {
+      color: rgb(17 24 39);
+    }
+
+    .vis-room__live-dot {
+      display: inline-block;
+      width: 0.5rem;
+      height: 0.5rem;
+      margin-right: 0.35rem;
+      border-radius: 999px;
+      background: rgb(16 185 129);
+      vertical-align: 0.05em;
+    }
+
+    .vis-room__hero-title {
+      display: block;
+      font-size: clamp(1.15rem, 2.4vw, 1.45rem);
+      font-weight: 650;
+      letter-spacing: -0.02em;
+      line-height: 1.25;
+      color: rgb(31 41 55);
+    }
+
+    .vis-room__hero-meta {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.82rem;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__focus {
+      margin: 0.85rem 0 0;
+      max-width: 38rem;
+      font-size: 0.86rem;
+      line-height: 1.55;
+      color: rgb(75 85 99);
+    }
+
+    .vis-room__updated {
+      margin: 0.45rem 0 0;
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__priority-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .vis-room__priority-list li {
+      display: flex;
+      align-items: baseline;
+      gap: 0.55rem;
+      padding: 0.28rem 0;
+      font-size: 0.88rem;
+      line-height: 1.4;
+    }
+
+    .vis-room__priority-index {
+      flex-shrink: 0;
+      width: 1.1rem;
+      font-size: 0.78rem;
+      font-weight: 650;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__priority-label {
+      color: rgb(31 41 55);
+      font-weight: 550;
+    }
+
+    .vis-room__go-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .vis-room__go-list a {
+      display: block;
+      padding: 0.22rem 0;
+      font-size: 0.92rem;
+      font-weight: 550;
+      color: rgb(31 41 55);
+      text-decoration: underline;
+      text-underline-offset: 3px;
+      text-decoration-color: rgb(209 213 219);
+    }
+
+    .vis-room__go-list a:hover {
+      text-decoration-color: rgb(107 114 128);
+    }
+
+    .vis-room__section {
+      margin-top: 2.75rem;
+    }
+
+    .vis-room__section-title {
+      margin: 0;
+      font-size: 0.72rem;
+      font-weight: 650;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__section-lead {
+      margin: 0.35rem 0 0;
+      font-size: 0.82rem;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__mvp {
+      margin-top: 1rem;
+    }
+
+    .vis-room__mvp-primary {
+      display: block;
+      padding: 0.2rem 0 1rem;
+      color: inherit;
+      text-decoration: none;
+      border-bottom: 1px solid rgb(229 231 235);
+    }
+
+    .vis-room__mvp-primary-label {
+      display: block;
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__mvp-primary-title {
+      display: block;
+      margin-top: 0.35rem;
+      font-size: 1.05rem;
+      font-weight: 650;
+      letter-spacing: -0.02em;
+    }
+
+    .vis-room__mvp-primary-desc {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.84rem;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__mvp-secondary {
+      margin: 0;
+      padding: 0.65rem 0 0;
+      list-style: none;
+    }
+
+    .vis-room__mvp-secondary li + li {
+      margin-top: 0.15rem;
+    }
+
+    .vis-room__mvp-secondary a {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.35rem 0;
+      color: inherit;
+      text-decoration: none;
+      font-size: 0.86rem;
+    }
+
+    .vis-room__mvp-secondary a:hover .vis-room__mvp-secondary-title {
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .vis-room__mvp-secondary-title {
+      color: rgb(55 65 81);
+    }
+
+    .vis-room__mvp-secondary-status {
+      flex-shrink: 0;
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__mvp-secondary--ref .vis-room__mvp-secondary-title,
+    .vis-room__mvp-secondary--ref .vis-room__mvp-secondary-status {
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__hub-group {
+      margin-top: 1.25rem;
+    }
+
+    .vis-room__hub-group--secondary {
+      margin-top: 1.75rem;
+    }
+
+    .vis-room__hub-group-title {
+      margin: 0 0 0.5rem;
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__hub-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .vis-room__hub-list--primary .vis-room__hub-title {
+      font-size: 1rem;
+    }
+
+    .vis-room__hub-list--secondary .vis-room__hub-title {
+      font-size: 0.92rem;
+      font-weight: 550;
+    }
+
+    .vis-room__hub-list li + li {
+      margin-top: 0.15rem;
+    }
+
+    .vis-room__hub-list a,
+    .vis-room__hub-item--planned > div {
+      display: block;
+      padding: 0.55rem 0;
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .vis-room__hub-list a:hover .vis-room__hub-title {
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
+    .vis-room__hub-title {
+      display: block;
+      font-weight: 650;
+      letter-spacing: -0.01em;
+      color: rgb(31 41 55);
+    }
+
+    .vis-room__hub-mandate {
+      display: block;
+      margin-top: 0.15rem;
+      font-size: 0.8rem;
+      line-height: 1.45;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__hub-planned {
+      display: block;
+      margin-top: 0.1rem;
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__hub-item--planned .vis-room__hub-title {
+      color: rgb(75 85 99);
+    }
+
+    .vis-room__details {
+      margin-top: 2.5rem;
+      font-size: 0.82rem;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__details summary {
+      cursor: pointer;
+      font-weight: 550;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__details--archive {
+      margin-top: 1.25rem;
+    }
+
+    .vis-room__later-list,
+    .vis-room__archive-links {
+      margin: 0.75rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .vis-room__later-list li + li,
+    .vis-room__archive-links li + li {
+      margin-top: 0.45rem;
+    }
+
+    .vis-room__later-label {
+      display: block;
+      font-weight: 550;
+      color: rgb(75 85 99);
+    }
+
+    .vis-room__later-detail {
+      display: block;
+      margin-top: 0.1rem;
+      font-size: 0.78rem;
+      line-height: 1.45;
+    }
+
+    .vis-room__archive-links a {
+      color: rgb(75 85 99);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .vis-room__archive-groups {
+      margin-top: 1rem;
+    }
+
+    .vis-room__archive-groups h3 {
+      margin: 0.75rem 0 0.35rem;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__archive-groups ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .vis-room__archive-groups li {
+      padding: 0.2rem 0;
+    }
+
+    .vis-room__archive-groups a {
+      font-size: 0.78rem;
+      color: rgb(75 85 99);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .vis-room__archive-file {
+      display: block;
+      font-family: ui-monospace, monospace;
+      font-size: 0.65rem;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__sot {
+      margin-top: 2.5rem;
+      padding-top: 1rem;
+      border-top: 1px solid rgb(243 244 246);
+    }
+
+    .vis-room__sot-title {
+      margin: 0;
+      font-size: 0.65rem;
+      font-weight: 650;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__sot-line {
+      margin: 0.35rem 0 0;
+      font-size: 0.68rem;
+      line-height: 1.5;
+      color: rgb(156 163 175);
+    }
+
+    @media (min-width: 768px) {
+      .vis-room {
+        padding: 2.5rem 1.5rem 3.5rem;
+      }
+
+      .vis-room__hero-grid {
+        grid-template-columns: 1.4fr 1fr 0.85fr;
+        gap: 2rem;
+        align-items: start;
+      }
+    }
+  </style>
 </PrototypeLayout>

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -2,7 +2,8 @@
 /* CONTRACT: VIS frontpage v0.1 — kontrollrom med visuell prioritet; MVP from registry, hubs from vis-frontpage-hubs-v01. */
 import PrototypeLayout from "../../layouts/PrototypeLayout.astro";
 import { groupedVisEntries, visTypeLabelNo, wireframeIndexEntries } from "../../lib/vis-wireframes";
-import { getVisFrontpageEntries, mvpCurrentState } from "../../data/mvp-current-state.ts";
+import { getVisFrontpageEntries, getCurrentSprintVisEntry, mvpCurrentState } from "../../data/mvp-current-state.ts";
+import { getClosedSprintArchiveLinks } from "../../lib/vis-sprint-guard.ts";
 import {
   getVisFrontpageHubs,
   visFrontpageMandate,
@@ -12,6 +13,8 @@ import {
 
 const base = import.meta.env.BASE_URL;
 const mvpNowEntries = getVisFrontpageEntries(base);
+const currentSprint = getCurrentSprintVisEntry(base);
+const closedSprintArchiveLinks = getClosedSprintArchiveLinks(base);
 const hubs = getVisFrontpageHubs(base);
 const primaryHubs = hubs.filter((h) => h.tier === "primary");
 const secondaryHubs = hubs.filter((h) => h.tier === "secondary");
@@ -81,6 +84,21 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
           </ul>
         </nav>
       </div>
+
+      {
+        currentSprint.isActive ? (
+          <article class="vis-room__sprint-strip" aria-labelledby="vis-current-sprint">
+            <p id="vis-current-sprint" class="vis-room__panel-label">Denne sprinten</p>
+            <a href={currentSprint.href} class="vis-room__sprint-link">
+              <span class="vis-room__sprint-title">{currentSprint.title}</span>
+              <span class="vis-room__sprint-focus">{currentSprint.weekFocus}</span>
+              {currentSprint.issue ? (
+                <span class="vis-room__sprint-meta">Issue {currentSprint.issue}</span>
+              ) : null}
+            </a>
+          </article>
+        ) : null
+      }
     </section>
 
     <section class="vis-room__section" aria-labelledby="vis-mvp-now">
@@ -173,8 +191,18 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
 
     <details class="vis-room__details vis-room__details--archive">
       <summary>Historikk / arkiv</summary>
+      {
+        closedSprintArchiveLinks.length > 0 ? (
+          <ul class="vis-room__archive-links">
+            {closedSprintArchiveLinks.map((link) => (
+              <li>
+                <a href={link.href}>{link.label}</a>
+              </li>
+            ))}
+          </ul>
+        ) : null
+      }
       <ul class="vis-room__archive-links">
-        <li><a href={`${base}vis/sprints/2026-w21/`}>Sprint W21</a></li>
         <li><a href={`${base}vis/system/`}>System legacy</a></li>
       </ul>
       {
@@ -362,6 +390,47 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
 
     .vis-room__go-list a:hover {
       text-decoration-color: rgb(107 114 128);
+    }
+
+    .vis-room__sprint-strip {
+      margin-top: 1.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid rgb(243 244 246);
+    }
+
+    .vis-room__sprint-link {
+      display: block;
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .vis-room__sprint-link:hover .vis-room__sprint-title {
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
+    .vis-room__sprint-title {
+      display: block;
+      font-size: 1rem;
+      font-weight: 650;
+      letter-spacing: -0.01em;
+      color: rgb(31 41 55);
+    }
+
+    .vis-room__sprint-focus {
+      display: block;
+      margin-top: 0.3rem;
+      max-width: 40rem;
+      font-size: 0.84rem;
+      line-height: 1.5;
+      color: rgb(75 85 99);
+    }
+
+    .vis-room__sprint-meta {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
     }
 
     .vis-room__section {

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -1,206 +1,208 @@
 ---
-/* CONTRACT: VIS backstage index — curated operational overview; MVP status from mvp-current-state registry. */
+/* CONTRACT: VIS frontpage v0.1 — kontrollrom / hub inngang; MVP status from registry, hubs from vis-frontpage-hubs-v01. */
 import PrototypeLayout from "../../layouts/PrototypeLayout.astro";
 import {
   featuredVisEntries,
   groupedVisEntries,
-  recentVisEntries,
   visTypeLabelNo,
   wireframeIndexEntries,
 } from "../../lib/vis-wireframes";
 import { getVisFrontpageEntries, mvpCurrentState } from "../../data/mvp-current-state.ts";
+import {
+  getVisFrontpageHubs,
+  visFrontpageMandate,
+  visSourceOfTruthNotes,
+} from "../../data/vis-frontpage-hubs-v01.ts";
 
-const entries = wireframeIndexEntries();
-const featured = featuredVisEntries(entries, 4);
-const grouped = groupedVisEntries(entries);
-const recent = recentVisEntries(entries, 4);
 const base = import.meta.env.BASE_URL;
 const mvpNowEntries = getVisFrontpageEntries(base);
+const hubs = getVisFrontpageHubs(base);
+const nextWork = mvpCurrentState.nextRisks.slice(0, 6);
 
-const chipClassByType = (kind: string) => {
-  if (kind === "sprint") {
-    return "border-gray-500 bg-gray-200 text-gray-900 font-semibold tracking-[0.08em]";
-  }
-  if (kind === "strategy") {
-    return "border-gray-400 bg-gray-100 text-gray-800 font-medium tracking-[0.06em]";
-  }
-  if (kind === "wireframe") {
-    return "border-dashed border-gray-400 bg-white text-gray-700 font-medium tracking-[0.09em]";
-  }
-  return "border-gray-300 bg-gray-50 text-gray-600 font-medium tracking-[0.06em]";
-};
+const archiveEntries = wireframeIndexEntries();
+const archiveFeatured = featuredVisEntries(archiveEntries, 3);
+const archiveGrouped = groupedVisEntries(archiveEntries);
 
 const statusClass = (status: string) => {
   if (status.includes("Canonical")) return "text-blue-700";
   if (status === "Applied") return "text-emerald-700";
-  if (status === "Historikk") return "text-gray-500";
   return "text-gray-600";
+};
+
+const hubAvailabilityClass = (availability: string) => {
+  if (availability === "active") return "border-emerald-200 bg-emerald-50/60 text-emerald-800";
+  if (availability === "planned") return "border-amber-200 bg-amber-50/50 text-amber-900";
+  return "border-gray-200 bg-gray-50 text-gray-600";
 };
 ---
 
-<PrototypeLayout title="Oversikt">
+<PrototypeLayout title="VIS kontrollrom">
   <main class="px-4 py-6 sm:px-6 sm:py-8">
-    <h1 class="text-lg font-semibold text-gray-900">VIS operativ oversikt</h1>
-    <p class="mt-2 max-w-prose text-sm text-gray-600">
-      VIS er intern reviewflate for Viddel MVP. GitHub Projects er oppgavebuss.
-      <a href={`${base}designsystem/`} class="text-gray-800 underline underline-offset-2 hover:text-gray-950">
-        /designsystem/
-      </a>
-      er canonical designreferanse.
-    </p>
+    <header class="max-w-prose">
+      <h1 class="text-lg font-semibold text-gray-900">{visFrontpageMandate.title}</h1>
+      <p class="mt-2 text-sm leading-relaxed text-gray-600">{visFrontpageMandate.lead}</p>
+      <ul class="mt-3 space-y-1 p-0 text-xs leading-relaxed text-gray-600">
+        {visFrontpageMandate.bullets.map((item) => (
+          <li class="list-none pl-0">{item}</li>
+        ))}
+      </ul>
+    </header>
 
-    <section class="mt-6">
+    <section class="mt-8" aria-labelledby="vis-mvp-now">
       <div class="flex flex-wrap items-baseline justify-between gap-2">
-        <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-800">MVP nå</h2>
+        <h2 id="vis-mvp-now" class="text-sm font-semibold uppercase tracking-wide text-gray-800">MVP nå</h2>
         <span class="text-[10px] text-gray-500">Oppdatert {mvpCurrentState.updatedAt}</span>
       </div>
       <p class="mt-1 max-w-prose text-xs leading-relaxed text-gray-600">{mvpCurrentState.currentFocus}</p>
-      <ul class="mt-4 grid gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3">
+      <ul class="mt-4 grid gap-3 p-0 sm:grid-cols-2 lg:grid-cols-3">
         {mvpNowEntries.map((item) => (
           <li class="list-none">
-            <a href={item.href} class="group block">
-              <div class="mb-2 overflow-hidden rounded-md bg-gray-100/80 px-3 py-2.5 group-hover:bg-gray-100">
-                <span class={`text-[10px] font-semibold uppercase tracking-wide ${statusClass(item.status)}`}>
-                  {item.status}
-                </span>
-              </div>
-              <p class="text-sm font-semibold text-gray-900 group-hover:text-gray-950">{item.title}</p>
-              <p class="mt-0.5 text-xs leading-relaxed text-gray-600">{item.description}</p>
-              {item.note ? <p class="mt-1 text-[11px] leading-snug text-amber-800/90">{item.note}</p> : null}
+            <a href={item.href} class="group block rounded-md border border-gray-200 bg-white px-3 py-3 hover:border-gray-300 hover:bg-gray-50/80">
+              <span class={`text-[10px] font-semibold uppercase tracking-wide ${statusClass(item.status)}`}>
+                {item.status}
+              </span>
+              <p class="mt-1.5 text-sm font-semibold text-gray-900 group-hover:text-gray-950">{item.title}</p>
+              <p class="mt-0.5 line-clamp-2 text-xs leading-relaxed text-gray-600">{item.description}</p>
+              {item.note ? <p class="mt-1.5 line-clamp-2 text-[11px] leading-snug text-amber-800/90">{item.note}</p> : null}
             </a>
           </li>
         ))}
       </ul>
     </section>
 
-    <section class="mt-8 max-w-prose">
-      <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Neste risiko</h2>
-      <ul class="mt-2 space-y-1.5 p-0 text-xs text-gray-600">
-        {mvpCurrentState.nextRisks.map((risk) => (
-          <li class="list-none">
-            <span class="font-medium text-gray-800">{risk.label}</span>
-            {risk.detail ? <span> — {risk.detail}</span> : null}
+    <section class="mt-10" aria-labelledby="vis-hubs">
+      <h2 id="vis-hubs" class="text-sm font-semibold uppercase tracking-wide text-gray-800">Hovedhuber</h2>
+      <p class="mt-1 max-w-prose text-xs text-gray-600">Faste kunnskapsområder — huber med mandat, ikke backlog.</p>
+      <ul class="mt-4 grid gap-3 p-0 sm:grid-cols-2 lg:grid-cols-3">
+        {hubs.map((hub) => {
+          const chipClass = hubAvailabilityClass(hub.availability);
+          const inner = (
+            <>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class={`inline-flex rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${chipClass}`}>
+                  {hub.statusLabel}
+                </span>
+                {hub.issue ? <span class="text-[10px] text-gray-500">{hub.issue}</span> : null}
+              </div>
+              <p class="mt-2 text-sm font-semibold text-gray-900">{hub.title}</p>
+              <p class="mt-1 text-xs leading-relaxed text-gray-600">{hub.mandate}</p>
+              {!hub.href ? (
+                <p class="mt-2 text-[11px] font-medium text-gray-500">Kommer — ikke implementert ennå</p>
+              ) : null}
+            </>
+          );
+
+          return (
+            <li class="list-none">
+              {hub.href ? (
+                <a
+                  href={hub.href}
+                  class="block h-full rounded-md border border-gray-200 bg-white px-3 py-3 hover:border-gray-300 hover:bg-gray-50/80"
+                >
+                  {inner}
+                </a>
+              ) : (
+                <div class="h-full rounded-md border border-dashed border-gray-300 bg-gray-50/50 px-3 py-3">{inner}</div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+
+    <section class="mt-10 max-w-prose" aria-labelledby="vis-next-work">
+      <h2 id="vis-next-work" class="text-sm font-semibold uppercase tracking-wide text-gray-800">Neste arbeid</h2>
+      <p class="mt-1 text-xs text-gray-600">Kort liste fra current-state — ikke full oppgavebuss.</p>
+      <ul class="mt-3 space-y-2 p-0 text-xs text-gray-600">
+        {nextWork.map((item) => (
+          <li class="list-none rounded-md border border-gray-200 bg-white px-3 py-2">
+            <span class="font-medium text-gray-900">{item.label}</span>
+            {item.detail ? <p class="mt-0.5 leading-relaxed">{item.detail}</p> : null}
           </li>
         ))}
       </ul>
     </section>
 
-    {
-      entries.length === 0 ? (
-        <p class="mt-6 text-sm text-gray-500">
-          Ingen historiske <code class="font-mono">.html</code>-artefakter funnet i{" "}
-          <code class="font-mono">public/vis/raw/</code>.
-        </p>
-      ) : (
-        <>
-          <section class="mt-10 border-t border-gray-200 pt-8">
-            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-800">Arkiv / eldre prototyper</h2>
-            <p class="mt-1 max-w-prose text-xs leading-relaxed text-gray-600">
-              Historiske wireframes og eldre VIS-dokumenter — ikke primær inngang til dagens MVP-arbeid.
-            </p>
-            <ul class="mt-2.5 grid gap-2.5 p-0 sm:grid-cols-2">
-              {featured.map(({ filename: name, slug, displayTitle, description, visType }) => {
-                const view = `${base}vis/${encodeURIComponent(slug)}`;
-                const typeLabel = visTypeLabelNo(visType);
-                return (
-                  <li class="list-none border-b border-gray-200 px-0 pb-3 pt-1 last:border-b-0">
-                    <span class:list={[
-                      "inline-flex rounded-sm border px-1.5 py-0.5 text-[10px] uppercase",
-                      chipClassByType(visType),
-                    ]}>
-                      {typeLabel}
-                    </span>
-                    <p class="mt-2 text-sm font-semibold text-gray-900">{displayTitle}</p>
-                    {description ? <p class="mt-1 text-xs text-gray-600">{description}</p> : null}
-                    <div class="mt-3">
-                      <a href={view} class="rounded-sm bg-gray-900 px-2.5 py-1.5 font-mono text-xs font-medium text-white hover:bg-gray-800">
-                        Åpne
-                      </a>
-                    </div>
-                    <p class="mt-2 truncate font-mono text-[10px] text-gray-500">{name}</p>
-                  </li>
-                );
-              })}
-            </ul>
-          </section>
+    <section class="mt-10 border-t border-gray-200 pt-8" aria-labelledby="vis-archive">
+      <h2 id="vis-archive" class="text-xs font-semibold uppercase tracking-wide text-gray-500">Historikk / arkiv</h2>
+      <p class="mt-1 max-w-prose text-xs text-gray-500">Lavere vekt — ikke gjeldende operativ sannhet.</p>
+      <ul class="mt-3 flex flex-wrap gap-2 p-0 text-xs">
+        <li class="list-none">
+          <a href={`${base}vis/sprints/2026-w21/`} class="rounded-sm border border-gray-200 bg-white px-2.5 py-1.5 text-gray-700 hover:bg-gray-50">
+            Sprint W21
+          </a>
+        </li>
+        <li class="list-none">
+          <a href={`${base}vis/system/`} class="rounded-sm border border-gray-200 bg-white px-2.5 py-1.5 text-gray-700 hover:bg-gray-50">
+            System legacy
+          </a>
+        </li>
+      </ul>
 
-          <section class="mt-8">
-            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-700">Historiske wireframes og dokumenter</h2>
-            <div class="mt-2.5 space-y-2.5">
-              {grouped.map((group) => (
-                <section class="rounded-md border border-gray-200 bg-white">
-                  <h3 class="border-b border-gray-200 bg-gray-50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-700">
-                    {group.section}
-                  </h3>
-                  <ul class="divide-y divide-gray-200">
-                    {group.items.map(({ filename: name, slug, displayTitle, description, visType }) => {
-                      const view = `${base}vis/${encodeURIComponent(slug)}`;
-                      const rawUrl = `${base}vis/raw/${encodeURIComponent(name)}`;
-                      const typeLabel = visTypeLabelNo(visType);
-                      return (
-                        <li class="flex flex-col gap-2 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
-                          <div class="min-w-0">
-                            <div class="flex flex-wrap items-center gap-2">
-                              <span
-                                class:list={[
-                                  "inline-flex shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] uppercase",
-                                  chipClassByType(visType),
-                                ]}
-                              >
-                                {typeLabel}
-                              </span>
-                              <p class="text-sm font-semibold leading-snug text-gray-900">{displayTitle}</p>
-                            </div>
-                            {description ? <p class="mt-1 text-xs leading-relaxed text-gray-600">{description}</p> : null}
-                            <p class="mt-1 truncate font-mono text-[10px] text-gray-500">{name}</p>
-                          </div>
-                          <div class="flex shrink-0 flex-wrap items-center gap-2">
-                            <a href={view} class="rounded-sm bg-gray-900 px-3 py-1.5 font-mono text-xs font-medium text-white hover:bg-gray-800">
-                              Åpne
-                            </a>
-                            <a
-                              href={rawUrl}
-                              class="rounded-sm border border-gray-300 bg-white px-3 py-1.5 font-mono text-xs text-gray-700 hover:bg-gray-100"
-                            >
-                              Direkte fil
-                            </a>
-                          </div>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </section>
-              ))}
-            </div>
-          </section>
-
-          <section id="siste-endringer" class="mt-8">
-            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-700">Siste endringer i arkivet</h2>
-            {recent.length > 0 ? (
-              <ul class="mt-2.5 rounded-md border border-gray-200 bg-white">
-                {recent.map(({ filename: name, slug, displayTitle, visUpdatedRaw }) => {
+      {
+        archiveEntries.length > 0 ? (
+          <div class="mt-5 space-y-4">
+            {archiveFeatured.length > 0 ? (
+              <ul class="grid gap-2 p-0 sm:grid-cols-2 lg:grid-cols-3">
+                {archiveFeatured.map(({ filename: name, slug, displayTitle, visType }) => {
                   const view = `${base}vis/${encodeURIComponent(slug)}`;
+                  const typeLabel = visTypeLabelNo(visType);
                   return (
-                    <li class="flex items-center justify-between gap-3 border-b border-gray-200 px-3 py-2 last:border-b-0">
-                      <div class="min-w-0">
-                        <p class="truncate text-sm font-medium text-gray-900">{displayTitle}</p>
-                        <p class="text-[10px] text-gray-500">{visUpdatedRaw || "ukjent dato"}</p>
-                      </div>
-                      <a href={view} class="rounded-sm bg-gray-900 px-2.5 py-1 text-xs text-white hover:bg-gray-800">
-                        Åpne
+                    <li class="list-none">
+                      <a href={view} class="block rounded-sm border border-gray-200 bg-gray-50/80 px-2.5 py-2 hover:bg-gray-100">
+                        <span class="text-[10px] uppercase tracking-wide text-gray-500">{typeLabel}</span>
+                        <p class="mt-1 text-xs font-medium text-gray-800">{displayTitle}</p>
+                        <p class="mt-0.5 truncate font-mono text-[10px] text-gray-400">{name}</p>
                       </a>
                     </li>
                   );
                 })}
               </ul>
-            ) : (
-              <p class="mt-2 text-xs text-gray-600">
-                Ingen `vis:updated` metadata funnet ennå. Seksjonen aktiveres automatisk når feltet tas i bruk.
-              </p>
-            )}
-          </section>
-        </>
-      )
-    }
+            ) : null}
+
+            <details class="rounded-md border border-gray-200 bg-white">
+              <summary class="cursor-pointer px-3 py-2 text-xs font-medium text-gray-700">
+                Eldre wireframes og VIS-dokumenter ({archiveEntries.length})
+              </summary>
+              <div class="border-t border-gray-200 px-1 py-2">
+                {archiveGrouped.map((group) => (
+                  <section class="mb-3 last:mb-0">
+                    <h3 class="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-gray-500">{group.section}</h3>
+                    <ul class="divide-y divide-gray-100">
+                      {group.items.map(({ filename: name, slug, displayTitle }) => {
+                        const view = `${base}vis/${encodeURIComponent(slug)}`;
+                        return (
+                          <li class="flex items-center justify-between gap-2 px-2 py-1.5">
+                            <div class="min-w-0">
+                              <p class="truncate text-xs text-gray-800">{displayTitle}</p>
+                              <p class="truncate font-mono text-[10px] text-gray-400">{name}</p>
+                            </div>
+                            <a href={view} class="shrink-0 text-[11px] text-gray-600 underline underline-offset-2">
+                              Åpne
+                            </a>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </section>
+                ))}
+              </div>
+            </details>
+          </div>
+        ) : null
+      }
+    </section>
+
+    <section class="mt-10 max-w-prose border-t border-gray-200 pt-6" aria-labelledby="vis-sot">
+      <h2 id="vis-sot" class="text-xs font-semibold uppercase tracking-wide text-gray-500">Source of truth</h2>
+      <ul class="mt-2 space-y-1.5 p-0 text-xs text-gray-600">
+        {visSourceOfTruthNotes.map((note) => (
+          <li class="list-none">
+            <code class="font-mono text-[11px] text-gray-800">{note.label}</code>
+            <span> — {note.role}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
   </main>
 </PrototypeLayout>


### PR DESCRIPTION
## Summary
- Reorganize `/vis/` as control room with hub & spoke IA
- MVP nå from registry (5 surfaces only — review/sprint moved to hubs)
- Seven main hubs with mandates (Backstage planned, not built)
- Neste arbeid from current-state
- Historikk/arkiv at lower visual weight
- Source-of-truth section

## Test plan
- [ ] `/vis/` — mandat, MVP nå, huber, neste arbeid, arkiv, SOT
- [ ] Hub links work (designsystem, review, roadmap, gitbuss, DAM)
- [ ] Backstage shows as planned/disabled
- [ ] No `/no/*` changes
- [ ] Build green


Made with [Cursor](https://cursor.com)