### PR TITLE
feat: Backstage v0.1 — intern systemreferanse (#184)

### DIFF
--- a/.cursor/rules/viddel-operating-rules.mdc
+++ b/.cursor/rules/viddel-operating-rules.mdc
@@ -1,5 +1,5 @@
 ---
-description: Viddel operating rules — designsystem, current-state registry, VIS frontpage, Return Tickets
+description: Viddel operating rules — designsystem, current-state registry, VIS frontpage, Backstage, Return Tickets
 alwaysApply: true
 ---
 
@@ -8,6 +8,7 @@ alwaysApply: true
 ## Source of truth
 
 - `/designsystem/` = gjeldende designsystem-sannhet
+- `/backstage/` = gjeldende systemreferanse (AI-flow, API, guards, env-vars, production)
 - `src/data/mvp-current-state.ts` = gjeldende operativ MVP-status
 - `/vis/sprints/...` = historikk og beslutningsgrunnlag
 
@@ -22,14 +23,35 @@ Update `src/data/mvp-current-state.ts` when work affects:
 
 VIS frontpage (`src/pages/vis/index.astro`) reads from this registry — do not hand-code «MVP nå» cards.
 
+## Backstage impact (always consider)
+
+Vurder `/backstage/` ved endringer i:
+
+- `src/pages/api/chat.ts`
+- `src/lib/chat-api-guard.ts`
+- `.env.example` (if present)
+- `src/data/mvp-current-state.ts` (when system/production status changes)
+- Vercel / Upstash / CES-relaterte docs
+- access / login
+- monitoring
+- production activation
+- routes eller systemflyt som Backstage forklarer
+
+If system understanding changes → update `src/data/backstage-v01.ts` in the same PR, or state explicitly in Return Ticket why Backstage is unaffected.
+
+Run `npm run verify:backstage-guard` before merge (included in `npm run build`).
+
 ## Return Ticket (required fields when relevant)
 
 - Designsystem impact
 - Current-state / VIS frontpage impact
+- **Backstage impact** (`Oppdatert` / `Ikke relevant` / `Må følges opp`)
 - Applied surfaces impacted
 - Follow-up needed
 
-If not applicable: `Current-state update: Ikke nødvendig — ingen endring i MVP-status, designmønstre eller applied surfaces.`
+If not applicable:
+- `Current-state update: Ikke nødvendig — ingen endring i MVP-status, designmønstre eller applied surfaces.`
+- `Backstage impact: Ikke relevant — ingen endring i systemflyt, API, guard, env-vars, monitoring eller production-status.`
 
 ## Docs
 

--- a/docs/project/06_RETURN_TICKET.md
+++ b/docs/project/06_RETURN_TICKET.md
@@ -30,6 +30,9 @@ Designsystem impact
 Current-state / VIS frontpage impact
 - (Hvis ikke relevant: «Current-state update: Ikke nødvendig — ingen endring i MVP-status, designmønstre eller applied surfaces.»)
 
+Backstage impact
+- `Oppdatert: ...` / `Ikke relevant: ingen endring i systemflyt, API, guard, env-vars, monitoring eller production-status.` / `Må følges opp: ...`
+
 Applied surfaces impacted
 - 
 
@@ -38,6 +41,7 @@ Follow-up needed
 
 Hva må oppdateres
 - [ ] VIS (`src/data/mvp-current-state.ts` ved MVP-statusendring)
+- [ ] `/backstage/` (ved endring i systemflyt, API, guard, env-vars, monitoring eller production)
 - [ ] `/designsystem/` (ved mønsterendring)
 - [ ] roadmap
 - [ ] Google Doc

--- a/docs/project/OPERATING_RULES.md
+++ b/docs/project/OPERATING_RULES.md
@@ -7,6 +7,7 @@ Operative regler for Cursor, Codex og menneskelig HITL i Viddel Lab.
 | Flate | Rolle |
 |-------|--------|
 | `/designsystem/` | Gjeldende designsystem-sannhet (mønstre, primitives, applied surfaces) |
+| `/backstage/` | Gjeldende systemreferanse (AI-flow, API, guards, env-vars, production) |
 | `src/data/mvp-current-state.ts` | Gjeldende operativ MVP-status og `currentSprint` |
 | `/vis/sprints/...` | Aktiv sprint (control room) eller historikk (arkiv) — avhenger av `currentSprint.status` |
 | GitHub Projects / issues | Oppgavebuss |

--- a/docs/project/OPERATING_RULES.md
+++ b/docs/project/OPERATING_RULES.md
@@ -43,6 +43,18 @@ Ved sprintskifte:
 
 Validering: `src/lib/vis-sprint-guard.ts` — aktiv sprint kan ikke ligge i `closedSprints` eller eksponeres som `historikk`-hub.
 
+## B3. Backstage-regel (systemreferanse)
+
+Backstage impact skal vurderes ved alle endringer i AI/API/system/production.
+
+Hvis en oppgave endrer systemflyt, API, guard, limits, env-vars, Vercel/Upstash/CES-kobling, monitoring, access/login eller production-aktivering:
+
+→ oppdater `/backstage/` (`src/data/backstage-v01.ts` + `src/pages/backstage/index.astro`) **eller** forklar eksplisitt i Return Ticket hvorfor Backstage ikke påvirkes.
+
+Ved endring i `src/lib/chat-api-guard.ts` (limits, max length): oppdater Backstage protection rules og runbooks i samme PR.
+
+Validering: `npm run verify:backstage-guard` (kjøres automatisk før `npm run build`).
+
 ## C. VIS frontpage-regel
 
 - VIS-forsiden viser gjeldende MVP-status fra `getVisFrontpageEntries()` / `mvpCurrentState`.
@@ -55,10 +67,21 @@ Alle relevante Return Tickets skal inneholde:
 
 1. **Designsystem impact** — mønstre brukt / nye / `/designsystem/` oppdatert?
 2. **Current-state / VIS frontpage impact** — skal `mvp-current-state.ts` oppdateres?
-3. **Applied surfaces impacted** — hvilke routes?
-4. **Follow-up needed** — åpne risiko eller neste steg?
+3. **Backstage impact** — skal `/backstage/` oppdateres? (Se under.)
+4. **Applied surfaces impacted** — hvilke routes?
+5. **Follow-up needed** — åpne risiko eller neste steg?
+
+**Backstage impact** — forventet innhold:
+
+- `Oppdatert: ...` (hva i runbooks, tjenestekart, feilstater eller lenker)
+- `Ikke relevant: ingen endring i systemflyt, API, guard, env-vars, monitoring eller production-status.`
+- `Må følges opp: ...`
 
 Hvis ikke relevant, skriv eksplisitt:
+
+> Backstage impact: Ikke relevant — ingen endring i systemflyt, API, guard, env-vars, monitoring eller production-status.
+
+Hvis current-state ikke endres:
 
 > Current-state update: Ikke nødvendig — ingen endring i MVP-status, designmønstre eller applied surfaces.
 
@@ -67,8 +90,9 @@ Hvis ikke relevant, skriv eksplisitt:
 1. Les issue/prompt og relevante docs.
 2. Les `/designsystem/` ved UI-arbeid.
 3. Les `src/data/mvp-current-state.ts` ved status-/VIS-arbeid.
-4. Hold endringer små; `npm run build` før ferdig.
-5. Return Ticket på relevant issue.
+4. Vurder Backstage (`/backstage/`) ved endringer i API, guard, env-vars eller production.
+5. Hold endringer små; `npm run build` før ferdig.
+6. Return Ticket på relevant issue.
 
 ## Filer
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs && astro build",
+    "build": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs && node --experimental-strip-types scripts/verify-backstage-guard.mjs && astro build",
     "verify:vis-sprint-guard": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs",
+    "verify:backstage-guard": "node --experimental-strip-types scripts/verify-backstage-guard.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "storyblok:bootstrap:slice01": "node scripts/storyblok-bootstrap-slice-01.mjs",

--- a/scripts/verify-backstage-guard.mjs
+++ b/scripts/verify-backstage-guard.mjs
@@ -1,0 +1,14 @@
+/* CONTRACT: Build-time check — Backstage registry, links and guard limit alignment. */
+import { validateBackstageGuard } from "../src/lib/backstage-guard.ts";
+
+const errors = validateBackstageGuard();
+
+if (errors.length > 0) {
+  console.error("Backstage guard failed:\n");
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log("Backstage guard OK");

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -164,6 +164,98 @@ export const cesExplainer = {
   body: "CES er AI-motoren som lager svaret. Viddel eier grensesnittet rundt — chatten, feilmeldingene og hvordan det føles for brukeren.",
 } as const;
 
+export type BackstageLink = {
+  label: string;
+  href: string;
+  /** Open in new tab for external consoles */
+  external?: boolean;
+};
+
+/** Klikkbare handlingslenker — ingen secrets, kun offentlige konsoll-URL-er. */
+export const backstageLinks = {
+  vercelProject: {
+    label: "Åpne Vercel-prosjekt",
+    href: "https://vercel.com/raddum-5965s-projects/vox-web",
+    external: true,
+  },
+  vercelEnv: {
+    label: "Åpne Vercel env-vars",
+    href: "https://vercel.com/raddum-5965s-projects/vox-web/settings/environment-variables",
+    external: true,
+  },
+  vercelDeployments: {
+    label: "Åpne Vercel Deployments",
+    href: "https://vercel.com/raddum-5965s-projects/vox-web/deployments",
+    external: true,
+  },
+  vercelLogs: {
+    label: "Åpne Runtime Logs",
+    href: "https://vercel.com/raddum-5965s-projects/vox-web/logs",
+    external: true,
+  },
+  upstashConsole: {
+    label: "Åpne Upstash Console",
+    href: "https://console.upstash.com/",
+    external: true,
+  },
+  googleCloud: {
+    label: "Åpne Google Cloud",
+    href: "https://console.cloud.google.com/?project=hearing-aid-mvp",
+    external: true,
+  },
+  githubRepo: {
+    label: "Åpne GitHub repo",
+    href: "https://github.com/THUNDERPLUNDER/vox-web",
+    external: true,
+  },
+  githubIssues: {
+    label: "Åpne GitHub issues",
+    href: "https://github.com/THUNDERPLUNDER/vox-web/issues",
+    external: true,
+  },
+  githubIssue181: {
+    label: "Issue #181 (access parkert)",
+    href: "https://github.com/THUNDERPLUNDER/vox-web/issues/181",
+    external: true,
+  },
+  githubPulls: {
+    label: "Åpne PR-er",
+    href: "https://github.com/THUNDERPLUNDER/vox-web/pulls",
+    external: true,
+  },
+  guardFile: {
+    label: "Åpne guard-koden",
+    href: "https://github.com/THUNDERPLUNDER/vox-web/blob/main/src/lib/chat-api-guard.ts",
+    external: true,
+  },
+  apiRouteFile: {
+    label: "Åpne API-ruten",
+    href: "https://github.com/THUNDERPLUNDER/vox-web/blob/main/src/pages/api/chat.ts",
+    external: true,
+  },
+  currentStateFile: {
+    label: "Åpne current-state-filen",
+    href: "https://github.com/THUNDERPLUNDER/vox-web/blob/main/src/data/mvp-current-state.ts",
+    external: true,
+  },
+  vis: {
+    label: "Åpne VIS",
+    href: "https://vox.raddum.no/vis/",
+  },
+  backstage: {
+    label: "Åpne Backstage",
+    href: "https://vox.raddum.no/backstage/",
+  },
+  designsystem: {
+    label: "Åpne Designsystem",
+    href: "https://vox.raddum.no/designsystem/",
+  },
+  chat: {
+    label: "Åpne Spør Viddel",
+    href: "https://vox.raddum.no/no/chat/",
+  },
+} as const satisfies Record<string, BackstageLink>;
+
 export type ChangeRunbook = {
   id: string;
   title: string;
@@ -172,6 +264,7 @@ export type ChangeRunbook = {
   whereToGo: string;
   after: string;
   test: string;
+  actionLinks: readonly BackstageLink[];
   tech?: string;
   envVars?: readonly string[];
 };
@@ -183,6 +276,7 @@ export type ServiceEntry = {
   role: readonly string[];
   whenToOpen: readonly string[];
   places: readonly string[];
+  actionLinks: readonly BackstageLink[];
 };
 
 /** Overordnet flyt — hvilke tjenester som henger sammen. */
@@ -216,6 +310,12 @@ export const services: ServiceEntry[] = [
       "Deployments",
       "Runtime Logs",
     ],
+    actionLinks: [
+      backstageLinks.vercelProject,
+      backstageLinks.vercelEnv,
+      backstageLinks.vercelDeployments,
+      backstageLinks.vercelLogs,
+    ],
   },
   {
     id: "upstash",
@@ -236,6 +336,7 @@ export const services: ServiceEntry[] = [
       "REST URL / REST TOKEN",
       "Usage / Monitor",
     ],
+    actionLinks: [backstageLinks.upstashConsole],
   },
   {
     id: "google-ces",
@@ -257,6 +358,7 @@ export const services: ServiceEntry[] = [
       "CES / Agent deployment",
       "Service account / credentials",
     ],
+    actionLinks: [backstageLinks.googleCloud],
   },
   {
     id: "github",
@@ -277,6 +379,11 @@ export const services: ServiceEntry[] = [
       "Pull requests",
       "Commit history",
     ],
+    actionLinks: [
+      backstageLinks.githubRepo,
+      backstageLinks.githubIssues,
+      backstageLinks.githubPulls,
+    ],
   },
   {
     id: "vis",
@@ -292,29 +399,35 @@ export const services: ServiceEntry[] = [
       "Navigere til /designsystem/ eller /backstage/",
     ],
     places: ["/vis/", "/designsystem/", "/backstage/"],
+    actionLinks: [backstageLinks.vis, backstageLinks.designsystem, backstageLinks.backstage],
   },
 ];
 
 export const firstCheckRules = [
   {
     symptom: "Siden laster ikke",
-    check: "Vercel → vox-web → Deployments / logs",
+    check: "Vercel → Deployments / logs",
+    links: [backstageLinks.vercelDeployments, backstageLinks.vercelLogs],
   },
   {
     symptom: "Chatten svarer ikke",
-    check: "Vercel → Runtime Logs først",
+    check: "Vercel → Runtime Logs først, deretter Google Cloud / CES",
+    links: [backstageLinks.vercelLogs, backstageLinks.googleCloud, backstageLinks.chat],
   },
   {
     symptom: "Rate limit slår inn",
     check: "Upstash + Vercel logs",
+    links: [backstageLinks.upstashConsole, backstageLinks.vercelLogs],
   },
   {
     symptom: "AI feiler",
     check: "Vercel logs + Google Cloud / CES",
+    links: [backstageLinks.vercelLogs, backstageLinks.googleCloud],
   },
   {
     symptom: "Status i VIS er feil",
-    check: "src/data/mvp-current-state.ts → sjekk /vis/",
+    check: "current-state-filen → sjekk VIS",
+    links: [backstageLinks.currentStateFile, backstageLinks.vis],
   },
 ] as const;
 
@@ -329,6 +442,11 @@ export const changeRunbooks: ChangeRunbook[] = [
       "GitHub/Cursor for kodeendring i guard. Etterpå Vercel → Deployments. Ikke Vercel env alene — grensene ligger i kode i dag.",
     after: "Commit, deploy til Production, og test at chat fortsatt fungerer.",
     test: "Ett vanlig spørsmål (skal fungere). 11 raske spørsmål (skal stoppe med tydelig melding). For lang melding (skal avvises).",
+    actionLinks: [
+      backstageLinks.guardFile,
+      backstageLinks.githubPulls,
+      backstageLinks.vercelDeployments,
+    ],
     tech: "src/lib/chat-api-guard.ts",
   },
   {
@@ -339,6 +457,7 @@ export const changeRunbooks: ChangeRunbook[] = [
     whereToGo: "GitHub/Cursor for kodeendring i guard. Etterpå Vercel → Deployments.",
     after: "Commit, deploy, og test med spørsmål på og rett over grensen.",
     test: "Send spørsmål med 2000 tegn (skal fungere). Send 2001 tegn eller mer (skal avvises med tydelig melding).",
+    actionLinks: [backstageLinks.guardFile, backstageLinks.vercelDeployments],
     tech: "src/lib/chat-api-guard.ts · brukt av src/pages/api/chat.ts",
   },
   {
@@ -350,6 +469,11 @@ export const changeRunbooks: ChangeRunbook[] = [
       "Upstash Console → Redis viddel-chat-rate-limit. Vercel → Settings → Environment Variables. Vercel → Deployments for redeploy.",
     after: "Redeploy Production. Test at chat svarer og at rate limit fortsatt virker.",
     test: "Ett vanlig spørsmål i Spør Viddel. Sjekk at feilmelding er trygg hvis noe er feil — ikke teknisk rot.",
+    actionLinks: [
+      backstageLinks.upstashConsole,
+      backstageLinks.vercelEnv,
+      backstageLinks.vercelDeployments,
+    ],
     envVars: ["UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN"],
     tech: "Verdier aldri i repo, ChatGPT eller Cursor.",
   },
@@ -362,6 +486,12 @@ export const changeRunbooks: ChangeRunbook[] = [
       "Google Cloud / CES for agent og deployment. Vercel → Environment Variables. Vercel → Deployments for redeploy.",
     after: "Redeploy Production. Test ekte svar i Spør Viddel.",
     test: "Send et enkelt spørsmål og bekreft at svaret kommer tilbake i chatten.",
+    actionLinks: [
+      backstageLinks.googleCloud,
+      backstageLinks.vercelEnv,
+      backstageLinks.vercelDeployments,
+      backstageLinks.chat,
+    ],
     envVars: [
       "CES_PROJECT_ID",
       "CES_LOCATION",
@@ -381,6 +511,12 @@ export const changeRunbooks: ChangeRunbook[] = [
       "Vercel → Environment Variables / Deployments. Kontrollert handling — påvirker production. Oppdater VIS/current-state etterpå.",
     after: "Redeploy. Oppdater VIS current-state så teamet vet at AI er av.",
     test: "Brukeren skal se trygg feilmelding («Viddel er ikke tilgjengelig akkurat nå») — ikke rå teknisk feil.",
+    actionLinks: [
+      backstageLinks.vercelEnv,
+      backstageLinks.vercelDeployments,
+      backstageLinks.currentStateFile,
+      backstageLinks.vis,
+    ],
     tech: "configuration_missing · src/lib/ces-env.ts",
   },
   {
@@ -392,6 +528,12 @@ export const changeRunbooks: ChangeRunbook[] = [
       "Ikke nå — eget arbeidsspor før ekstern pilot. UI-retning: «Mine sider» i globalmenyen, ikke kodefelt i chatten.",
     after: "Server-side må fortsatt beskytte /api/chat når det kommer.",
     test: "Når det kommer: chatten skal oppleves som tilgjengelig når brukeren er inne — uten passord i selve chat-flaten.",
+    actionLinks: [
+      backstageLinks.githubIssues,
+      backstageLinks.githubIssue181,
+      backstageLinks.vis,
+      backstageLinks.backstage,
+    ],
     tech: "Access Gate #181 parkert/revertet.",
   },
   {
@@ -402,6 +544,11 @@ export const changeRunbooks: ChangeRunbook[] = [
     whereToGo: "GitHub/Cursor → src/data/mvp-current-state.ts. VIS → /vis/ for kontroll etterpå.",
     after: "Sjekk /vis/ etterpå. Legg Return Ticket på relevant issue.",
     test: "VIS kontrollrom viser oppdatert nå-status og neste arbeid.",
+    actionLinks: [
+      backstageLinks.currentStateFile,
+      backstageLinks.vis,
+      backstageLinks.githubIssues,
+    ],
     tech: "UI-mønster → vurder /designsystem/ · systemflyt → oppdater /backstage/",
   },
 ];

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -169,11 +169,154 @@ export type ChangeRunbook = {
   title: string;
   whatChanges: string;
   where: string;
+  whereToGo: string;
   after: string;
   test: string;
   tech?: string;
   envVars?: readonly string[];
 };
+
+export type ServiceEntry = {
+  id: string;
+  name: string;
+  layer: string;
+  role: readonly string[];
+  whenToOpen: readonly string[];
+  places: readonly string[];
+};
+
+/** Overordnet flyt — hvilke tjenester som henger sammen. */
+export const serviceMapFlow = [
+  { label: "Brukerflate", hint: "Spør Viddel" },
+  { label: "Vercel", hint: "Nettsted + API" },
+  { label: "Upstash · CES", hint: "Teller + AI" },
+  { label: "GitHub · VIS", hint: "Styring + status" },
+] as const;
+
+/** Tjenestekart — hvor gjør vi hva? */
+export const services: ServiceEntry[] = [
+  {
+    id: "vercel",
+    name: "Vercel",
+    layer: "Kjører production",
+    role: [
+      "Kjører Viddel-siden og /api/chat i production",
+      "Har environment variables",
+      "Har deployments og runtime logs",
+    ],
+    whenToOpen: [
+      "Sette eller endre env-vars",
+      "Redeploye etter endring",
+      "Se runtime logs",
+      "Når production ikke virker",
+    ],
+    places: [
+      "Project: vox-web",
+      "Settings → Environment Variables",
+      "Deployments",
+      "Runtime Logs",
+    ],
+  },
+  {
+    id: "upstash",
+    name: "Upstash",
+    layer: "Teller bruk",
+    role: [
+      "Teller bruk for rate limit",
+      "Holder styr på spørsmål per IP",
+      "Lagrer ikke samtalehistorikk",
+    ],
+    whenToOpen: [
+      "Sjekke rate limit / bruk",
+      "Bytte eller rotere Redis-token",
+      "Når rate limit oppfører seg rart",
+    ],
+    places: [
+      "Redis: viddel-chat-rate-limit",
+      "REST URL / REST TOKEN",
+      "Usage / Monitor",
+    ],
+  },
+  {
+    id: "google-ces",
+    name: "Google Cloud / CES",
+    layer: "AI-motor",
+    role: [
+      "AI-motoren som lager svarene",
+      "Viddel-agent og deployment",
+      "Kalles fra /api/chat via service account",
+    ],
+    whenToOpen: [
+      "AI-svar kommer ikke",
+      "Agent/deployment skal sjekkes",
+      "CES-id-er eller service account må oppdateres",
+      "Kunnskapsgrunnlag eller agentoppsett endres",
+    ],
+    places: [
+      "Google Cloud project",
+      "CES / Agent deployment",
+      "Service account / credentials",
+    ],
+  },
+  {
+    id: "github",
+    name: "GitHub",
+    layer: "Kode og oppgaver",
+    role: [
+      "Kode, PR-er, issues og Return Tickets",
+      "Oppgavebuss og beslutningshistorikk",
+    ],
+    whenToOpen: [
+      "Se hva som er gjort",
+      "Opprette eller endre arbeidsspor",
+      "Lese Return Tickets",
+      "Når Cursor har pushet branch/PR",
+    ],
+    places: [
+      "THUNDERPLUNDER/vox-web → Issues",
+      "Pull requests",
+      "Commit history",
+    ],
+  },
+  {
+    id: "vis",
+    name: "VIS",
+    layer: "Intern styring",
+    role: [
+      "Intern visnings- og reviewflate",
+      "Current-state, huber, sprint og systemflater",
+    ],
+    whenToOpen: [
+      "Se hvor prosjektet står",
+      "QA-e flater",
+      "Navigere til /designsystem/ eller /backstage/",
+    ],
+    places: ["/vis/", "/designsystem/", "/backstage/"],
+  },
+];
+
+export const firstCheckRules = [
+  {
+    symptom: "Siden laster ikke",
+    check: "Vercel → vox-web → Deployments / logs",
+  },
+  {
+    symptom: "Chatten svarer ikke",
+    check: "Vercel → Runtime Logs først",
+  },
+  {
+    symptom: "Rate limit slår inn",
+    check: "Upstash + Vercel logs",
+  },
+  {
+    symptom: "AI feiler",
+    check: "Vercel logs + Google Cloud / CES",
+  },
+  {
+    symptom: "Status i VIS er feil",
+    check: "src/data/mvp-current-state.ts → sjekk /vis/",
+  },
+] as const;
 
 /** Runbooks — hvordan vi endrer operative verdier senere. */
 export const changeRunbooks: ChangeRunbook[] = [
@@ -182,6 +325,8 @@ export const changeRunbooks: ChangeRunbook[] = [
     title: "Endre rate limits",
     whatChanges: "Hvor mange spørsmål som tillates — per 10 minutter og per døgn (per IP).",
     where: "I chat guard-koden. Nåværende grenser: 10 per 10 min og 50 per døgn.",
+    whereToGo:
+      "GitHub/Cursor for kodeendring i guard. Etterpå Vercel → Deployments. Ikke Vercel env alene — grensene ligger i kode i dag.",
     after: "Commit, deploy til Production, og test at chat fortsatt fungerer.",
     test: "Ett vanlig spørsmål (skal fungere). 11 raske spørsmål (skal stoppe med tydelig melding). For lang melding (skal avvises).",
     tech: "src/lib/chat-api-guard.ts",
@@ -191,6 +336,7 @@ export const changeRunbooks: ChangeRunbook[] = [
     title: "Endre maks lengde på spørsmål",
     whatChanges: "Hvor langt spørsmål brukeren kan sende — i dag 2000 tegn.",
     where: "I input-valideringen for chat guard.",
+    whereToGo: "GitHub/Cursor for kodeendring i guard. Etterpå Vercel → Deployments.",
     after: "Commit, deploy, og test med spørsmål på og rett over grensen.",
     test: "Send spørsmål med 2000 tegn (skal fungere). Send 2001 tegn eller mer (skal avvises med tydelig melding).",
     tech: "src/lib/chat-api-guard.ts · brukt av src/pages/api/chat.ts",
@@ -199,7 +345,9 @@ export const changeRunbooks: ChangeRunbook[] = [
     id: "upstash",
     title: "Endre eller bytte Upstash",
     whatChanges: "Bytte telleren som holder styr på bruk — f.eks. ny Upstash-database eller nye nøkler.",
-    where: "Vercel → Environment Variables → Production.",
+    where: "Upstash Console for Redis/REST-token. Vercel for env-vars.",
+    whereToGo:
+      "Upstash Console → Redis viddel-chat-rate-limit. Vercel → Settings → Environment Variables. Vercel → Deployments for redeploy.",
     after: "Redeploy Production. Test at chat svarer og at rate limit fortsatt virker.",
     test: "Ett vanlig spørsmål i Spør Viddel. Sjekk at feilmelding er trygg hvis noe er feil — ikke teknisk rot.",
     envVars: ["UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN"],
@@ -209,7 +357,9 @@ export const changeRunbooks: ChangeRunbook[] = [
     id: "ces",
     title: "Endre CES / AI-motor-kobling",
     whatChanges: "Bytte eller oppdatere koblingen til AI-agenten — ny versjon, deployment eller prosjekt.",
-    where: "Vercel Environment Variables (Production) og oppsett i Google/CES.",
+    where: "Google Cloud/CES for agent/deployment. Vercel for env-vars.",
+    whereToGo:
+      "Google Cloud / CES for agent og deployment. Vercel → Environment Variables. Vercel → Deployments for redeploy.",
     after: "Redeploy Production. Test ekte svar i Spør Viddel.",
     test: "Send et enkelt spørsmål og bekreft at svaret kommer tilbake i chatten.",
     envVars: [
@@ -226,7 +376,9 @@ export const changeRunbooks: ChangeRunbook[] = [
     id: "disable-ai",
     title: "Slå av AI midlertidig",
     whatChanges: "Stoppe AI-svar midlertidig — ved feil, kostnadsbekymring eller uventet adferd.",
-    where: "Trygg metode: fjern eller deaktiver nødvendig CES-konfig i Vercel Production (CES env-vars).",
+    where: "Fjern eller deaktiver CES env-vars i Vercel Production.",
+    whereToGo:
+      "Vercel → Environment Variables / Deployments. Kontrollert handling — påvirker production. Oppdater VIS/current-state etterpå.",
     after: "Redeploy. Oppdater VIS current-state så teamet vet at AI er av.",
     test: "Brukeren skal se trygg feilmelding («Viddel er ikke tilgjengelig akkurat nå») — ikke rå teknisk feil.",
     tech: "configuration_missing · src/lib/ces-env.ts",
@@ -235,8 +387,10 @@ export const changeRunbooks: ChangeRunbook[] = [
     id: "access",
     title: "Tilgang / passord / ekstern pilot",
     whatChanges: "Hvem som får bruke Spør Viddel ved ekstern pilot — ikke relevant nå (access er parkert).",
-    where: "Fremtidig retning: «Mine sider» / innlogget tilstand i globalmenyen — ikke kodefelt inne i chatten.",
-    after: "Eget arbeidsspor før ekstern pilot. Server-side må fortsatt beskytte /api/chat.",
+    where: "Fremtidig retning: «Mine sider» / innlogget tilstand i globalmenyen.",
+    whereToGo:
+      "Ikke nå — eget arbeidsspor før ekstern pilot. UI-retning: «Mine sider» i globalmenyen, ikke kodefelt i chatten.",
+    after: "Server-side må fortsatt beskytte /api/chat når det kommer.",
     test: "Når det kommer: chatten skal oppleves som tilgjengelig når brukeren er inne — uten passord i selve chat-flaten.",
     tech: "Access Gate #181 parkert/revertet.",
   },
@@ -245,9 +399,10 @@ export const changeRunbooks: ChangeRunbook[] = [
     title: "Når vi endrer status",
     whatChanges: "Hva som er sant nå — live AI, guard, neste steg, risiko.",
     where: "Registry-filen for MVP-status.",
+    whereToGo: "GitHub/Cursor → src/data/mvp-current-state.ts. VIS → /vis/ for kontroll etterpå.",
     after: "Sjekk /vis/ etterpå. Legg Return Ticket på relevant issue.",
     test: "VIS kontrollrom viser oppdatert nå-status og neste arbeid.",
-    tech: "src/data/mvp-current-state.ts · UI-mønster → vurder /designsystem/ · systemflyt → oppdater /backstage/",
+    tech: "UI-mønster → vurder /designsystem/ · systemflyt → oppdater /backstage/",
   },
 ];
 

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -164,6 +164,93 @@ export const cesExplainer = {
   body: "CES er AI-motoren som lager svaret. Viddel eier grensesnittet rundt — chatten, feilmeldingene og hvordan det føles for brukeren.",
 } as const;
 
+export type ChangeRunbook = {
+  id: string;
+  title: string;
+  whatChanges: string;
+  where: string;
+  after: string;
+  test: string;
+  tech?: string;
+  envVars?: readonly string[];
+};
+
+/** Runbooks — hvordan vi endrer operative verdier senere. */
+export const changeRunbooks: ChangeRunbook[] = [
+  {
+    id: "rate-limits",
+    title: "Endre rate limits",
+    whatChanges: "Hvor mange spørsmål som tillates — per 10 minutter og per døgn (per IP).",
+    where: "I chat guard-koden. Nåværende grenser: 10 per 10 min og 50 per døgn.",
+    after: "Commit, deploy til Production, og test at chat fortsatt fungerer.",
+    test: "Ett vanlig spørsmål (skal fungere). 11 raske spørsmål (skal stoppe med tydelig melding). For lang melding (skal avvises).",
+    tech: "src/lib/chat-api-guard.ts",
+  },
+  {
+    id: "max-length",
+    title: "Endre maks lengde på spørsmål",
+    whatChanges: "Hvor langt spørsmål brukeren kan sende — i dag 2000 tegn.",
+    where: "I input-valideringen for chat guard.",
+    after: "Commit, deploy, og test med spørsmål på og rett over grensen.",
+    test: "Send spørsmål med 2000 tegn (skal fungere). Send 2001 tegn eller mer (skal avvises med tydelig melding).",
+    tech: "src/lib/chat-api-guard.ts · brukt av src/pages/api/chat.ts",
+  },
+  {
+    id: "upstash",
+    title: "Endre eller bytte Upstash",
+    whatChanges: "Bytte telleren som holder styr på bruk — f.eks. ny Upstash-database eller nye nøkler.",
+    where: "Vercel → Environment Variables → Production.",
+    after: "Redeploy Production. Test at chat svarer og at rate limit fortsatt virker.",
+    test: "Ett vanlig spørsmål i Spør Viddel. Sjekk at feilmelding er trygg hvis noe er feil — ikke teknisk rot.",
+    envVars: ["UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN"],
+    tech: "Verdier aldri i repo, ChatGPT eller Cursor.",
+  },
+  {
+    id: "ces",
+    title: "Endre CES / AI-motor-kobling",
+    whatChanges: "Bytte eller oppdatere koblingen til AI-agenten — ny versjon, deployment eller prosjekt.",
+    where: "Vercel Environment Variables (Production) og oppsett i Google/CES.",
+    after: "Redeploy Production. Test ekte svar i Spør Viddel.",
+    test: "Send et enkelt spørsmål og bekreft at svaret kommer tilbake i chatten.",
+    envVars: [
+      "CES_PROJECT_ID",
+      "CES_LOCATION",
+      "CES_APP_ID",
+      "CES_APP_VERSION_ID",
+      "CES_DEPLOYMENT_ID",
+      "GOOGLE_SERVICE_ACCOUNT_JSON",
+    ],
+    tech: "Service account JSON kun i Vercel — aldri i repo.",
+  },
+  {
+    id: "disable-ai",
+    title: "Slå av AI midlertidig",
+    whatChanges: "Stoppe AI-svar midlertidig — ved feil, kostnadsbekymring eller uventet adferd.",
+    where: "Trygg metode: fjern eller deaktiver nødvendig CES-konfig i Vercel Production (CES env-vars).",
+    after: "Redeploy. Oppdater VIS current-state så teamet vet at AI er av.",
+    test: "Brukeren skal se trygg feilmelding («Viddel er ikke tilgjengelig akkurat nå») — ikke rå teknisk feil.",
+    tech: "configuration_missing · src/lib/ces-env.ts",
+  },
+  {
+    id: "access",
+    title: "Tilgang / passord / ekstern pilot",
+    whatChanges: "Hvem som får bruke Spør Viddel ved ekstern pilot — ikke relevant nå (access er parkert).",
+    where: "Fremtidig retning: «Mine sider» / innlogget tilstand i globalmenyen — ikke kodefelt inne i chatten.",
+    after: "Eget arbeidsspor før ekstern pilot. Server-side må fortsatt beskytte /api/chat.",
+    test: "Når det kommer: chatten skal oppleves som tilgjengelig når brukeren er inne — uten passord i selve chat-flaten.",
+    tech: "Access Gate #181 parkert/revertet.",
+  },
+  {
+    id: "status",
+    title: "Når vi endrer status",
+    whatChanges: "Hva som er sant nå — live AI, guard, neste steg, risiko.",
+    where: "Registry-filen for MVP-status.",
+    after: "Sjekk /vis/ etterpå. Legg Return Ticket på relevant issue.",
+    test: "VIS kontrollrom viser oppdatert nå-status og neste arbeid.",
+    tech: "src/data/mvp-current-state.ts · UI-mønster → vurder /designsystem/ · systemflyt → oppdater /backstage/",
+  },
+];
+
 export type TroubleshootingCase = {
   id: string;
   userSees: string;

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -1,0 +1,198 @@
+/* CONTRACT: Backstage v0.1 content — human-readable system reference for AI/API/guards/env (no secret values). */
+
+export const backstageMeta = {
+  title: "Backstage",
+  lead: "Backstage forklarer hvordan Viddel fungerer bak scenen: AI-flow, API, guards, env-vars, feilstater og production-sjekker.",
+  updatedAt: "2026-05-30",
+  issue: "#184",
+  relatedIssue: "#180",
+} as const;
+
+export const systemFlowSteps = [
+  { id: "user", label: "Bruker" },
+  { id: "chat-ui", label: "/no/chat/" },
+  { id: "api", label: "/api/chat" },
+  { id: "input", label: "Input guard" },
+  { id: "origin", label: "Origin guard" },
+  { id: "rate", label: "Upstash rate limit" },
+  { id: "ces", label: "CES runSession" },
+  { id: "response", label: "Svar tilbake" },
+] as const;
+
+export const chatFlowSteps = [
+  {
+    id: "ui",
+    title: "Chat UI",
+    detail: "Standalone custom chat på `/no/chat/` — samler melding og sessionId, viser svar og feilmeldinger.",
+  },
+  {
+    id: "api",
+    title: "API",
+    detail: "POST `/api/chat` — server-side proxy. Credentials og CES-detaljer eksponeres aldri til klienten.",
+  },
+  {
+    id: "input",
+    title: "Input guard",
+    detail: "Validerer JSON, tom melding, sessionId-format og maks 2000 tegn før noe sendes videre.",
+  },
+  {
+    id: "origin",
+    title: "Origin guard",
+    detail: "Ekstra friksjon mot direkte API-kall utenfor tillatte domener (vox.raddum.no, viddel.no, preview/dev).",
+  },
+  {
+    id: "rate",
+    title: "Upstash rate limit",
+    detail: "IP-basert telling per burst (10/10 min) og døgn (50/24 t). Upstash lagrer tellere — ikke samtalehistorikk.",
+  },
+  {
+    id: "ces",
+    title: "CES runSession",
+    detail: "Headless Google CES runSession med service account. Returnerer agenttekst til API-et.",
+  },
+  {
+    id: "response",
+    title: "Svar tilbake",
+    detail: "JSON `{ text, turnCompleted, turnIndex }` rendres i custom UI uten CES-widget.",
+  },
+] as const;
+
+export const guardLimits = [
+  {
+    label: "Maks meldingslengde",
+    value: "2000 tegn",
+    note: "Avkortes av input guard — brukeren får `message_too_long`.",
+  },
+  {
+    label: "Burst-grense",
+    value: "10 spørsmål / 10 min / IP",
+    note: "Sliding window via Upstash (`viddel-chat-burst`).",
+  },
+  {
+    label: "Døgngrense",
+    value: "50 spørsmål / døgn / IP",
+    note: "Sliding window via Upstash (`viddel-chat-daily`).",
+  },
+  {
+    label: "Fail-closed i production",
+    value: "Ja",
+    note: "Mangler Upstash env i production → `guard_unavailable` (503). Preview/dev kan kjøre uten.",
+  },
+  {
+    label: "Upstash rolle",
+    value: "Teller only",
+    note: "Lagrer ikke samtaleinnhold eller session-historikk.",
+  },
+] as const;
+
+export type EnvVarEntry = {
+  name: string;
+  group: "upstash" | "ces" | "auth";
+  controls: string;
+};
+
+export const envVars: EnvVarEntry[] = [
+  {
+    name: "UPSTASH_REDIS_REST_URL",
+    group: "upstash",
+    controls: "Upstash Redis REST-endpoint for rate-limit tellere.",
+  },
+  {
+    name: "UPSTASH_REDIS_REST_TOKEN",
+    group: "upstash",
+    controls: "Autentisering mot Upstash — kun server-side.",
+  },
+  {
+    name: "CES_PROJECT_ID",
+    group: "ces",
+    controls: "Google CES prosjekt-ID for runSession.",
+  },
+  {
+    name: "CES_LOCATION",
+    group: "ces",
+    controls: "CES region/location (f.eks. europe-west1).",
+  },
+  {
+    name: "CES_APP_ID",
+    group: "ces",
+    controls: "CES app-ID for Viddel-agenten.",
+  },
+  {
+    name: "CES_APP_VERSION_ID",
+    group: "ces",
+    controls: "Versjon av CES-appen som skal kjøres.",
+  },
+  {
+    name: "CES_DEPLOYMENT_ID",
+    group: "ces",
+    controls: "Aktiv CES deployment som mottar runSession-kall.",
+  },
+  {
+    name: "GOOGLE_SERVICE_ACCOUNT_JSON",
+    group: "auth",
+    controls: "Service account JSON for Google auth mot CES — aldri i klient eller repo.",
+  },
+];
+
+export const envVarNotes = [
+  "Alle env-vars må ligge i Vercel **Production** (og Preview ved behov for testing).",
+  "Verdier settes kun i Vercel dashboard — aldri i repo, ChatGPT, Cursor-logg eller Return Tickets.",
+  "Etter endring: redeploy production før verifisering.",
+] as const;
+
+export type ErrorState = {
+  code: string;
+  meaning: string;
+  userSees: string;
+  weCheck: string;
+};
+
+export const errorStates: ErrorState[] = [
+  {
+    code: "message_too_long",
+    meaning: "Meldingen overstiger 2000 tegn.",
+    userSees: "«Spørsmålet er litt for langt. Prøv å korte det ned og send på nytt.»",
+    weCheck: "Forventet guard-adferd — ingen CES-kall. Be bruker korte ned.",
+  },
+  {
+    code: "rate_limited",
+    meaning: "IP har nådd burst- eller døgngrense i Upstash.",
+    userSees: "«Du har stilt mange spørsmål på kort tid. Prøv igjen litt senere.»",
+    weCheck: "Upstash tellere, evt. misbruk. Vent eller vurder justering av grenser.",
+  },
+  {
+    code: "guard_unavailable",
+    meaning: "Rate limiter kan ikke nå Upstash, eller Upstash env mangler i production.",
+    userSees: "«Viddel er ikke tilgjengelig akkurat nå.»",
+    weCheck: "UPSTASH_* i Vercel Production, Upstash status, Vercel redeploy.",
+  },
+  {
+    code: "configuration_missing",
+    meaning: "Minst én CES env-var mangler på serveren.",
+    userSees: "«Viddel er ikke tilgjengelig akkurat nå.» (503)",
+    weCheck: "Alle CES_* og GOOGLE_SERVICE_ACCOUNT_JSON satt i Production — se env-liste over.",
+  },
+  {
+    code: "auth / upstream / internal_error",
+    meaning: "CES auth feilet, upstream-feil fra Google, eller uventet serverfeil.",
+    userSees: "«Vi fikk ikke tak i svaret akkurat nå. Prøv igjen.» eller «Viddel er ikke tilgjengelig akkurat nå.» (auth)",
+    weCheck: "Service account JSON, CES deployment aktiv, Google Cloud status, Vercel function logs (`[api/chat]`).",
+  },
+];
+
+export const productionChecklist = [
+  "Upstash env-vars satt i Vercel Production?",
+  "CES env-vars satt i Vercel Production?",
+  "Redeploy kjørt etter env-endring?",
+  "POST `/api/chat` returnerer 200 med gyldig message + sessionId?",
+  "`/no/chat/` viser svar i UI?",
+  "`/vis/` current-state oppdatert i `mvp-current-state.ts`?",
+  "Return Ticket lagt på relevant issue?",
+] as const;
+
+export const beforeExternalSharing = [
+  "AI usage monitoring v0.1 bør være på plass før ekstern deling.",
+  "Access/login via «Mine sider» vurderes senere ved ekstern pilot — ikke kodefelt i chat-UI (#181 parkert).",
+  "Ikke legg access code eller hemmeligheter i chat-flaten.",
+  "Ekstern test krever egen produktbeslutning og QA-pass.",
+] as const;

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -1,88 +1,229 @@
-/* CONTRACT: Backstage v0.1 content — human-readable system reference for AI/API/guards/env (no secret values). */
+/* CONTRACT: Backstage v0.1 content — pedagogisk systemforklaring (forståelse først, teknikk nederst). */
 
 export const backstageMeta = {
   title: "Backstage",
-  lead: "Backstage forklarer hvordan Viddel fungerer bak scenen: AI-flow, API, guards, env-vars, feilstater og production-sjekker.",
+  lead: "Backstage er kontrollrommet for hvordan Viddel fungerer bak scenen. Her forklarer vi AI-flyten, beskyttelsen, feilstater og hva som må sjekkes før vi deler med flere.",
   updatedAt: "2026-05-30",
   issue: "#184",
-  relatedIssue: "#180",
 } as const;
 
-export const systemFlowSteps = [
-  { id: "user", label: "Bruker" },
-  { id: "chat-ui", label: "/no/chat/" },
-  { id: "api", label: "/api/chat" },
-  { id: "input", label: "Input guard" },
-  { id: "origin", label: "Origin guard" },
-  { id: "rate", label: "Upstash rate limit" },
-  { id: "ces", label: "CES runSession" },
-  { id: "response", label: "Svar tilbake" },
+export const statusPanel = [
+  { label: "Spør Viddel", value: "Live i production", tone: "live" as const },
+  { label: "Guard", value: "Aktiv", tone: "ok" as const },
+  { label: "Ekstern deling", value: "Venter på usage monitoring", tone: "wait" as const },
 ] as const;
 
-export const chatFlowSteps = [
+export const quickAnswers = [
   {
-    id: "ui",
-    title: "Chat UI",
-    detail: "Standalone custom chat på `/no/chat/` — samler melding og sessionId, viser svar og feilmeldinger.",
+    question: "Hva skjer når noen spør Viddel?",
+    answer: "Spørsmålet går gjennom Viddel sitt eget grensesnitt, sjekkes, telles og sendes til AI-motoren — svaret kommer tilbake i samme chat.",
   },
   {
-    id: "api",
-    title: "API",
-    detail: "POST `/api/chat` — server-side proxy. Credentials og CES-detaljer eksponeres aldri til klienten.",
+    question: "Hva beskytter oss?",
+    answer: "Grenser på lengde og antall spørsmål, pluss sjekk av hvor forespørselen kommer fra. Mangler beskyttelsen i production, stenger Viddel trygt.",
   },
   {
-    id: "input",
-    title: "Input guard",
-    detail: "Validerer JSON, tom melding, sessionId-format og maks 2000 tegn før noe sendes videre.",
+    question: "Hva gjør vi når noe ikke virker?",
+    answer: "Start med hva brukeren ser, sjekk env-vars i Vercel, Upstash og CES — se feilsøkingsseksjonen under.",
+  },
+] as const;
+
+export type SystemMapLayer = {
+  id: string;
+  layer: string;
+  title: string;
+  human: string;
+  tech?: string;
+};
+
+/** FIGUR 1 — overordnet systemkart med visuelle lag. */
+export const systemMapLayers: SystemMapLayer[] = [
+  {
+    id: "user",
+    layer: "Bruker",
+    title: "Brukeren",
+    human: "Brukeren skriver et spørsmål i Spør Viddel.",
   },
   {
-    id: "origin",
-    title: "Origin guard",
-    detail: "Ekstra friksjon mot direkte API-kall utenfor tillatte domener (vox.raddum.no, viddel.no, preview/dev).",
+    id: "surface",
+    layer: "Brukerflate",
+    title: "Spør Viddel UI",
+    human: "Viddel sitt eget chat-grensesnitt — ikke en ferdig widget innebygd.",
+    tech: "/no/chat/",
   },
   {
-    id: "rate",
-    title: "Upstash rate limit",
-    detail: "IP-basert telling per burst (10/10 min) og døgn (50/24 t). Upstash lagrer tellere — ikke samtalehistorikk.",
+    id: "server",
+    layer: "Viddel-server",
+    title: "Viddel API",
+    human: "Viddel tar imot spørsmålet og holder nøkler og AI-kall på serveren.",
+    tech: "/api/chat",
   },
   {
-    id: "ces",
-    title: "CES runSession",
-    detail: "Headless Google CES runSession med service account. Returnerer agenttekst til API-et.",
+    id: "guard",
+    layer: "Beskyttelse",
+    title: "Guard + Upstash",
+    human: "Viddel sjekker at spørsmålet er lovlig og innenfor grensen. Upstash teller bruk.",
+  },
+  {
+    id: "ai",
+    layer: "AI-motor",
+    title: "CES",
+    human: "CES lager svaret. Viddel eier grensesnittet rundt.",
+    tech: "runSession",
   },
   {
     id: "response",
-    title: "Svar tilbake",
-    detail: "JSON `{ text, turnCompleted, turnIndex }` rendres i custom UI uten CES-widget.",
+    layer: "Svar",
+    title: "Tilbake til brukeren",
+    human: "Svaret vises i Viddel sitt eget grensesnitt.",
+  },
+];
+
+export type ChatFlowStep = {
+  step: number;
+  title: string;
+  human: string;
+  why?: string;
+  tech?: string;
+};
+
+/** FIGUR 2 — detaljert, menneskelig chat-flyt. */
+export const chatFlowSteps: ChatFlowStep[] = [
+  {
+    step: 1,
+    title: "Brukeren spør",
+    human: "Spørsmålet sendes fra Spør Viddel.",
+    tech: "/no/chat/",
+  },
+  {
+    step: 2,
+    title: "Viddel sjekker lengde",
+    human: "For lange spørsmål stoppes før de sendes videre.",
+    why: "Dette hindrer at altfor lange spørsmål sendes videre.",
+    tech: "maks 2000 tegn",
+  },
+  {
+    step: 3,
+    title: "Viddel sjekker hvor forespørselen kommer fra",
+    human: "Kun godkjente nettsteder kan kalle API-et direkte.",
+    why: "Dette beskytter mot misbruk utenfor Viddel.",
+    tech: "origin guard",
+  },
+  {
+    step: 4,
+    title: "Upstash sjekker bruksmengde",
+    human: "Teller hvor mange spørsmål som kommer fra samme IP.",
+    why: "Dette beskytter kostnad og misbruk.",
+    tech: "10 / 10 min · 50 / døgn",
+  },
+  {
+    step: 5,
+    title: "CES får spørsmålet",
+    human: "AI-motoren lager svaret.",
+    why: "Dette er selve AI-svaret.",
+    tech: "CES runSession",
+  },
+  {
+    step: 6,
+    title: "Viddel viser svaret",
+    human: "Svaret vises i chatten — uten CES-widget i nettleseren.",
+  },
+];
+
+export const protectionRules = [
+  {
+    title: "Maks lengde",
+    value: "2000 tegn",
+    human: "Lengre spørsmål avvises med en tydelig melding til brukeren.",
+  },
+  {
+    title: "Kort sikt",
+    value: "10 spørsmål per 10 minutter",
+    human: "Beskyttelse mot rask spam fra samme IP.",
+  },
+  {
+    title: "Døgn",
+    value: "50 spørsmål per døgn",
+    human: "Tak på total bruk per IP per dag.",
+  },
+  {
+    title: "Trygg stenging",
+    value: "Viddel stenger trygt",
+    human: "Hvis tellelaget mangler i production, svarer Viddel ikke — den står ikke åpen uten beskyttelse.",
+    tech: "guard_unavailable",
   },
 ] as const;
 
-export const guardLimits = [
+export const upstashExplainer = {
+  title: "Hva betyr Upstash?",
+  body: "Upstash er bare telleren. Den husker ikke samtalen. Den teller hvor mange spørsmål som kommer fra samme IP — slik at vi kan stoppe misbruk uten å lagre det brukeren skriver.",
+} as const;
+
+export const cesExplainer = {
+  title: "Hva betyr CES?",
+  body: "CES er AI-motoren som lager svaret. Viddel eier grensesnittet rundt — chatten, feilmeldingene og hvordan det føles for brukeren.",
+} as const;
+
+export type TroubleshootingCase = {
+  id: string;
+  userSees: string;
+  usuallyMeans: string[];
+  weCheck: string[];
+  techCodes?: string[];
+};
+
+export const troubleshootingCases: TroubleshootingCase[] = [
   {
-    label: "Maks meldingslengde",
-    value: "2000 tegn",
-    note: "Avkortes av input guard — brukeren får `message_too_long`.",
+    id: "too-long",
+    userSees: "«Spørsmålet er litt for langt. Prøv å korte det ned og send på nytt.»",
+    usuallyMeans: ["Spørsmålet er over 2000 tegn.", "Forventet beskyttelse — ikke en systemfeil."],
+    weCheck: ["Be brukeren korte ned spørsmålet.", "Ingen videre feilsøking nødvendig."],
+    techCodes: ["message_too_long"],
   },
   {
-    label: "Burst-grense",
-    value: "10 spørsmål / 10 min / IP",
-    note: "Sliding window via Upstash (`viddel-chat-burst`).",
+    id: "rate-limit",
+    userSees: "«Du har stilt mange spørsmål på kort tid. Prøv igjen litt senere.»",
+    usuallyMeans: ["IP har nådd grensen (10 per 10 min eller 50 per døgn).", "Kan være ekte bruk eller misbruk."],
+    weCheck: ["Upstash tellere.", "Vent og prøv igjen.", "Vurder justering av grenser ved behov."],
+    techCodes: ["rate_limited"],
   },
   {
-    label: "Døgngrense",
-    value: "50 spørsmål / døgn / IP",
-    note: "Sliding window via Upstash (`viddel-chat-daily`).",
+    id: "unavailable",
+    userSees: "«Viddel er ikke tilgjengelig akkurat nå.»",
+    usuallyMeans: [
+      "CES-variabler mangler i Vercel.",
+      "Upstash mangler eller svarer ikke.",
+      "Google/CES-feil.",
+    ],
+    weCheck: [
+      "Vercel env-vars (Production).",
+      "Vercel runtime logs.",
+      "Upstash status.",
+      "CES status.",
+    ],
+    techCodes: ["configuration_missing", "guard_unavailable", "auth"],
   },
   {
-    label: "Fail-closed i production",
-    value: "Ja",
-    note: "Mangler Upstash env i production → `guard_unavailable` (503). Preview/dev kan kjøre uten.",
+    id: "retry",
+    userSees: "«Vi fikk ikke tak i svaret akkurat nå. Prøv igjen.»",
+    usuallyMeans: ["Midlertidig feil mot AI-motoren.", "Uventet serverfeil."],
+    weCheck: ["Vercel function logs.", "CES deployment aktiv.", "Prøv på nytt etter kort ventetid."],
+    techCodes: ["upstream", "internal_error"],
   },
-  {
-    label: "Upstash rolle",
-    value: "Teller only",
-    note: "Lagrer ikke samtaleinnhold eller session-historikk.",
-  },
+];
+
+export const productionChecklist = [
+  "Kan vi få ekte svar i Spør Viddel?",
+  "Er guard aktiv (Upstash env satt i Production)?",
+  "Ser vi feil i Vercel logs?",
+  "Er VIS current-state oppdatert?",
+  "Er Return Ticket lagt?",
+] as const;
+
+export const beforeExternalSharing = [
+  "AI usage monitoring v0.1 først.",
+  "Access/login senere via «Mine sider» i globalmenyen — ikke kodefelt inne i chatten.",
+  "Ekstern pilot krever egen beslutning.",
 ] as const;
 
 export type EnvVarEntry = {
@@ -92,107 +233,25 @@ export type EnvVarEntry = {
 };
 
 export const envVars: EnvVarEntry[] = [
-  {
-    name: "UPSTASH_REDIS_REST_URL",
-    group: "upstash",
-    controls: "Upstash Redis REST-endpoint for rate-limit tellere.",
-  },
-  {
-    name: "UPSTASH_REDIS_REST_TOKEN",
-    group: "upstash",
-    controls: "Autentisering mot Upstash — kun server-side.",
-  },
-  {
-    name: "CES_PROJECT_ID",
-    group: "ces",
-    controls: "Google CES prosjekt-ID for runSession.",
-  },
-  {
-    name: "CES_LOCATION",
-    group: "ces",
-    controls: "CES region/location (f.eks. europe-west1).",
-  },
-  {
-    name: "CES_APP_ID",
-    group: "ces",
-    controls: "CES app-ID for Viddel-agenten.",
-  },
-  {
-    name: "CES_APP_VERSION_ID",
-    group: "ces",
-    controls: "Versjon av CES-appen som skal kjøres.",
-  },
-  {
-    name: "CES_DEPLOYMENT_ID",
-    group: "ces",
-    controls: "Aktiv CES deployment som mottar runSession-kall.",
-  },
-  {
-    name: "GOOGLE_SERVICE_ACCOUNT_JSON",
-    group: "auth",
-    controls: "Service account JSON for Google auth mot CES — aldri i klient eller repo.",
-  },
+  { name: "UPSTASH_REDIS_REST_URL", group: "upstash", controls: "Teller-endpoint." },
+  { name: "UPSTASH_REDIS_REST_TOKEN", group: "upstash", controls: "Teller-autentisering." },
+  { name: "CES_PROJECT_ID", group: "ces", controls: "CES prosjekt." },
+  { name: "CES_LOCATION", group: "ces", controls: "CES region." },
+  { name: "CES_APP_ID", group: "ces", controls: "Viddel-app i CES." },
+  { name: "CES_APP_VERSION_ID", group: "ces", controls: "App-versjon." },
+  { name: "CES_DEPLOYMENT_ID", group: "ces", controls: "Aktiv deployment." },
+  { name: "GOOGLE_SERVICE_ACCOUNT_JSON", group: "auth", controls: "Google auth — kun server-side." },
 ];
 
 export const envVarNotes = [
-  "Alle env-vars må ligge i Vercel **Production** (og Preview ved behov for testing).",
-  "Verdier settes kun i Vercel dashboard — aldri i repo, ChatGPT, Cursor-logg eller Return Tickets.",
-  "Etter endring: redeploy production før verifisering.",
+  "Sett kun i Vercel Production (Preview ved behov).",
+  "Verdier aldri i repo, ChatGPT eller Cursor.",
+  "Redeploy etter endring.",
 ] as const;
 
-export type ErrorState = {
-  code: string;
-  meaning: string;
-  userSees: string;
-  weCheck: string;
-};
-
-export const errorStates: ErrorState[] = [
-  {
-    code: "message_too_long",
-    meaning: "Meldingen overstiger 2000 tegn.",
-    userSees: "«Spørsmålet er litt for langt. Prøv å korte det ned og send på nytt.»",
-    weCheck: "Forventet guard-adferd — ingen CES-kall. Be bruker korte ned.",
-  },
-  {
-    code: "rate_limited",
-    meaning: "IP har nådd burst- eller døgngrense i Upstash.",
-    userSees: "«Du har stilt mange spørsmål på kort tid. Prøv igjen litt senere.»",
-    weCheck: "Upstash tellere, evt. misbruk. Vent eller vurder justering av grenser.",
-  },
-  {
-    code: "guard_unavailable",
-    meaning: "Rate limiter kan ikke nå Upstash, eller Upstash env mangler i production.",
-    userSees: "«Viddel er ikke tilgjengelig akkurat nå.»",
-    weCheck: "UPSTASH_* i Vercel Production, Upstash status, Vercel redeploy.",
-  },
-  {
-    code: "configuration_missing",
-    meaning: "Minst én CES env-var mangler på serveren.",
-    userSees: "«Viddel er ikke tilgjengelig akkurat nå.» (503)",
-    weCheck: "Alle CES_* og GOOGLE_SERVICE_ACCOUNT_JSON satt i Production — se env-liste over.",
-  },
-  {
-    code: "auth / upstream / internal_error",
-    meaning: "CES auth feilet, upstream-feil fra Google, eller uventet serverfeil.",
-    userSees: "«Vi fikk ikke tak i svaret akkurat nå. Prøv igjen.» eller «Viddel er ikke tilgjengelig akkurat nå.» (auth)",
-    weCheck: "Service account JSON, CES deployment aktiv, Google Cloud status, Vercel function logs (`[api/chat]`).",
-  },
-];
-
-export const productionChecklist = [
-  "Upstash env-vars satt i Vercel Production?",
-  "CES env-vars satt i Vercel Production?",
-  "Redeploy kjørt etter env-endring?",
-  "POST `/api/chat` returnerer 200 med gyldig message + sessionId?",
-  "`/no/chat/` viser svar i UI?",
-  "`/vis/` current-state oppdatert i `mvp-current-state.ts`?",
-  "Return Ticket lagt på relevant issue?",
-] as const;
-
-export const beforeExternalSharing = [
-  "AI usage monitoring v0.1 bør være på plass før ekstern deling.",
-  "Access/login via «Mine sider» vurderes senere ved ekstern pilot — ikke kodefelt i chat-UI (#181 parkert).",
-  "Ikke legg access code eller hemmeligheter i chat-flaten.",
-  "Ekstern test krever egen produktbeslutning og QA-pass.",
+export const sourceFiles = [
+  "src/pages/api/chat.ts",
+  "src/lib/chat-api-guard.ts",
+  "src/lib/ces-env.ts",
+  "src/lib/ces-run-session.ts",
 ] as const;

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -77,7 +77,7 @@ export const mvpCurrentState = {
   } satisfies CurrentSprint,
   closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
-    "CES production live på /no/chat/ — intern test med Thomas og Vibeke. Upstash guard aktiv (#180). Backstage v0.1 live (#184). Neste: AI usage monitoring v0.1 før ekstern deling.",
+    "CES production live på /no/chat/ — intern test med Thomas og Vibeke. Upstash guard aktiv (#180). Backstage v0.1 live (#184) med build-time guard. Neste: AI usage monitoring v0.1 før ekstern deling.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -199,7 +199,7 @@ export const mvpCurrentState = {
   recentChanges: [
     {
       date: "2026-05-30",
-      summary: "Backstage v0.1 — intern systemreferanse på /backstage/ (#184)",
+      summary: "Backstage guardrail — operating rules, Return Ticket-felt, build-time verify (#184)",
       issue: "#184",
       commit: "—",
     },

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -77,7 +77,7 @@ export const mvpCurrentState = {
   } satisfies CurrentSprint,
   closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
-    "CES production live på /no/chat/ — intern test med Thomas og Vibeke. Upstash guard aktiv (#180). Access Gate (#181) parkert/revertet. Neste: AI usage monitoring v0.1 og Backstage v0.1 før ekstern deling.",
+    "CES production live på /no/chat/ — intern test med Thomas og Vibeke. Upstash guard aktiv (#180). Backstage v0.1 live (#184). Neste: AI usage monitoring v0.1 før ekstern deling.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -111,7 +111,7 @@ export const mvpCurrentState = {
       label: "Spør Viddel",
       route: "/no/chat/",
       status: "Applied",
-      note: "Production UI live. CES prod env aktiv — live AI-svar i production. Public AI guard v0.1 (#180). Intern test Thomas/Vibeke. Access gate (#181) parkert/revertet. Ekstern deling venter monitoring + backstage.",
+      note: "Production UI live. CES prod env aktiv — live AI-svar i production. Public AI guard v0.1 (#180). Intern test Thomas/Vibeke. Backstage v0.1 (#184) live. Ekstern deling venter monitoring.",
       visFrontpage: true,
       kind: "public",
       frontpageDescription: "Standalone headless AI — live i production (intern test). Guard aktiv.",
@@ -133,6 +133,13 @@ export const mvpCurrentState = {
       label: "Designsystem",
       route: "/designsystem/",
       role: "Gjeldende designsystem-sannhet",
+      visFrontpage: false,
+    },
+    {
+      id: "backstage",
+      label: "Backstage",
+      route: "/backstage/",
+      role: "System/API/guard/env — canonical referanse",
       visFrontpage: false,
     },
     {
@@ -165,8 +172,8 @@ export const mvpCurrentState = {
     },
     {
       id: "backstage-v01",
-      label: "Backstage v0.1",
-      detail: "Påkrevd før ekstern deling — intern operativ flate.",
+      label: "Backstage v0.1 — live",
+      detail: "Intern systemreferanse på /backstage/ — AI-flow, guards, env-vars og production checklist (#184).",
     },
     {
       id: "test-access-gate-parked",
@@ -192,8 +199,8 @@ export const mvpCurrentState = {
   recentChanges: [
     {
       date: "2026-05-30",
-      summary: "VIS sprint guard — currentSprint registry; W21 aktiv i kontrollrom",
-      issue: "#185",
+      summary: "Backstage v0.1 — intern systemreferanse på /backstage/ (#184)",
+      issue: "#184",
       commit: "—",
     },
     {

--- a/src/data/vis-frontpage-hubs-v01.ts
+++ b/src/data/vis-frontpage-hubs-v01.ts
@@ -35,9 +35,9 @@ export function getVisFrontpageHubs(baseUrl: string): VisFrontpageHub[] {
       id: "backstage",
       title: "Backstage",
       mandate: "AI, API, guards, env-vars og production.",
-      availability: "planned",
+      href: `${base}backstage/`,
+      availability: "active",
       tier: "primary",
-      issue: "#184",
     },
     {
       id: "gitbuss",
@@ -102,13 +102,12 @@ export const visFrontpageMandate = {
 export const visPrimaryNextWorkIds = [
   "internal-ai-test-qa",
   "ai-usage-monitoring",
-  "backstage-v01",
 ] as const;
 
 export const visSourceOfTruthNotes = [
   { label: "src/data/mvp-current-state.ts", role: "Gjeldende MVP-status" },
   { label: "/designsystem/", role: "Gjeldende UI/mønstre" },
-  { label: "/backstage/", role: "System/API/guard når etablert (#184)" },
+  { label: "/backstage/", role: "System/API/guard/env — canonical referanse" },
   { label: "GitHub issues/projects", role: "Oppgavebuss" },
   { label: "Roadmap", role: "Retning / faser" },
   { label: "DAM / bildebank", role: "Assetoversikt" },

--- a/src/lib/backstage-guard.ts
+++ b/src/lib/backstage-guard.ts
@@ -1,0 +1,150 @@
+/* CONTRACT: Backstage guard — build-time checks that /backstage/ registry stays complete and aligned with chat guard. */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  backstageLinks,
+  changeRunbooks,
+  envVars,
+  protectionRules,
+  services,
+  troubleshootingCases,
+} from "../data/backstage-v01.ts";
+import { getVisFrontpageHubs } from "../data/vis-frontpage-hubs-v01.ts";
+import { CHAT_MAX_MESSAGE_LENGTH } from "./chat-api-guard.ts";
+
+const REQUIRED_ENV_VARS = [
+  "UPSTASH_REDIS_REST_URL",
+  "UPSTASH_REDIS_REST_TOKEN",
+  "CES_PROJECT_ID",
+  "CES_LOCATION",
+  "CES_APP_ID",
+  "CES_APP_VERSION_ID",
+  "CES_DEPLOYMENT_ID",
+  "GOOGLE_SERVICE_ACCOUNT_JSON",
+] as const;
+
+const REQUIRED_ERROR_CODES = [
+  "message_too_long",
+  "rate_limited",
+  "guard_unavailable",
+  "configuration_missing",
+] as const;
+
+const REQUIRED_RUNBOOK_IDS = [
+  "rate-limits",
+  "max-length",
+  "upstash",
+  "ces",
+  "disable-ai",
+  "access",
+  "status",
+] as const;
+
+const REQUIRED_SERVICE_IDS = ["vercel", "upstash", "google-ces", "github", "vis"] as const;
+
+const REQUIRED_LINK_PATTERNS = [
+  "vercel.com",
+  "console.upstash.com",
+  "console.cloud.google.com",
+  "github.com",
+  "vox.raddum.no",
+] as const;
+
+const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Fail build if Backstage registry or VIS hub is incomplete or drifted from chat guard. */
+export function validateBackstageGuard(): string[] {
+  const errors: string[] = [];
+
+  const backstagePage = join(srcRoot, "pages/backstage/index.astro");
+  const backstageData = join(srcRoot, "data/backstage-v01.ts");
+
+  if (!existsSync(backstagePage)) {
+    errors.push("Missing /backstage/ route: src/pages/backstage/index.astro");
+  }
+  if (!existsSync(backstageData)) {
+    errors.push("Missing Backstage data: src/data/backstage-v01.ts");
+  }
+
+  const envNames = new Set(envVars.map((v) => v.name));
+  for (const name of REQUIRED_ENV_VARS) {
+    if (!envNames.has(name)) {
+      errors.push(`Backstage env-vars missing required name: ${name}`);
+    }
+  }
+
+  const errorCodes = new Set(
+    troubleshootingCases.flatMap((c) => c.techCodes ?? []),
+  );
+  for (const code of REQUIRED_ERROR_CODES) {
+    if (!errorCodes.has(code)) {
+      errors.push(`Backstage troubleshooting missing error code: ${code}`);
+    }
+  }
+
+  const runbookIds = new Set(changeRunbooks.map((r) => r.id));
+  for (const id of REQUIRED_RUNBOOK_IDS) {
+    if (!runbookIds.has(id)) {
+      errors.push(`Backstage runbooks missing required id: ${id}`);
+    }
+  }
+
+  const serviceIds = new Set(services.map((s) => s.id));
+  for (const id of REQUIRED_SERVICE_IDS) {
+    if (!serviceIds.has(id)) {
+      errors.push(`Backstage service map missing required service: ${id}`);
+    }
+  }
+
+  const allHrefs = [
+    ...Object.values(backstageLinks).map((l) => l.href),
+    ...services.flatMap((s) => s.actionLinks.map((l) => l.href)),
+  ].join(" ");
+
+  for (const pattern of REQUIRED_LINK_PATTERNS) {
+    if (!allHrefs.includes(pattern)) {
+      errors.push(`Backstage links missing reference to: ${pattern}`);
+    }
+  }
+
+  const backstageHub = getVisFrontpageHubs("/").find((h) => h.id === "backstage");
+  if (!backstageHub?.href) {
+    errors.push("VIS hub Backstage must have an active href");
+  } else if (backstageHub.availability !== "active") {
+    errors.push(`VIS hub Backstage must be active (got: ${backstageHub.availability})`);
+  }
+
+  const maxLengthRule = protectionRules.find((r) => r.title === "Maks lengde");
+  if (!maxLengthRule?.value.includes(String(CHAT_MAX_MESSAGE_LENGTH))) {
+    errors.push(
+      `Backstage max length (${maxLengthRule?.value}) must match CHAT_MAX_MESSAGE_LENGTH (${CHAT_MAX_MESSAGE_LENGTH})`,
+    );
+  }
+
+  const burstRule = protectionRules.find((r) => r.title === "Kort sikt");
+  const dailyRule = protectionRules.find((r) => r.title === "Døgn");
+  if (!burstRule?.value.includes("10")) {
+    errors.push("Backstage burst limit text must reference 10 per 10 minutes");
+  }
+  if (!dailyRule?.value.includes("50")) {
+    errors.push("Backstage daily limit text must reference 50 per day");
+  }
+
+  const guardPath = join(srcRoot, "lib/chat-api-guard.ts");
+  if (existsSync(guardPath)) {
+    const guardSource = readFileSync(guardPath, "utf8");
+    if (!guardSource.includes('slidingWindow(10, "10 m")')) {
+      errors.push("chat-api-guard.ts burst limit changed — update Backstage protection rules");
+    }
+    if (!guardSource.includes('slidingWindow(50, "24 h")')) {
+      errors.push("chat-api-guard.ts daily limit changed — update Backstage protection rules");
+    }
+    if (!guardSource.includes(`CHAT_MAX_MESSAGE_LENGTH = ${CHAT_MAX_MESSAGE_LENGTH}`)) {
+      errors.push("CHAT_MAX_MESSAGE_LENGTH changed — update Backstage protection rules");
+    }
+  }
+
+  return errors;
+}

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -17,6 +17,9 @@ import {
   troubleshootingCases,
   upstashExplainer,
   changeRunbooks,
+  services,
+  serviceMapFlow,
+  firstCheckRules,
 } from "../../data/backstage-v01.ts";
 
 const base = import.meta.env.BASE_URL;
@@ -143,6 +146,58 @@ const layerTone: Record<string, string> = {
       </article>
     </section>
 
+    <section class="bs__section" aria-labelledby="bs-services">
+      <h2 id="bs-services" class="bs__section-title">Hvor gjør vi hva?</h2>
+      <p class="bs__section-lead">Hvilke tjenester som gjør jobben — og når vi åpner dem.</p>
+
+      <div class="bs-svc-flow" aria-label="Tjenesteflyt oversikt">
+        {serviceMapFlow.map((step, index) => (
+          <div class="bs-svc-flow__item">
+            <span class="bs-svc-flow__label">{step.label}</span>
+            <span class="bs-svc-flow__hint">{step.hint}</span>
+            {index < serviceMapFlow.length - 1 ? (
+              <span class="bs-svc-flow__arrow" aria-hidden="true">→</span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <ul class="bs-svc-grid">
+        {services.map((svc) => (
+          <li class="bs-svc-card">
+            <div class="bs-svc-card__head">
+              <h3 class="bs-svc-card__name">{svc.name}</h3>
+              <span class="bs-svc-card__layer">{svc.layer}</span>
+            </div>
+            <div class="bs-svc-card__block">
+              <p class="bs-svc-card__label">Gjør</p>
+              <ul class="bs-svc-card__list">
+                {svc.role.map((line) => (
+                  <li>{line}</li>
+                ))}
+              </ul>
+            </div>
+            <div class="bs-svc-card__block">
+              <p class="bs-svc-card__label">Når åpner vi?</p>
+              <ul class="bs-svc-card__list">
+                {svc.whenToOpen.map((line) => (
+                  <li>{line}</li>
+                ))}
+              </ul>
+            </div>
+            <div class="bs-svc-card__block">
+              <p class="bs-svc-card__label">Typiske steder</p>
+              <ul class="bs-svc-card__places">
+                {svc.places.map((line) => (
+                  <li>{line}</li>
+                ))}
+              </ul>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+
     <section class="bs__section" aria-labelledby="bs-change">
       <h2 id="bs-change" class="bs__section-title">Når vi må endre noe</h2>
       <p class="bs__section-lead">Slik går vi frem når vi senere må justere verdier, koblinger eller tilgang.</p>
@@ -152,6 +207,10 @@ const layerTone: Record<string, string> = {
           <li class="bs-runbook__card">
             <h3 class="bs-runbook__title">{book.title}</h3>
             <dl class="bs-runbook__dl">
+              <div class="bs-runbook__go">
+                <dt>Hvor går vi?</dt>
+                <dd>{book.whereToGo}</dd>
+              </div>
               <div>
                 <dt>Hva endres?</dt>
                 <dd>{book.whatChanges}</dd>
@@ -185,6 +244,19 @@ const layerTone: Record<string, string> = {
     <section class="bs__section" aria-labelledby="bs-troubleshoot">
       <h2 id="bs-troubleshoot" class="bs__section-title">Når noe ikke virker</h2>
       <p class="bs__section-lead">Start med hva brukeren ser — deretter hva det betyr og hva vi sjekker.</p>
+
+      <div class="bs-first-check" aria-labelledby="bs-first-check">
+        <h3 id="bs-first-check" class="bs-first-check__title">Første sted å sjekke</h3>
+        <ul class="bs-first-check__list">
+          {firstCheckRules.map((rule) => (
+            <li>
+              <span class="bs-first-check__symptom">{rule.symptom}</span>
+              <span class="bs-first-check__arrow" aria-hidden="true">→</span>
+              <span class="bs-first-check__check">{rule.check}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
 
       <ul class="bs-fix">
         {troubleshootingCases.map((item) => (
@@ -679,6 +751,224 @@ const layerTone: Record<string, string> = {
       margin: 0.5rem 0 0;
       font-size: 0.88rem;
       line-height: 1.6;
+      color: rgb(75 85 99);
+    }
+
+    .bs-runbook__dl {
+      margin: 0.75rem 0 0;
+      display: grid;
+      gap: 0.65rem;
+    }
+
+    .bs-runbook__go {
+      padding: 0.65rem 0.75rem;
+      margin-bottom: 0.15rem;
+      border-radius: 0.35rem;
+      background: rgb(239 246 255);
+      border: 1px solid rgb(219 234 254);
+    }
+
+    .bs-runbook__go dt {
+      color: rgb(29 78 216);
+    }
+
+    .bs-runbook__go dd {
+      color: rgb(30 58 138);
+      font-weight: 550;
+    }
+
+    .bs-svc-flow {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: stretch;
+      gap: 0.35rem;
+      margin-top: 1.25rem;
+      padding: 1rem;
+      border-radius: 0.6rem;
+      background: rgb(249 250 251);
+      border: 1px solid rgb(243 244 246);
+    }
+
+    .bs-svc-flow__item {
+      flex: 1 1 7rem;
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 0.15rem;
+      padding: 0.65rem 0.75rem;
+      border-radius: 0.4rem;
+      background: rgb(255 255 255);
+      border: 1px solid rgb(229 231 235);
+      min-width: 6.5rem;
+    }
+
+    .bs-svc-flow__label {
+      font-size: 0.82rem;
+      font-weight: 650;
+      color: rgb(31 41 55);
+    }
+
+    .bs-svc-flow__hint {
+      font-size: 0.72rem;
+      color: rgb(107 114 128);
+    }
+
+    .bs-svc-flow__arrow {
+      display: none;
+    }
+
+    @media (min-width: 640px) {
+      .bs-svc-flow__item:not(:last-child)::after {
+        content: "→";
+        position: absolute;
+        right: -0.65rem;
+        top: 50%;
+        transform: translateY(-50%);
+        font-size: 0.85rem;
+        color: rgb(156 163 175);
+        z-index: 1;
+      }
+    }
+
+    .bs-svc-grid {
+      display: grid;
+      gap: 1rem;
+      margin: 1.5rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    @media (min-width: 640px) {
+      .bs-svc-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 960px) {
+      .bs-svc-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
+      .bs-svc-grid li:last-child:nth-child(odd) {
+        grid-column: span 1;
+      }
+    }
+
+    .bs-svc-card {
+      padding: 1.1rem 1.15rem;
+      border-radius: 0.55rem;
+      border: 1px solid rgb(229 231 235);
+      background: rgb(255 255 255);
+      box-shadow: 0 2px 6px rgb(0 0 0 / 0.04);
+    }
+
+    .bs-svc-card__head {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.35rem 0.75rem;
+      padding-bottom: 0.65rem;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .bs-svc-card__name {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 650;
+      color: rgb(17 24 39);
+    }
+
+    .bs-svc-card__layer {
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .bs-svc-card__block {
+      margin-top: 0.65rem;
+    }
+
+    .bs-svc-card__label {
+      margin: 0;
+      font-size: 0.62rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .bs-svc-card__list,
+    .bs-svc-card__places {
+      margin: 0.25rem 0 0;
+      padding-left: 1rem;
+      font-size: 0.8rem;
+      line-height: 1.45;
+      color: rgb(55 65 81);
+    }
+
+    .bs-svc-card__list li + li,
+    .bs-svc-card__places li + li {
+      margin-top: 0.2rem;
+    }
+
+    .bs-svc-card__places {
+      list-style: none;
+      padding-left: 0;
+      font-family: ui-monospace, monospace;
+      font-size: 0.72rem;
+      color: rgb(75 85 99);
+    }
+
+    .bs-first-check {
+      margin-top: 1rem;
+      padding: 1rem 1.1rem;
+      border-radius: 0.5rem;
+      background: rgb(254 252 232);
+      border: 1px solid rgb(254 240 138);
+    }
+
+    .bs-first-check__title {
+      margin: 0;
+      font-size: 0.82rem;
+      font-weight: 650;
+      color: rgb(113 63 18);
+    }
+
+    .bs-first-check__list {
+      margin: 0.65rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs-first-check__list li {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 0.35rem 0.5rem;
+      padding: 0.35rem 0;
+      font-size: 0.84rem;
+      line-height: 1.45;
+      border-bottom: 1px solid rgb(254 240 138 / 0.5);
+    }
+
+    .bs-first-check__list li:last-child {
+      border-bottom: none;
+    }
+
+    .bs-first-check__symptom {
+      font-weight: 600;
+      color: rgb(92 58 15);
+    }
+
+    .bs-first-check__arrow {
+      color: rgb(180 130 50);
+      font-size: 0.75rem;
+    }
+
+    .bs-first-check__check {
       color: rgb(75 85 99);
     }
 

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -193,6 +193,20 @@ const layerTone: Record<string, string> = {
                 ))}
               </ul>
             </div>
+            {svc.actionLinks.length > 0 ? (
+              <div class="bs-link-chips" aria-label={`Gå hit — ${svc.name}`}>
+                {svc.actionLinks.map((link) => (
+                  <a
+                    href={link.href}
+                    class="bs-link-chip"
+                    target={link.external ? "_blank" : undefined}
+                    rel={link.external ? "noopener noreferrer" : undefined}
+                  >
+                    {link.label}
+                  </a>
+                ))}
+              </div>
+            ) : null}
           </li>
         ))}
       </ul>
@@ -210,6 +224,20 @@ const layerTone: Record<string, string> = {
               <div class="bs-runbook__go">
                 <dt>Hvor går vi?</dt>
                 <dd>{book.whereToGo}</dd>
+                {book.actionLinks.length > 0 ? (
+                  <div class="bs-link-chips bs-link-chips--in-go">
+                    {book.actionLinks.map((link) => (
+                      <a
+                        href={link.href}
+                        class="bs-link-chip"
+                        target={link.external ? "_blank" : undefined}
+                        rel={link.external ? "noopener noreferrer" : undefined}
+                      >
+                        {link.label}
+                      </a>
+                    ))}
+                  </div>
+                ) : null}
               </div>
               <div>
                 <dt>Hva endres?</dt>
@@ -253,6 +281,20 @@ const layerTone: Record<string, string> = {
               <span class="bs-first-check__symptom">{rule.symptom}</span>
               <span class="bs-first-check__arrow" aria-hidden="true">→</span>
               <span class="bs-first-check__check">{rule.check}</span>
+              {"links" in rule && rule.links.length > 0 ? (
+                <div class="bs-link-chips bs-link-chips--inline">
+                  {rule.links.map((link) => (
+                    <a
+                      href={link.href}
+                      class="bs-link-chip bs-link-chip--sm"
+                      target={link.external ? "_blank" : undefined}
+                      rel={link.external ? "noopener noreferrer" : undefined}
+                    >
+                      {link.label}
+                    </a>
+                  ))}
+                </div>
+              ) : null}
             </li>
           ))}
         </ul>
@@ -777,6 +819,60 @@ const layerTone: Record<string, string> = {
       font-weight: 550;
     }
 
+    .bs-link-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      margin-top: 0.65rem;
+    }
+
+    .bs-link-chips--in-go {
+      margin-top: 0.75rem;
+    }
+
+    .bs-link-chips--inline {
+      flex-basis: 100%;
+      margin-top: 0.45rem;
+      margin-left: 0;
+    }
+
+    .bs-link-chip {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.28rem 0.55rem;
+      border-radius: 999px;
+      border: 1px solid rgb(209 213 219);
+      background: rgb(255 255 255);
+      font-size: 0.72rem;
+      font-weight: 550;
+      line-height: 1.2;
+      color: rgb(55 65 81);
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    .bs-link-chip:hover {
+      border-color: rgb(156 163 175);
+      background: rgb(249 250 251);
+      color: rgb(17 24 39);
+    }
+
+    .bs-link-chip--sm {
+      font-size: 0.68rem;
+      padding: 0.22rem 0.48rem;
+    }
+
+    .bs-link-chips--in-go .bs-link-chip {
+      border-color: rgb(191 219 254);
+      background: rgb(255 255 255);
+      color: rgb(29 78 216);
+    }
+
+    .bs-link-chips--in-go .bs-link-chip:hover {
+      background: rgb(239 246 255);
+      border-color: rgb(147 197 253);
+    }
+
     .bs-svc-flow {
       display: flex;
       flex-wrap: wrap;
@@ -948,7 +1044,7 @@ const layerTone: Record<string, string> = {
       flex-wrap: wrap;
       align-items: baseline;
       gap: 0.35rem 0.5rem;
-      padding: 0.35rem 0;
+      padding: 0.5rem 0;
       font-size: 0.84rem;
       line-height: 1.45;
       border-bottom: 1px solid rgb(254 240 138 / 0.5);

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -1,0 +1,490 @@
+---
+/* CONTRACT: Backstage v0.1 — intern noindex referanse for AI-flow, API, guards, env-vars og production (#184). */
+import PrototypeLayout from "../../layouts/PrototypeLayout.astro";
+import {
+  backstageMeta,
+  beforeExternalSharing,
+  chatFlowSteps,
+  envVarNotes,
+  envVars,
+  errorStates,
+  guardLimits,
+  productionChecklist,
+  systemFlowSteps,
+} from "../../data/backstage-v01.ts";
+
+const base = import.meta.env.BASE_URL;
+
+const envGroups = [
+  { id: "upstash", label: "Upstash (rate limit)" },
+  { id: "ces", label: "CES (AI runtime)" },
+  { id: "auth", label: "Google auth" },
+] as const;
+---
+
+<PrototypeLayout title="Backstage — Viddel system">
+  <main class="bs">
+    <nav class="bs__crumb" aria-label="Du er her">
+      <a href={`${base}vis/`}>VIS</a>
+      <span aria-hidden="true">/</span>
+      <span>Backstage</span>
+    </nav>
+
+    <header class="bs__hero">
+      <p class="bs__kicker">Intern · Systemreferanse · {backstageMeta.issue}</p>
+      <h1>{backstageMeta.title}</h1>
+      <p class="bs__lead">{backstageMeta.lead}</p>
+      <p class="bs__meta">
+        Oppdatert {backstageMeta.updatedAt} · Guard ref {backstageMeta.relatedIssue} ·
+        <code>/designsystem/</code> = UI · <code>/backstage/</code> = system
+      </p>
+    </header>
+
+    <section class="bs__section" aria-labelledby="bs-system-map">
+      <h2 id="bs-system-map" class="bs__section-title">Systemkart</h2>
+      <div class="bs__flow" role="list" aria-label="AI-chat flyt oversikt">
+        {systemFlowSteps.map((step, index) => (
+          <div class="bs__flow-item" role="listitem">
+            <span class="bs__flow-step">{step.label}</span>
+            {index < systemFlowSteps.length - 1 ? (
+              <span class="bs__flow-arrow" aria-hidden="true">→</span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+      <p class="bs__flow-note">Headless flyt — ingen CES-widget i nettleseren.</p>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-chat-flow">
+      <h2 id="bs-chat-flow" class="bs__section-title">AI-chat flow</h2>
+      <ol class="bs__steps">
+        {chatFlowSteps.map((step, index) => (
+          <li>
+            <span class="bs__step-index">{index + 1}</span>
+            <div>
+              <h3 class="bs__step-title">{step.title}</h3>
+              <p class="bs__step-detail">{step.detail}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-guards">
+      <h2 id="bs-guards" class="bs__section-title">Guard &amp; limits</h2>
+      <ul class="bs__cards">
+        {guardLimits.map((item) => (
+          <li class="bs__card">
+            <p class="bs__card-label">{item.label}</p>
+            <p class="bs__card-value">{item.value}</p>
+            <p class="bs__card-note">{item.note}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-env">
+      <h2 id="bs-env" class="bs__section-title">Env-vars</h2>
+      <p class="bs__section-lead">Oversikt uten verdier — sett kun i Vercel dashboard.</p>
+      {
+        envGroups.map((group) => (
+          <div class="bs__env-group">
+            <h3 class="bs__env-group-title">{group.label}</h3>
+            <ul class="bs__env-list">
+              {envVars
+                .filter((v) => v.group === group.id)
+                .map((v) => (
+                  <li>
+                    <code class="bs__env-name">{v.name}</code>
+                    <span class="bs__env-controls">{v.controls}</span>
+                  </li>
+                ))}
+            </ul>
+          </div>
+        ))
+      }
+      <ul class="bs__bullets">
+        {envVarNotes.map((note) => (
+          <li>{note}</li>
+        ))}
+      </ul>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-errors">
+      <h2 id="bs-errors" class="bs__section-title">Feilstater</h2>
+      <ul class="bs__errors">
+        {errorStates.map((err) => (
+          <li class="bs__error">
+            <p class="bs__error-code"><code>{err.code}</code></p>
+            <dl class="bs__error-dl">
+              <div>
+                <dt>Betyr</dt>
+                <dd>{err.meaning}</dd>
+              </div>
+              <div>
+                <dt>Bruker ser</dt>
+                <dd>{err.userSees}</dd>
+              </div>
+              <div>
+                <dt>Vi sjekker</dt>
+                <dd>{err.weCheck}</dd>
+              </div>
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-checklist">
+      <h2 id="bs-checklist" class="bs__section-title">Production checklist</h2>
+      <ul class="bs__checklist">
+        {productionChecklist.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
+    </section>
+
+    <section class="bs__section bs__section--note" aria-labelledby="bs-external">
+      <h2 id="bs-external" class="bs__section-title">Før ekstern deling</h2>
+      <ul class="bs__bullets">
+        {beforeExternalSharing.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
+    </section>
+
+    <footer class="bs__footer">
+      <p>
+        Kildekode: <code>src/pages/api/chat.ts</code> · <code>src/lib/chat-api-guard.ts</code> ·
+        <code>src/lib/ces-env.ts</code>
+      </p>
+      <p><a href={`${base}vis/`}>← Tilbake til VIS kontrollrom</a></p>
+    </footer>
+  </main>
+
+  <style>
+    .bs {
+      max-width: 52rem;
+      margin: 0 auto;
+      padding: 2rem 1rem 3rem;
+      color: rgb(17 24 39);
+    }
+
+    .bs__crumb {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.78rem;
+      color: rgb(107 114 128);
+    }
+
+    .bs__crumb a {
+      color: rgb(75 85 99);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .bs__kicker {
+      margin: 1.25rem 0 0;
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .bs__hero h1 {
+      margin: 0.35rem 0 0;
+      font-size: clamp(1.45rem, 3vw, 1.85rem);
+      font-weight: 650;
+      letter-spacing: -0.03em;
+    }
+
+    .bs__lead {
+      margin: 0.6rem 0 0;
+      max-width: 38rem;
+      font-size: 0.94rem;
+      line-height: 1.55;
+      color: rgb(55 65 81);
+    }
+
+    .bs__meta {
+      margin: 0.5rem 0 0;
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
+    }
+
+    .bs__meta code,
+    .bs__env-name,
+    .bs__error-code code {
+      font-family: ui-monospace, monospace;
+      font-size: 0.85em;
+    }
+
+    .bs__section {
+      margin-top: 2.5rem;
+    }
+
+    .bs__section--note {
+      padding: 1rem 0 0;
+      border-top: 1px solid rgb(243 244 246);
+    }
+
+    .bs__section-title {
+      margin: 0;
+      font-size: 0.72rem;
+      font-weight: 650;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .bs__section-lead {
+      margin: 0.35rem 0 0;
+      font-size: 0.82rem;
+      color: rgb(107 114 128);
+    }
+
+    .bs__flow {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.25rem;
+      margin-top: 1rem;
+    }
+
+    .bs__flow-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .bs__flow-step {
+      display: inline-block;
+      padding: 0.35rem 0.55rem;
+      border: 1px solid rgb(229 231 235);
+      border-radius: 0.35rem;
+      background: rgb(249 250 251);
+      font-size: 0.72rem;
+      font-weight: 550;
+      color: rgb(31 41 55);
+    }
+
+    .bs__flow-arrow {
+      font-size: 0.75rem;
+      color: rgb(156 163 175);
+    }
+
+    .bs__flow-note {
+      margin: 0.65rem 0 0;
+      font-size: 0.78rem;
+      color: rgb(107 114 128);
+    }
+
+    .bs__steps {
+      margin: 1rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs__steps li {
+      display: flex;
+      gap: 0.75rem;
+      padding: 0.65rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .bs__steps li:last-child {
+      border-bottom: none;
+    }
+
+    .bs__step-index {
+      flex-shrink: 0;
+      width: 1.25rem;
+      font-size: 0.78rem;
+      font-weight: 650;
+      color: rgb(156 163 175);
+    }
+
+    .bs__step-title {
+      margin: 0;
+      font-size: 0.92rem;
+      font-weight: 650;
+      color: rgb(31 41 55);
+    }
+
+    .bs__step-detail {
+      margin: 0.2rem 0 0;
+      font-size: 0.84rem;
+      line-height: 1.5;
+      color: rgb(75 85 99);
+    }
+
+    .bs__cards {
+      display: grid;
+      gap: 0.65rem;
+      margin: 1rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    @media (min-width: 640px) {
+      .bs__cards {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    .bs__card {
+      padding: 0.65rem 0.75rem;
+      border: 1px solid rgb(243 244 246);
+      border-radius: 0.35rem;
+    }
+
+    .bs__card-label {
+      margin: 0;
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .bs__card-value {
+      margin: 0.25rem 0 0;
+      font-size: 0.92rem;
+      font-weight: 650;
+      color: rgb(31 41 55);
+    }
+
+    .bs__card-note {
+      margin: 0.25rem 0 0;
+      font-size: 0.78rem;
+      line-height: 1.45;
+      color: rgb(107 114 128);
+    }
+
+    .bs__env-group {
+      margin-top: 1rem;
+    }
+
+    .bs__env-group-title {
+      margin: 0 0 0.35rem;
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: rgb(55 65 81);
+    }
+
+    .bs__env-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs__env-list li {
+      padding: 0.45rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .bs__env-name {
+      display: block;
+      font-size: 0.78rem;
+      color: rgb(31 41 55);
+    }
+
+    .bs__env-controls {
+      display: block;
+      margin-top: 0.15rem;
+      font-size: 0.78rem;
+      line-height: 1.45;
+      color: rgb(107 114 128);
+    }
+
+    .bs__bullets {
+      margin: 0.75rem 0 0;
+      padding-left: 1.1rem;
+      font-size: 0.84rem;
+      line-height: 1.55;
+      color: rgb(75 85 99);
+    }
+
+    .bs__bullets li + li {
+      margin-top: 0.35rem;
+    }
+
+    .bs__errors {
+      margin: 1rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs__error {
+      padding: 0.75rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .bs__error-code {
+      margin: 0;
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: rgb(31 41 55);
+    }
+
+    .bs__error-dl {
+      margin: 0.45rem 0 0;
+      display: grid;
+      gap: 0.45rem;
+    }
+
+    .bs__error-dl dt {
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .bs__error-dl dd {
+      margin: 0.1rem 0 0;
+      font-size: 0.82rem;
+      line-height: 1.45;
+      color: rgb(75 85 99);
+    }
+
+    .bs__checklist {
+      margin: 1rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs__checklist li {
+      position: relative;
+      padding: 0.35rem 0 0.35rem 1.35rem;
+      font-size: 0.86rem;
+      line-height: 1.45;
+      color: rgb(55 65 81);
+    }
+
+    .bs__checklist li::before {
+      content: "☐";
+      position: absolute;
+      left: 0;
+      color: rgb(156 163 175);
+    }
+
+    .bs__footer {
+      margin-top: 2.5rem;
+      padding-top: 1rem;
+      border-top: 1px solid rgb(243 244 246);
+      font-size: 0.72rem;
+      line-height: 1.5;
+      color: rgb(156 163 175);
+    }
+
+    .bs__footer a {
+      color: rgb(75 85 99);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+  </style>
+</PrototypeLayout>

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -1,28 +1,42 @@
 ---
-/* CONTRACT: Backstage v0.1 — intern noindex referanse for AI-flow, API, guards, env-vars og production (#184). */
+/* CONTRACT: Backstage v0.1 — pedagogisk intern referanse; forståelse først, teknikk nederst (#184). */
 import PrototypeLayout from "../../layouts/PrototypeLayout.astro";
 import {
   backstageMeta,
   beforeExternalSharing,
+  cesExplainer,
   chatFlowSteps,
   envVarNotes,
   envVars,
-  errorStates,
-  guardLimits,
   productionChecklist,
-  systemFlowSteps,
+  protectionRules,
+  quickAnswers,
+  sourceFiles,
+  statusPanel,
+  systemMapLayers,
+  troubleshootingCases,
+  upstashExplainer,
 } from "../../data/backstage-v01.ts";
 
 const base = import.meta.env.BASE_URL;
 
 const envGroups = [
-  { id: "upstash", label: "Upstash (rate limit)" },
-  { id: "ces", label: "CES (AI runtime)" },
+  { id: "upstash", label: "Upstash (teller)" },
+  { id: "ces", label: "CES (AI-motor)" },
   { id: "auth", label: "Google auth" },
 ] as const;
+
+const layerTone: Record<string, string> = {
+  Bruker: "bs-map__band--user",
+  Brukerflate: "bs-map__band--surface",
+  "Viddel-server": "bs-map__band--server",
+  Beskyttelse: "bs-map__band--guard",
+  "AI-motor": "bs-map__band--ai",
+  Svar: "bs-map__band--response",
+};
 ---
 
-<PrototypeLayout title="Backstage — Viddel system">
+<PrototypeLayout title="Backstage — Viddel">
   <main class="bs">
     <nav class="bs__crumb" aria-label="Du er her">
       <a href={`${base}vis/`}>VIS</a>
@@ -31,105 +45,139 @@ const envGroups = [
     </nav>
 
     <header class="bs__hero">
-      <p class="bs__kicker">Intern · Systemreferanse · {backstageMeta.issue}</p>
+      <p class="bs__kicker">Intern · {backstageMeta.issue}</p>
       <h1>{backstageMeta.title}</h1>
       <p class="bs__lead">{backstageMeta.lead}</p>
-      <p class="bs__meta">
-        Oppdatert {backstageMeta.updatedAt} · Guard ref {backstageMeta.relatedIssue} ·
-        <code>/designsystem/</code> = UI · <code>/backstage/</code> = system
-      </p>
     </header>
 
-    <section class="bs__section" aria-labelledby="bs-system-map">
-      <h2 id="bs-system-map" class="bs__section-title">Systemkart</h2>
-      <div class="bs__flow" role="list" aria-label="AI-chat flyt oversikt">
-        {systemFlowSteps.map((step, index) => (
-          <div class="bs__flow-item" role="listitem">
-            <span class="bs__flow-step">{step.label}</span>
-            {index < systemFlowSteps.length - 1 ? (
-              <span class="bs__flow-arrow" aria-hidden="true">→</span>
+    <section class="bs__status" aria-label="Status nå">
+      {statusPanel.map((item) => (
+        <div class:list={["bs__status-item", `bs__status-item--${item.tone}`]}>
+          <p class="bs__status-label">{item.label}</p>
+          <p class="bs__status-value">{item.value}</p>
+        </div>
+      ))}
+    </section>
+
+    <section class="bs__quick" aria-labelledby="bs-quick">
+      <h2 id="bs-quick" class="bs__visually-hidden">Tre spørsmål</h2>
+      <div class="bs__quick-grid">
+        {quickAnswers.map((item) => (
+          <article class="bs__quick-card">
+            <h3 class="bs__quick-q">{item.question}</h3>
+            <p class="bs__quick-a">{item.answer}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+
+    <section class="bs__anchor" aria-labelledby="bs-system-map">
+      <h2 id="bs-system-map" class="bs__anchor-title">Systemkart</h2>
+      <p class="bs__anchor-lead">Slik flyter et spørsmål gjennom Viddel — fra bruker til svar.</p>
+
+      <figure class="bs-map" aria-label="Systemkart for Spør Viddel">
+        {systemMapLayers.map((node, index) => (
+          <div class="bs-map__row">
+            <div class:list={["bs-map__band", layerTone[node.layer]]}>
+              <span class="bs-map__layer">{node.layer}</span>
+            </div>
+            <div class="bs-map__node">
+              <h3 class="bs-map__title">{node.title}</h3>
+              <p class="bs-map__human">{node.human}</p>
+              {node.tech ? <p class="bs-map__tech">({node.tech})</p> : null}
+            </div>
+            {index < systemMapLayers.length - 1 ? (
+              <div class="bs-map__connector" aria-hidden="true">
+                <span class="bs-map__arrow">↓</span>
+              </div>
             ) : null}
           </div>
         ))}
-      </div>
-      <p class="bs__flow-note">Headless flyt — ingen CES-widget i nettleseren.</p>
+      </figure>
     </section>
 
-    <section class="bs__section" aria-labelledby="bs-chat-flow">
-      <h2 id="bs-chat-flow" class="bs__section-title">AI-chat flow</h2>
-      <ol class="bs__steps">
-        {chatFlowSteps.map((step, index) => (
-          <li>
-            <span class="bs__step-index">{index + 1}</span>
-            <div>
-              <h3 class="bs__step-title">{step.title}</h3>
-              <p class="bs__step-detail">{step.detail}</p>
+    <section class="bs__section" aria-labelledby="bs-user-flow">
+      <h2 id="bs-user-flow" class="bs__section-title">Hva skjer når brukeren spør?</h2>
+      <p class="bs__section-lead">Steg for steg — menneskelig forklaring først.</p>
+
+      <ol class="bs-flow">
+        {chatFlowSteps.map((step) => (
+          <li class="bs-flow__step">
+            <span class="bs-flow__num">{step.step}</span>
+            <div class="bs-flow__body">
+              <h3 class="bs-flow__title">{step.title}</h3>
+              <p class="bs-flow__human">{step.human}</p>
+              {step.why ? <p class="bs-flow__why">{step.why}</p> : null}
+              {step.tech ? <p class="bs-flow__tech">{step.tech}</p> : null}
             </div>
           </li>
         ))}
       </ol>
     </section>
 
-    <section class="bs__section" aria-labelledby="bs-guards">
-      <h2 id="bs-guards" class="bs__section-title">Guard &amp; limits</h2>
-      <ul class="bs__cards">
-        {guardLimits.map((item) => (
-          <li class="bs__card">
-            <p class="bs__card-label">{item.label}</p>
-            <p class="bs__card-value">{item.value}</p>
-            <p class="bs__card-note">{item.note}</p>
+    <section class="bs__section" aria-labelledby="bs-protection">
+      <h2 id="bs-protection" class="bs__section-title">Hva beskytter oss?</h2>
+      <ul class="bs-protect">
+        {protectionRules.map((rule) => (
+          <li class="bs-protect__item">
+            <p class="bs-protect__head">
+              <span class="bs-protect__title">{rule.title}</span>
+              <span class="bs-protect__value">{rule.value}</span>
+            </p>
+            <p class="bs-protect__human">{rule.human}</p>
+            {"tech" in rule && rule.tech ? <p class="bs-protect__tech">{rule.tech}</p> : null}
           </li>
         ))}
       </ul>
     </section>
 
-    <section class="bs__section" aria-labelledby="bs-env">
-      <h2 id="bs-env" class="bs__section-title">Env-vars</h2>
-      <p class="bs__section-lead">Oversikt uten verdier — sett kun i Vercel dashboard.</p>
-      {
-        envGroups.map((group) => (
-          <div class="bs__env-group">
-            <h3 class="bs__env-group-title">{group.label}</h3>
-            <ul class="bs__env-list">
-              {envVars
-                .filter((v) => v.group === group.id)
-                .map((v) => (
-                  <li>
-                    <code class="bs__env-name">{v.name}</code>
-                    <span class="bs__env-controls">{v.controls}</span>
-                  </li>
-                ))}
-            </ul>
-          </div>
-        ))
-      }
-      <ul class="bs__bullets">
-        {envVarNotes.map((note) => (
-          <li>{note}</li>
-        ))}
-      </ul>
+    <section class="bs__explainers">
+      <article class="bs-explainer" aria-labelledby="bs-upstash">
+        <h2 id="bs-upstash" class="bs-explainer__title">{upstashExplainer.title}</h2>
+        <p class="bs-explainer__body">{upstashExplainer.body}</p>
+      </article>
+      <article class="bs-explainer" aria-labelledby="bs-ces">
+        <h2 id="bs-ces" class="bs-explainer__title">{cesExplainer.title}</h2>
+        <p class="bs-explainer__body">{cesExplainer.body}</p>
+      </article>
     </section>
 
-    <section class="bs__section" aria-labelledby="bs-errors">
-      <h2 id="bs-errors" class="bs__section-title">Feilstater</h2>
-      <ul class="bs__errors">
-        {errorStates.map((err) => (
-          <li class="bs__error">
-            <p class="bs__error-code"><code>{err.code}</code></p>
-            <dl class="bs__error-dl">
+    <section class="bs__section" aria-labelledby="bs-troubleshoot">
+      <h2 id="bs-troubleshoot" class="bs__section-title">Når noe ikke virker</h2>
+      <p class="bs__section-lead">Start med hva brukeren ser — deretter hva det betyr og hva vi sjekker.</p>
+
+      <ul class="bs-fix">
+        {troubleshootingCases.map((item) => (
+          <li class="bs-fix__case">
+            <p class="bs-fix__user">
+              <span class="bs-fix__label">Brukeren ser</span>
+              {item.userSees}
+            </p>
+            <div class="bs-fix__cols">
               <div>
-                <dt>Betyr</dt>
-                <dd>{err.meaning}</dd>
+                <p class="bs-fix__label">Kan bety</p>
+                <ul class="bs-fix__list">
+                  {item.usuallyMeans.map((line) => (
+                    <li>{line}</li>
+                  ))}
+                </ul>
               </div>
               <div>
-                <dt>Bruker ser</dt>
-                <dd>{err.userSees}</dd>
+                <p class="bs-fix__label">Vi sjekker</p>
+                <ul class="bs-fix__list">
+                  {item.weCheck.map((line) => (
+                    <li>{line}</li>
+                  ))}
+                </ul>
               </div>
-              <div>
-                <dt>Vi sjekker</dt>
-                <dd>{err.weCheck}</dd>
-              </div>
-            </dl>
+            </div>
+            {item.techCodes?.length ? (
+              <p class="bs-fix__tech">
+                Teknisk: {item.techCodes.map((c) => (
+                  <code>{c}</code>
+                ))}
+              </p>
+            ) : null}
           </li>
         ))}
       </ul>
@@ -137,7 +185,7 @@ const envGroups = [
 
     <section class="bs__section" aria-labelledby="bs-checklist">
       <h2 id="bs-checklist" class="bs__section-title">Production checklist</h2>
-      <ul class="bs__checklist">
+      <ul class="bs-checklist">
         {productionChecklist.map((item) => (
           <li>{item}</li>
         ))}
@@ -146,28 +194,72 @@ const envGroups = [
 
     <section class="bs__section bs__section--note" aria-labelledby="bs-external">
       <h2 id="bs-external" class="bs__section-title">Før ekstern deling</h2>
-      <ul class="bs__bullets">
+      <ul class="bs-note-list">
         {beforeExternalSharing.map((item) => (
           <li>{item}</li>
         ))}
       </ul>
     </section>
 
+    <details class="bs-tech">
+      <summary>Teknisk referanse</summary>
+      <div class="bs-tech__body">
+        <p class="bs-tech__lead">Env-vars (uten verdier) og kildefiler — for utvikling og feilsøking.</p>
+
+        {envGroups.map((group) => (
+          <div class="bs-tech__group">
+            <h3 class="bs-tech__group-title">{group.label}</h3>
+            <ul class="bs-tech__env">
+              {envVars
+                .filter((v) => v.group === group.id)
+                .map((v) => (
+                  <li>
+                    <code>{v.name}</code>
+                    <span>{v.controls}</span>
+                  </li>
+                ))}
+            </ul>
+          </div>
+        ))}
+
+        <ul class="bs-tech__notes">
+          {envVarNotes.map((note) => (
+            <li>{note}</li>
+          ))}
+        </ul>
+
+        <p class="bs-tech__files-label">Kildefiler</p>
+        <ul class="bs-tech__files">
+          {sourceFiles.map((file) => (
+            <li><code>{file}</code></li>
+          ))}
+        </ul>
+      </div>
+    </details>
+
     <footer class="bs__footer">
-      <p>
-        Kildekode: <code>src/pages/api/chat.ts</code> · <code>src/lib/chat-api-guard.ts</code> ·
-        <code>src/lib/ces-env.ts</code>
-      </p>
-      <p><a href={`${base}vis/`}>← Tilbake til VIS kontrollrom</a></p>
+      <p>Oppdatert {backstageMeta.updatedAt} · <a href={`${base}vis/`}>← VIS kontrollrom</a></p>
     </footer>
   </main>
 
   <style>
     .bs {
-      max-width: 52rem;
+      max-width: 44rem;
       margin: 0 auto;
-      padding: 2rem 1rem 3rem;
+      padding: 2.5rem 1.25rem 4rem;
       color: rgb(17 24 39);
+    }
+
+    .bs__visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
 
     .bs__crumb {
@@ -186,7 +278,7 @@ const envGroups = [
     }
 
     .bs__kicker {
-      margin: 1.25rem 0 0;
+      margin: 1.5rem 0 0;
       font-size: 0.68rem;
       font-weight: 600;
       letter-spacing: 0.12em;
@@ -195,289 +287,553 @@ const envGroups = [
     }
 
     .bs__hero h1 {
-      margin: 0.35rem 0 0;
-      font-size: clamp(1.45rem, 3vw, 1.85rem);
+      margin: 0.4rem 0 0;
+      font-size: clamp(1.75rem, 4vw, 2.25rem);
       font-weight: 650;
       letter-spacing: -0.03em;
+      line-height: 1.1;
     }
 
     .bs__lead {
-      margin: 0.6rem 0 0;
-      max-width: 38rem;
-      font-size: 0.94rem;
+      margin: 1rem 0 0;
+      max-width: 36rem;
+      font-size: 1.05rem;
+      line-height: 1.6;
+      color: rgb(55 65 81);
+    }
+
+    .bs__status {
+      display: grid;
+      gap: 0.75rem;
+      margin-top: 2.25rem;
+    }
+
+    @media (min-width: 640px) {
+      .bs__status {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    .bs__status-item {
+      padding: 1rem 1.1rem;
+      border-radius: 0.5rem;
+      border: 1px solid rgb(229 231 235);
+      background: rgb(249 250 251);
+    }
+
+    .bs__status-item--live {
+      border-color: rgb(167 243 208);
+      background: rgb(236 253 245);
+    }
+
+    .bs__status-item--wait {
+      border-color: rgb(254 240 138);
+      background: rgb(254 252 232);
+    }
+
+    .bs__status-label {
+      margin: 0;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .bs__status-value {
+      margin: 0.35rem 0 0;
+      font-size: 0.95rem;
+      font-weight: 650;
+      line-height: 1.35;
+      color: rgb(31 41 55);
+    }
+
+    .bs__quick {
+      margin-top: 2.75rem;
+    }
+
+    .bs__quick-grid {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 768px) {
+      .bs__quick-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    .bs__quick-card {
+      padding: 1.1rem 1.15rem;
+      border-radius: 0.5rem;
+      background: rgb(255 255 255);
+      border: 1px solid rgb(243 244 246);
+      box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+    }
+
+    .bs__quick-q {
+      margin: 0;
+      font-size: 0.88rem;
+      font-weight: 650;
+      line-height: 1.35;
+      color: rgb(31 41 55);
+    }
+
+    .bs__quick-a {
+      margin: 0.5rem 0 0;
+      font-size: 0.84rem;
+      line-height: 1.55;
+      color: rgb(75 85 99);
+    }
+
+    .bs__anchor {
+      margin-top: 3.5rem;
+      padding-top: 2.5rem;
+      border-top: 1px solid rgb(243 244 246);
+    }
+
+    .bs__anchor-title {
+      margin: 0;
+      font-size: clamp(1.25rem, 3vw, 1.55rem);
+      font-weight: 650;
+      letter-spacing: -0.02em;
+      color: rgb(17 24 39);
+    }
+
+    .bs__anchor-lead {
+      margin: 0.5rem 0 0;
+      font-size: 0.92rem;
+      color: rgb(107 114 128);
+    }
+
+    .bs-map {
+      margin: 1.75rem 0 0;
+      padding: 0;
+    }
+
+    .bs-map__row {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .bs-map__band {
+      align-self: flex-start;
+      padding: 0.2rem 0.55rem;
+      border-radius: 0.25rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .bs-map__band--user { background: rgb(243 244 246); }
+    .bs-map__band--surface { background: rgb(219 234 254); color: rgb(30 64 175); }
+    .bs-map__band--server { background: rgb(224 231 255); color: rgb(55 48 163); }
+    .bs-map__band--guard { background: rgb(254 243 199); color: rgb(146 64 14); }
+    .bs-map__band--ai { background: rgb(237 233 254); color: rgb(91 33 182); }
+    .bs-map__band--response { background: rgb(209 250 229); color: rgb(6 95 70); }
+
+    .bs-map__layer {
+      font-size: 0.62rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    .bs-map__node {
+      padding: 1.1rem 1.25rem;
+      border: 1px solid rgb(229 231 235);
+      border-radius: 0.6rem;
+      background: rgb(255 255 255);
+      box-shadow: 0 2px 8px rgb(0 0 0 / 0.04);
+    }
+
+    .bs-map__title {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 650;
+      color: rgb(17 24 39);
+    }
+
+    .bs-map__human {
+      margin: 0.4rem 0 0;
+      font-size: 0.92rem;
       line-height: 1.55;
       color: rgb(55 65 81);
     }
 
-    .bs__meta {
-      margin: 0.5rem 0 0;
+    .bs-map__tech {
+      margin: 0.35rem 0 0;
       font-size: 0.72rem;
       color: rgb(156 163 175);
     }
 
-    .bs__meta code,
-    .bs__env-name,
-    .bs__error-code code {
-      font-family: ui-monospace, monospace;
-      font-size: 0.85em;
+    .bs-map__connector {
+      display: flex;
+      justify-content: center;
+      padding: 0.35rem 0;
+    }
+
+    .bs-map__arrow {
+      font-size: 1.1rem;
+      color: rgb(156 163 175);
+      line-height: 1;
     }
 
     .bs__section {
-      margin-top: 2.5rem;
+      margin-top: 3rem;
     }
 
     .bs__section--note {
-      padding: 1rem 0 0;
+      padding-top: 1.5rem;
       border-top: 1px solid rgb(243 244 246);
     }
 
     .bs__section-title {
       margin: 0;
-      font-size: 0.72rem;
+      font-size: clamp(1.05rem, 2.5vw, 1.25rem);
       font-weight: 650;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      color: rgb(107 114 128);
+      letter-spacing: -0.01em;
+      color: rgb(17 24 39);
     }
 
     .bs__section-lead {
-      margin: 0.35rem 0 0;
-      font-size: 0.82rem;
+      margin: 0.4rem 0 0;
+      font-size: 0.88rem;
       color: rgb(107 114 128);
     }
 
-    .bs__flow {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 0.25rem;
-      margin-top: 1rem;
-    }
-
-    .bs__flow-item {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-    }
-
-    .bs__flow-step {
-      display: inline-block;
-      padding: 0.35rem 0.55rem;
-      border: 1px solid rgb(229 231 235);
-      border-radius: 0.35rem;
-      background: rgb(249 250 251);
-      font-size: 0.72rem;
-      font-weight: 550;
-      color: rgb(31 41 55);
-    }
-
-    .bs__flow-arrow {
-      font-size: 0.75rem;
-      color: rgb(156 163 175);
-    }
-
-    .bs__flow-note {
-      margin: 0.65rem 0 0;
-      font-size: 0.78rem;
-      color: rgb(107 114 128);
-    }
-
-    .bs__steps {
-      margin: 1rem 0 0;
+    .bs-flow {
+      margin: 1.5rem 0 0;
       padding: 0;
       list-style: none;
     }
 
-    .bs__steps li {
+    .bs-flow__step {
       display: flex;
-      gap: 0.75rem;
-      padding: 0.65rem 0;
+      gap: 1rem;
+      padding: 1.1rem 0;
       border-bottom: 1px solid rgb(243 244 246);
     }
 
-    .bs__steps li:last-child {
+    .bs-flow__step:last-child {
       border-bottom: none;
     }
 
-    .bs__step-index {
+    .bs-flow__num {
       flex-shrink: 0;
-      width: 1.25rem;
-      font-size: 0.78rem;
-      font-weight: 650;
-      color: rgb(156 163 175);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      border-radius: 999px;
+      background: rgb(243 244 246);
+      font-size: 0.85rem;
+      font-weight: 700;
+      color: rgb(75 85 99);
     }
 
-    .bs__step-title {
+    .bs-flow__title {
       margin: 0;
-      font-size: 0.92rem;
+      font-size: 1rem;
       font-weight: 650;
       color: rgb(31 41 55);
     }
 
-    .bs__step-detail {
-      margin: 0.2rem 0 0;
+    .bs-flow__human {
+      margin: 0.3rem 0 0;
+      font-size: 0.9rem;
+      line-height: 1.55;
+      color: rgb(55 65 81);
+    }
+
+    .bs-flow__why {
+      margin: 0.45rem 0 0;
+      font-size: 0.82rem;
+      line-height: 1.45;
+      color: rgb(107 114 128);
+      font-style: italic;
+    }
+
+    .bs-flow__tech {
+      margin: 0.25rem 0 0;
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
+    }
+
+    .bs-protect {
+      margin: 1.25rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs-protect__item {
+      padding: 1rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .bs-protect__item:last-child {
+      border-bottom: none;
+    }
+
+    .bs-protect__head {
+      margin: 0;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 0.5rem 1rem;
+    }
+
+    .bs-protect__title {
+      font-size: 0.95rem;
+      font-weight: 650;
+      color: rgb(31 41 55);
+    }
+
+    .bs-protect__value {
+      font-size: 0.88rem;
+      font-weight: 600;
+      color: rgb(107 114 128);
+    }
+
+    .bs-protect__human {
+      margin: 0.35rem 0 0;
+      font-size: 0.88rem;
+      line-height: 1.55;
+      color: rgb(75 85 99);
+    }
+
+    .bs-protect__tech {
+      margin: 0.25rem 0 0;
+      font-size: 0.68rem;
+      color: rgb(156 163 175);
+      font-family: ui-monospace, monospace;
+    }
+
+    .bs__explainers {
+      display: grid;
+      gap: 1rem;
+      margin-top: 2.5rem;
+    }
+
+    @media (min-width: 640px) {
+      .bs__explainers {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    .bs-explainer {
+      padding: 1.25rem 1.35rem;
+      border-radius: 0.6rem;
+      background: rgb(249 250 251);
+      border: 1px solid rgb(243 244 246);
+    }
+
+    .bs-explainer__title {
+      margin: 0;
+      font-size: 0.95rem;
+      font-weight: 650;
+      color: rgb(31 41 55);
+    }
+
+    .bs-explainer__body {
+      margin: 0.5rem 0 0;
+      font-size: 0.88rem;
+      line-height: 1.6;
+      color: rgb(75 85 99);
+    }
+
+    .bs-fix {
+      margin: 1.25rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs-fix__case {
+      padding: 1.25rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .bs-fix__case:last-child {
+      border-bottom: none;
+    }
+
+    .bs-fix__label {
+      display: block;
+      margin: 0 0 0.25rem;
+      font-size: 0.65rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .bs-fix__user {
+      margin: 0;
+      font-size: 0.92rem;
+      font-weight: 550;
+      line-height: 1.45;
+      color: rgb(31 41 55);
+    }
+
+    .bs-fix__cols {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+
+    @media (min-width: 640px) {
+      .bs-fix__cols {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+
+    .bs-fix__list {
+      margin: 0.25rem 0 0;
+      padding-left: 1rem;
       font-size: 0.84rem;
       line-height: 1.5;
       color: rgb(75 85 99);
     }
 
-    .bs__cards {
-      display: grid;
-      gap: 0.65rem;
-      margin: 1rem 0 0;
-      padding: 0;
-      list-style: none;
+    .bs-fix__list li + li {
+      margin-top: 0.25rem;
     }
 
-    @media (min-width: 640px) {
-      .bs__cards {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-    }
-
-    .bs__card {
-      padding: 0.65rem 0.75rem;
-      border: 1px solid rgb(243 244 246);
-      border-radius: 0.35rem;
-    }
-
-    .bs__card-label {
-      margin: 0;
-      font-size: 0.68rem;
-      font-weight: 600;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: rgb(107 114 128);
-    }
-
-    .bs__card-value {
-      margin: 0.25rem 0 0;
-      font-size: 0.92rem;
-      font-weight: 650;
-      color: rgb(31 41 55);
-    }
-
-    .bs__card-note {
-      margin: 0.25rem 0 0;
-      font-size: 0.78rem;
-      line-height: 1.45;
-      color: rgb(107 114 128);
-    }
-
-    .bs__env-group {
-      margin-top: 1rem;
-    }
-
-    .bs__env-group-title {
-      margin: 0 0 0.35rem;
-      font-size: 0.82rem;
-      font-weight: 600;
-      color: rgb(55 65 81);
-    }
-
-    .bs__env-list {
-      margin: 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .bs__env-list li {
-      padding: 0.45rem 0;
-      border-bottom: 1px solid rgb(243 244 246);
-    }
-
-    .bs__env-name {
-      display: block;
-      font-size: 0.78rem;
-      color: rgb(31 41 55);
-    }
-
-    .bs__env-controls {
-      display: block;
-      margin-top: 0.15rem;
-      font-size: 0.78rem;
-      line-height: 1.45;
-      color: rgb(107 114 128);
-    }
-
-    .bs__bullets {
+    .bs-fix__tech {
       margin: 0.75rem 0 0;
-      padding-left: 1.1rem;
-      font-size: 0.84rem;
-      line-height: 1.55;
-      color: rgb(75 85 99);
-    }
-
-    .bs__bullets li + li {
-      margin-top: 0.35rem;
-    }
-
-    .bs__errors {
-      margin: 1rem 0 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .bs__error {
-      padding: 0.75rem 0;
-      border-bottom: 1px solid rgb(243 244 246);
-    }
-
-    .bs__error-code {
-      margin: 0;
-      font-size: 0.82rem;
-      font-weight: 600;
-      color: rgb(31 41 55);
-    }
-
-    .bs__error-dl {
-      margin: 0.45rem 0 0;
-      display: grid;
-      gap: 0.45rem;
-    }
-
-    .bs__error-dl dt {
       font-size: 0.68rem;
-      font-weight: 650;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
       color: rgb(156 163 175);
     }
 
-    .bs__error-dl dd {
-      margin: 0.1rem 0 0;
-      font-size: 0.82rem;
-      line-height: 1.45;
-      color: rgb(75 85 99);
+    .bs-fix__tech code {
+      margin-right: 0.35rem;
+      font-family: ui-monospace, monospace;
     }
 
-    .bs__checklist {
+    .bs-checklist {
       margin: 1rem 0 0;
       padding: 0;
       list-style: none;
     }
 
-    .bs__checklist li {
+    .bs-checklist li {
       position: relative;
-      padding: 0.35rem 0 0.35rem 1.35rem;
-      font-size: 0.86rem;
+      padding: 0.5rem 0 0.5rem 1.5rem;
+      font-size: 0.92rem;
       line-height: 1.45;
       color: rgb(55 65 81);
     }
 
-    .bs__checklist li::before {
+    .bs-checklist li::before {
       content: "☐";
       position: absolute;
       left: 0;
       color: rgb(156 163 175);
     }
 
+    .bs-note-list {
+      margin: 0.75rem 0 0;
+      padding-left: 1.1rem;
+      font-size: 0.9rem;
+      line-height: 1.6;
+      color: rgb(75 85 99);
+    }
+
+    .bs-note-list li + li {
+      margin-top: 0.4rem;
+    }
+
+    .bs-tech {
+      margin-top: 3rem;
+      padding: 1rem 1.1rem;
+      border: 1px solid rgb(243 244 246);
+      border-radius: 0.5rem;
+      background: rgb(249 250 251);
+      font-size: 0.82rem;
+      color: rgb(75 85 99);
+    }
+
+    .bs-tech summary {
+      cursor: pointer;
+      font-weight: 650;
+      color: rgb(107 114 128);
+    }
+
+    .bs-tech__body {
+      margin-top: 1rem;
+    }
+
+    .bs-tech__lead {
+      margin: 0 0 1rem;
+      line-height: 1.5;
+    }
+
+    .bs-tech__group {
+      margin-top: 0.75rem;
+    }
+
+    .bs-tech__group-title {
+      margin: 0;
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: rgb(55 65 81);
+    }
+
+    .bs-tech__env {
+      margin: 0.35rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs-tech__env li {
+      padding: 0.3rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .bs-tech__env code {
+      display: block;
+      font-size: 0.72rem;
+      color: rgb(31 41 55);
+    }
+
+    .bs-tech__env span {
+      display: block;
+      margin-top: 0.1rem;
+      font-size: 0.72rem;
+      color: rgb(107 114 128);
+    }
+
+    .bs-tech__notes {
+      margin: 1rem 0 0;
+      padding-left: 1rem;
+      font-size: 0.78rem;
+      line-height: 1.5;
+    }
+
+    .bs-tech__files-label {
+      margin: 1rem 0 0.35rem;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .bs-tech__files {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .bs-tech__files code {
+      font-size: 0.72rem;
+      color: rgb(75 85 99);
+    }
+
     .bs__footer {
       margin-top: 2.5rem;
       padding-top: 1rem;
-      border-top: 1px solid rgb(243 244 246);
-      font-size: 0.72rem;
-      line-height: 1.5;
+      font-size: 0.78rem;
       color: rgb(156 163 175);
     }
 

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -16,6 +16,7 @@ import {
   systemMapLayers,
   troubleshootingCases,
   upstashExplainer,
+  changeRunbooks,
 } from "../../data/backstage-v01.ts";
 
 const base = import.meta.env.BASE_URL;
@@ -140,6 +141,45 @@ const layerTone: Record<string, string> = {
         <h2 id="bs-ces" class="bs-explainer__title">{cesExplainer.title}</h2>
         <p class="bs-explainer__body">{cesExplainer.body}</p>
       </article>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-change">
+      <h2 id="bs-change" class="bs__section-title">Når vi må endre noe</h2>
+      <p class="bs__section-lead">Slik går vi frem når vi senere må justere verdier, koblinger eller tilgang.</p>
+
+      <ul class="bs-runbook">
+        {changeRunbooks.map((book) => (
+          <li class="bs-runbook__card">
+            <h3 class="bs-runbook__title">{book.title}</h3>
+            <dl class="bs-runbook__dl">
+              <div>
+                <dt>Hva endres?</dt>
+                <dd>{book.whatChanges}</dd>
+              </div>
+              <div>
+                <dt>Hvor endres det?</dt>
+                <dd>{book.where}</dd>
+              </div>
+              <div>
+                <dt>Hva må vi gjøre etterpå?</dt>
+                <dd>{book.after}</dd>
+              </div>
+              <div>
+                <dt>Hva må vi teste?</dt>
+                <dd>{book.test}</dd>
+              </div>
+            </dl>
+            {book.envVars?.length ? (
+              <p class="bs-runbook__env">
+                Variabler (uten verdier): {book.envVars.map((v) => (
+                  <code>{v}</code>
+                ))}
+              </p>
+            ) : null}
+            {book.tech ? <p class="bs-runbook__tech">{book.tech}</p> : null}
+          </li>
+        ))}
+      </ul>
     </section>
 
     <section class="bs__section" aria-labelledby="bs-troubleshoot">
@@ -640,6 +680,72 @@ const layerTone: Record<string, string> = {
       font-size: 0.88rem;
       line-height: 1.6;
       color: rgb(75 85 99);
+    }
+
+    .bs-runbook {
+      margin: 1.25rem 0 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 1rem;
+    }
+
+    .bs-runbook__card {
+      padding: 1.15rem 1.25rem;
+      border: 1px solid rgb(243 244 246);
+      border-radius: 0.5rem;
+      background: rgb(255 255 255);
+      box-shadow: 0 1px 3px rgb(0 0 0 / 0.04);
+    }
+
+    .bs-runbook__title {
+      margin: 0;
+      font-size: 0.98rem;
+      font-weight: 650;
+      color: rgb(31 41 55);
+    }
+
+    .bs-runbook__dl {
+      margin: 0.75rem 0 0;
+      display: grid;
+      gap: 0.65rem;
+    }
+
+    .bs-runbook__dl dt {
+      font-size: 0.65rem;
+      font-weight: 700;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .bs-runbook__dl dd {
+      margin: 0.15rem 0 0;
+      font-size: 0.86rem;
+      line-height: 1.5;
+      color: rgb(55 65 81);
+    }
+
+    .bs-runbook__env {
+      margin: 0.65rem 0 0;
+      font-size: 0.72rem;
+      line-height: 1.5;
+      color: rgb(107 114 128);
+    }
+
+    .bs-runbook__env code {
+      display: inline-block;
+      margin: 0.15rem 0.35rem 0 0;
+      font-family: ui-monospace, monospace;
+      font-size: 0.68rem;
+      color: rgb(75 85 99);
+    }
+
+    .bs-runbook__tech {
+      margin: 0.45rem 0 0;
+      font-size: 0.68rem;
+      line-height: 1.45;
+      color: rgb(156 163 175);
     }
 
     .bs-fix {


### PR DESCRIPTION
## Summary
- Ny route `/backstage/` — noindex intern referanse for AI-flow, guards, env-vars, feilstater og production checklist
- VIS hub Backstage aktivert (primær hub + Gå videre-lenke)
- `mvp-current-state.ts` og OPERATING_RULES oppdatert

## Test plan
- [ ] `/backstage/` — alle seksjoner, noindex
- [ ] `/vis/` — Backstage-lenke fungerer
- [ ] Ingen endring på `/no/*`, `/designsystem/`, `/api/chat`
- [ ] `npm run build` grønn

Closes #184

Made with [Cursor](https://cursor.com)