### PR TITLE
feat(vis): Runtime Feed v0.1 — kompakt agent-status på /vis/

### DIFF
--- a/.cursor/rules/viddel-operating-rules.mdc
+++ b/.cursor/rules/viddel-operating-rules.mdc
@@ -24,6 +24,24 @@ Update `src/data/mvp-current-state.ts` when work affects:
 
 VIS frontpage (`src/pages/vis/index.astro`) reads from this registry — do not hand-code «MVP nå» cards.
 
+## VIS Runtime Feed (after important Return Tickets)
+
+After a significant Return Ticket, update `src/data/vis-runtime-feed.ts` **or** state explicitly in the Return Ticket why VIS runtime is unaffected.
+
+Run `npm run verify:vis-runtime-feed` before merge (included in `npm run build`).
+
+### Communication standard (required)
+
+Write for **Thomas and Vibeke** — a short control-room summary, not internal technical status.
+
+- `headline` must explain the work **without prior context** (full human sentence).
+- Technical status is secondary — not the main message.
+- When Hybrid, PostHog, Upstash, CES appear in the main message, explain them in plain language.
+
+Good: «Vi vurderer hvordan Viddel skal måle bruk av AI-chatten før vi deler den med flere.»
+
+Avoid as headline/main text: «Solution assessment ferdig — Thomas vurderer Hybrid v0.1.»
+
 ## Backstage impact (always consider)
 
 Vurder `/backstage/` ved endringer i:
@@ -47,7 +65,7 @@ Run `npm run verify:backstage-guard` before merge (included in `npm run build`).
 - Designsystem impact
 - Current-state / VIS frontpage impact
 - **Backstage impact** (`Oppdatert` / `Ikke relevant` / `Må følges opp`)
-- **VIS runtime update** (ja/nei + statuslinje, eller «Ikke nødvendig»)
+- **VIS runtime update** (ja/nei + menneskelig språk per format i `06_RETURN_TICKET.md`, eller «Ikke nødvendig»)
 - Applied surfaces impacted
 - Follow-up needed
 

--- a/.cursor/rules/viddel-operating-rules.mdc
+++ b/.cursor/rules/viddel-operating-rules.mdc
@@ -10,6 +10,7 @@ alwaysApply: true
 - `/designsystem/` = gjeldende designsystem-sannhet
 - `/backstage/` = gjeldende systemreferanse (AI-flow, API, guards, env-vars, production)
 - `src/data/mvp-current-state.ts` = gjeldende operativ MVP-status
+- `src/data/vis-runtime-feed.ts` = kondensert agent-status på VIS-forsiden
 - `/vis/sprints/...` = historikk og beslutningsgrunnlag
 
 ## Before UI changes
@@ -46,6 +47,7 @@ Run `npm run verify:backstage-guard` before merge (included in `npm run build`).
 - Designsystem impact
 - Current-state / VIS frontpage impact
 - **Backstage impact** (`Oppdatert` / `Ikke relevant` / `Må følges opp`)
+- **VIS runtime update** (ja/nei + statuslinje, eller «Ikke nødvendig»)
 - Applied surfaces impacted
 - Follow-up needed
 

--- a/docs/project/06_RETURN_TICKET.md
+++ b/docs/project/06_RETURN_TICKET.md
@@ -33,6 +33,16 @@ Current-state / VIS frontpage impact
 Backstage impact
 - `Oppdatert: ...` / `Ikke relevant: ingen endring i systemflyt, API, guard, env-vars, monitoring eller production-status.` / `Må følges opp: ...`
 
+VIS runtime update
+- Oppdatert: ja / nei
+- Statuslinje:
+- Aktivt nå:
+- Sist ferdigstilt:
+- Neste beslutning:
+- Lenker:
+
+Hvis ikke relevant: `VIS runtime update: Ikke nødvendig — ingen endring i hva Cursor/rigger jobber med akkurat nå.`
+
 Applied surfaces impacted
 - 
 
@@ -41,6 +51,7 @@ Follow-up needed
 
 Hva må oppdateres
 - [ ] VIS (`src/data/mvp-current-state.ts` ved MVP-statusendring)
+- [ ] VIS Runtime Feed (`src/data/vis-runtime-feed.ts` ved viktig Return Ticket)
 - [ ] `/backstage/` (ved endring i systemflyt, API, guard, env-vars, monitoring eller production)
 - [ ] `/designsystem/` (ved mønsterendring)
 - [ ] roadmap

--- a/docs/project/06_RETURN_TICKET.md
+++ b/docs/project/06_RETURN_TICKET.md
@@ -35,12 +35,16 @@ Backstage impact
 
 VIS runtime update
 - Oppdatert: ja / nei
-- Headline (første setning uten kontekst):
-- Arbeid / område / hvorfor / status / mulig løsning / neste beslutning:
-- Fremdrift (progressSteps):
-- Sist ferdigstilt (kort linje):
-- Siste retur:
-- Lenker (primary + secondary):
+- Hva skjer nå? (én menneskelig setning)
+- Hvorfor gjør vi det?
+- Område
+- Status / fremdrift
+- Neste beslutning
+- Sist ferdigstilt
+- Siste retur
+- Lenker (primary + secondary)
+
+**Presisering:** Intern shorthand er ikke nok. Return Ticket skal gi nok språk til at VIS kan forstås dagen etter, også uten muntlig kontekst.
 
 Hvis ikke relevant: `VIS runtime update: Ikke nødvendig — ingen endring i hva Cursor/rigger jobber med akkurat nå.`
 

--- a/docs/project/06_RETURN_TICKET.md
+++ b/docs/project/06_RETURN_TICKET.md
@@ -35,11 +35,12 @@ Backstage impact
 
 VIS runtime update
 - Oppdatert: ja / nei
-- Statuslinje:
-- Aktivt nå:
-- Sist ferdigstilt:
-- Neste beslutning:
-- Lenker:
+- Headline (første setning uten kontekst):
+- Arbeid / område / hvorfor / status / mulig løsning / neste beslutning:
+- Fremdrift (progressSteps):
+- Sist ferdigstilt (kort linje):
+- Siste retur:
+- Lenker (primary + secondary):
 
 Hvis ikke relevant: `VIS runtime update: Ikke nødvendig — ingen endring i hva Cursor/rigger jobber med akkurat nå.`
 

--- a/docs/project/OPERATING_RULES.md
+++ b/docs/project/OPERATING_RULES.md
@@ -55,6 +55,28 @@ Ved endring i `src/lib/chat-api-guard.ts` (limits, max length): oppdater Backsta
 
 Validering: `npm run verify:backstage-guard` (kjøres automatisk før `npm run build`).
 
+## B4. VIS Runtime Feed — kommunikasjonsregel
+
+`src/data/vis-runtime-feed.ts` vises øverst på `/vis/` som kort kontrollrom-sammendrag.
+
+**Skriv for Thomas og Vibeke** — ikke som intern teknisk status.
+
+- Første setning (`headline`) skal forklare arbeidet **uten forkunnskap**.
+- Teknisk status kan stå sekundært (Arbeid, Status, lenker), men **ikke** være hovedbudskap.
+- Tekniske ord (Hybrid, PostHog, Upstash, CES) i hovedbudskap skal forklares med vanlige ord.
+
+**God retning:**
+
+> «Vi vurderer hvordan Viddel skal måle bruk av AI-chatten før vi deler den med flere.»
+
+**For intern — ikke bruk som headline/hovedtekst:**
+
+> «Solution assessment ferdig — Thomas vurderer Hybrid v0.1.»
+
+Etter viktig Return Ticket: oppdater feed **eller** forklar i Return Ticket hvorfor VIS runtime ikke påvirkes.
+
+Validering: `npm run verify:vis-runtime-feed` (kjøres automatisk før `npm run build`).
+
 ## C. VIS frontpage-regel
 
 - VIS-forsiden viser gjeldende MVP-status fra `getVisFrontpageEntries()` / `mvpCurrentState`.
@@ -68,8 +90,9 @@ Alle relevante Return Tickets skal inneholde:
 1. **Designsystem impact** — mønstre brukt / nye / `/designsystem/` oppdatert?
 2. **Current-state / VIS frontpage impact** — skal `mvp-current-state.ts` oppdateres?
 3. **Backstage impact** — skal `/backstage/` oppdateres? (Se under.)
-4. **Applied surfaces impacted** — hvilke routes?
-5. **Follow-up needed** — åpne risiko eller neste steg?
+4. **VIS runtime update** — skal `vis-runtime-feed.ts` oppdateres? (Se under.)
+5. **Applied surfaces impacted** — hvilke routes?
+6. **Follow-up needed** — åpne risiko eller neste steg?
 
 **Backstage impact** — forventet innhold:
 
@@ -85,18 +108,33 @@ Hvis current-state ikke endres:
 
 > Current-state update: Ikke nødvendig — ingen endring i MVP-status, designmønstre eller applied surfaces.
 
+**VIS runtime update** — forventet format:
+
+- Oppdatert: ja / nei
+- Hva skjer nå? (én menneskelig setning)
+- Hvorfor gjør vi det?
+- Område
+- Status / fremdrift
+- Neste beslutning
+- Sist ferdigstilt
+- Lenker
+
+Intern shorthand er **ikke nok**. Return Ticket skal gi nok språk til at VIS kan forstås dagen etter, også uten muntlig kontekst.
+
 ## E. Agent-sjekkliste (kort)
 
 1. Les issue/prompt og relevante docs.
 2. Les `/designsystem/` ved UI-arbeid.
 3. Les `src/data/mvp-current-state.ts` ved status-/VIS-arbeid.
 4. Vurder Backstage (`/backstage/`) ved endringer i API, guard, env-vars eller production.
-5. Hold endringer små; `npm run build` før ferdig.
-6. Return Ticket på relevant issue.
+5. Vurder VIS Runtime Feed (`vis-runtime-feed.ts`) ved viktig Return Ticket — skriv for Thomas/Vibeke.
+6. Hold endringer små; `npm run build` før ferdig.
+7. Return Ticket på relevant issue.
 
 ## Filer
 
 - Registry: `src/data/mvp-current-state.ts`
+- VIS Runtime Feed: `src/data/vis-runtime-feed.ts`, `src/lib/vis-runtime-feed-guard.ts`
 - Backstage: `src/data/backstage-v01.ts`, `src/lib/backstage-guard.ts`
 - Agent entry: `AGENTS.md`
 - Cursor: `.cursor/rules/viddel-operating-rules.mdc`

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs && node --experimental-strip-types scripts/verify-backstage-guard.mjs && astro build",
+    "build": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs && node --experimental-strip-types scripts/verify-backstage-guard.mjs && node --experimental-strip-types scripts/verify-vis-runtime-feed.mjs && astro build",
     "verify:vis-sprint-guard": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs",
     "verify:backstage-guard": "node --experimental-strip-types scripts/verify-backstage-guard.mjs",
+    "verify:vis-runtime-feed": "node --experimental-strip-types scripts/verify-vis-runtime-feed.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "storyblok:bootstrap:slice01": "node scripts/storyblok-bootstrap-slice-01.mjs",

--- a/scripts/verify-vis-runtime-feed.mjs
+++ b/scripts/verify-vis-runtime-feed.mjs
@@ -1,0 +1,14 @@
+/* CONTRACT: Build-time check — VIS Runtime Feed registry and /vis/ wiring. */
+import { validateVisRuntimeFeedGuard } from "../src/lib/vis-runtime-feed-guard.ts";
+
+const errors = validateVisRuntimeFeedGuard();
+
+if (errors.length > 0) {
+  console.error("VIS runtime feed guard failed:\n");
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log("VIS runtime feed guard OK");

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -1,12 +1,23 @@
 /* CONTRACT: VIS Runtime Feed v0.1 — kondensert agent-status for /vis/ (manuelt ved Return Ticket). */
 
+export type VisRuntimeActiveEntry = {
+  id: string;
+  title: string;
+  area: string;
+  status: string;
+  goal: string;
+  progress: string;
+  next: string;
+  issue?: string;
+  link?: string;
+};
+
 export type VisRuntimeFeedEntry = {
   id: string;
   title: string;
   status: string;
   issue?: string;
   link?: string;
-  next?: string;
 };
 
 export type VisRuntimeFeedLink = {
@@ -24,7 +35,8 @@ export type VisRuntimeFeedDecision = {
 export type VisRuntimeFeed = {
   updatedAt: string;
   statusLine: string;
-  activeNow: VisRuntimeFeedEntry[];
+  lastReturnTicketSummary: string;
+  activeNow: VisRuntimeActiveEntry[];
   recentlyCompleted: VisRuntimeFeedEntry[];
   nextDecision: VisRuntimeFeedDecision;
   links: VisRuntimeFeedLink[];
@@ -32,66 +44,60 @@ export type VisRuntimeFeed = {
 
 /** Manually updated after important Return Tickets — not synced from GitHub. */
 export const visRuntimeFeed = {
-  updatedAt: "2026-05-30",
-  statusLine: "Backstage og VIS er live. #188 assessment levert — venter godkjenning før monitoring-implementasjon.",
+  updatedAt: "2026-05-31",
+  statusLine: "Assessment levert for #188 — venter godkjenning før monitoring-implementasjon.",
+  lastReturnTicketSummary:
+    "VIS Runtime Feed v0.1 etablert — manuell agent-status på /vis/ før #188 implementasjon.",
   activeNow: [
     {
       id: "ai-usage-monitoring-v01",
       title: "#188 AI usage monitoring v0.1",
+      area: "Data / monitoring / innsikt",
       status: "Solution assessment ferdig — Thomas vurderer Hybrid v0.1",
+      goal: "Velge trygg monitoring-retning før ekstern deling",
+      progress: "Assessment ✓ → Godkjenning → Implementasjon",
+      next: "Godkjenne Hybrid v0.1 eller justere scope",
       issue: "#188",
       link: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
-      next: "Godkjenn retning og implementer smal hybrid monitoring",
     },
   ],
   recentlyCompleted: [
     {
       id: "backstage-v01",
       title: "Backstage v0.1 live",
-      status: "Merget og production-verifisert",
+      status: "Live",
       issue: "#184",
       link: "https://vox.raddum.no/backstage/",
     },
     {
       id: "vis-ia-frontpage-v01",
       title: "VIS IA / frontpage v0.1 live",
-      status: "Kontrollrom med huber og MVP-status fra registry",
+      status: "Live",
       issue: "#186",
       link: "https://vox.raddum.no/vis/",
     },
     {
       id: "chat-production-live",
       title: "Spør Viddel live i production",
-      status: "CES aktiv · Upstash guard · intern test",
+      status: "Live",
       link: "https://vox.raddum.no/no/chat/",
     },
   ],
   nextDecision: {
-    title: "Godkjenn Hybrid v0.1",
-    detail:
-      "Upstash/Vercel/CES for drift + PostHog EU for få trygge produkt-events — ingen innholdslogging i v0.1.",
+    title: "Hybrid v0.1",
+    detail: "Upstash/Vercel/CES for drift + PostHog EU for få trygge produkt-events",
     link: "https://github.com/THUNDERPLUNDER/vox-web/issues/188#issuecomment-4585993994",
   },
   links: [
     {
-      label: "Issue #188 — AI usage monitoring",
+      label: "#188",
       href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
       kind: "issue",
     },
     {
-      label: "Assessment-kommentar #188",
+      label: "Assessment",
       href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188#issuecomment-4585993994",
       kind: "issue",
-    },
-    {
-      label: "Backstage",
-      href: "https://vox.raddum.no/backstage/",
-      kind: "page",
-    },
-    {
-      label: "Spør Viddel",
-      href: "https://vox.raddum.no/no/chat/",
-      kind: "page",
     },
   ],
 } satisfies VisRuntimeFeed;

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -1,0 +1,101 @@
+/* CONTRACT: VIS Runtime Feed v0.1 — kondensert agent-status for /vis/ (manuelt ved Return Ticket). */
+
+export type VisRuntimeFeedEntry = {
+  id: string;
+  title: string;
+  status: string;
+  issue?: string;
+  link?: string;
+  next?: string;
+};
+
+export type VisRuntimeFeedLink = {
+  label: string;
+  href: string;
+  kind?: "issue" | "page" | "external";
+};
+
+export type VisRuntimeFeedDecision = {
+  title: string;
+  detail: string;
+  link?: string;
+};
+
+export type VisRuntimeFeed = {
+  updatedAt: string;
+  statusLine: string;
+  activeNow: VisRuntimeFeedEntry[];
+  recentlyCompleted: VisRuntimeFeedEntry[];
+  nextDecision: VisRuntimeFeedDecision;
+  links: VisRuntimeFeedLink[];
+};
+
+/** Manually updated after important Return Tickets — not synced from GitHub. */
+export const visRuntimeFeed = {
+  updatedAt: "2026-05-30",
+  statusLine: "Backstage og VIS er live. #188 assessment levert — venter godkjenning før monitoring-implementasjon.",
+  activeNow: [
+    {
+      id: "ai-usage-monitoring-v01",
+      title: "#188 AI usage monitoring v0.1",
+      status: "Solution assessment ferdig — Thomas vurderer Hybrid v0.1",
+      issue: "#188",
+      link: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
+      next: "Godkjenn retning og implementer smal hybrid monitoring",
+    },
+  ],
+  recentlyCompleted: [
+    {
+      id: "backstage-v01",
+      title: "Backstage v0.1 live",
+      status: "Merget og production-verifisert",
+      issue: "#184",
+      link: "https://vox.raddum.no/backstage/",
+    },
+    {
+      id: "vis-ia-frontpage-v01",
+      title: "VIS IA / frontpage v0.1 live",
+      status: "Kontrollrom med huber og MVP-status fra registry",
+      issue: "#186",
+      link: "https://vox.raddum.no/vis/",
+    },
+    {
+      id: "chat-production-live",
+      title: "Spør Viddel live i production",
+      status: "CES aktiv · Upstash guard · intern test",
+      link: "https://vox.raddum.no/no/chat/",
+    },
+  ],
+  nextDecision: {
+    title: "Godkjenn Hybrid v0.1",
+    detail:
+      "Upstash/Vercel/CES for drift + PostHog EU for få trygge produkt-events — ingen innholdslogging i v0.1.",
+    link: "https://github.com/THUNDERPLUNDER/vox-web/issues/188#issuecomment-4585993994",
+  },
+  links: [
+    {
+      label: "Issue #188 — AI usage monitoring",
+      href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
+      kind: "issue",
+    },
+    {
+      label: "Assessment-kommentar #188",
+      href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188#issuecomment-4585993994",
+      kind: "issue",
+    },
+    {
+      label: "Backstage",
+      href: "https://vox.raddum.no/backstage/",
+      kind: "page",
+    },
+    {
+      label: "Spør Viddel",
+      href: "https://vox.raddum.no/no/chat/",
+      kind: "page",
+    },
+  ],
+} satisfies VisRuntimeFeed;
+
+export function getVisRuntimeFeed(): VisRuntimeFeed {
+  return visRuntimeFeed;
+}

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -1,4 +1,5 @@
-/* CONTRACT: VIS Runtime Feed v0.1 — kondensert agent-status for /vis/ (manuelt ved Return Ticket). */
+/* CONTRACT: VIS Runtime Feed v0.1 — kondensert agent-status for /vis/ (manuelt ved Return Ticket).
+   Kommunikasjonsregel: skriv for Thomas/Vibeke — headline uten forkunnskap. Se OPERATING_RULES § B4. */
 
 export type VisRuntimeProgressStep = {
   id: string;

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -1,23 +1,24 @@
 /* CONTRACT: VIS Runtime Feed v0.1 — kondensert agent-status for /vis/ (manuelt ved Return Ticket). */
 
-export type VisRuntimeActiveEntry = {
+export type VisRuntimeProgressStep = {
   id: string;
-  title: string;
-  area: string;
-  status: string;
-  goal: string;
-  progress: string;
-  next: string;
-  issue?: string;
-  link?: string;
+  label: string;
+  state: "done" | "current" | "upcoming";
 };
 
-export type VisRuntimeFeedEntry = {
+export type VisRuntimeActiveWork = {
   id: string;
-  title: string;
+  /** Første setning — forklarer arbeidet uten kontekst. */
+  headline: string;
+  workTitle: string;
+  area: string;
+  why: string;
   status: string;
+  possibleSolution: string;
+  nextDecision: string;
   issue?: string;
-  link?: string;
+  issueLink?: string;
+  progressSteps: VisRuntimeProgressStep[];
 };
 
 export type VisRuntimeFeedLink = {
@@ -26,80 +27,62 @@ export type VisRuntimeFeedLink = {
   kind?: "issue" | "page" | "external";
 };
 
-export type VisRuntimeFeedDecision = {
-  title: string;
-  detail: string;
-  link?: string;
-};
-
 export type VisRuntimeFeed = {
   updatedAt: string;
-  statusLine: string;
+  activeNow: VisRuntimeActiveWork[];
+  recentlyCompletedSummary: string;
   lastReturnTicketSummary: string;
-  activeNow: VisRuntimeActiveEntry[];
-  recentlyCompleted: VisRuntimeFeedEntry[];
-  nextDecision: VisRuntimeFeedDecision;
-  links: VisRuntimeFeedLink[];
+  links: {
+    primary: VisRuntimeFeedLink[];
+    secondary?: VisRuntimeFeedLink[];
+  };
 };
 
 /** Manually updated after important Return Tickets — not synced from GitHub. */
 export const visRuntimeFeed = {
   updatedAt: "2026-05-31",
-  statusLine: "Assessment levert for #188 — venter godkjenning før monitoring-implementasjon.",
-  lastReturnTicketSummary:
-    "VIS Runtime Feed v0.1 etablert — manuell agent-status på /vis/ før #188 implementasjon.",
   activeNow: [
     {
       id: "ai-usage-monitoring-v01",
-      title: "#188 AI usage monitoring v0.1",
-      area: "Data / monitoring / innsikt",
-      status: "Solution assessment ferdig — Thomas vurderer Hybrid v0.1",
-      goal: "Velge trygg monitoring-retning før ekstern deling",
-      progress: "Assessment ✓ → Godkjenning → Implementasjon",
-      next: "Godkjenne Hybrid v0.1 eller justere scope",
+      headline:
+        "Vi vurderer hvordan Viddel skal måle bruk av AI-chatten før vi deler den med flere.",
+      workTitle: "#188 AI usage monitoring v0.1",
+      area: "Data, monitoring og innsikt",
+      why:
+        "Vi trenger å se om chatten virker, om den feiler, og hvilke innganger som faktisk blir brukt — uten å lagre spørsmål eller svar.",
+      status: "Vurdering ferdig. Neste steg er å velge løsning.",
+      possibleSolution:
+        "Smal hybrid: teknisk drift i Vercel, Upstash og CES + få trygge produkt-events i PostHog EU.",
+      nextDecision:
+        "Skal vi godkjenne hybrid-retningen, eller starte enklere med bare driftstellerne?",
       issue: "#188",
-      link: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
+      issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
+      progressSteps: [
+        { id: "assessment", label: "Vurdering ferdig", state: "done" },
+        { id: "decision", label: "Beslutning", state: "current" },
+        { id: "implementation", label: "Implementasjon", state: "upcoming" },
+      ],
     },
   ],
-  recentlyCompleted: [
-    {
-      id: "backstage-v01",
-      title: "Backstage v0.1 live",
-      status: "Live",
-      issue: "#184",
-      link: "https://vox.raddum.no/backstage/",
-    },
-    {
-      id: "vis-ia-frontpage-v01",
-      title: "VIS IA / frontpage v0.1 live",
-      status: "Live",
-      issue: "#186",
-      link: "https://vox.raddum.no/vis/",
-    },
-    {
-      id: "chat-production-live",
-      title: "Spør Viddel live i production",
-      status: "Live",
-      link: "https://vox.raddum.no/no/chat/",
-    },
-  ],
-  nextDecision: {
-    title: "Hybrid v0.1",
-    detail: "Upstash/Vercel/CES for drift + PostHog EU for få trygge produkt-events",
-    link: "https://github.com/THUNDERPLUNDER/vox-web/issues/188#issuecomment-4585993994",
+  recentlyCompletedSummary:
+    "Backstage v0.1, VIS frontpage v0.1 og Spør Viddel live i production.",
+  lastReturnTicketSummary: "#188 assessment er levert. Ingen kode endret ennå.",
+  links: {
+    primary: [
+      {
+        label: "Issue #188",
+        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
+        kind: "issue",
+      },
+    ],
+    secondary: [
+      {
+        label: "Assessment-kommentar",
+        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188#issuecomment-4585993994",
+        kind: "issue",
+      },
+    ],
   },
-  links: [
-    {
-      label: "#188",
-      href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
-      kind: "issue",
-    },
-    {
-      label: "Assessment",
-      href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188#issuecomment-4585993994",
-      kind: "issue",
-    },
-  ],
 } satisfies VisRuntimeFeed;
 
 export function getVisRuntimeFeed(): VisRuntimeFeed {

--- a/src/lib/vis-runtime-feed-guard.ts
+++ b/src/lib/vis-runtime-feed-guard.ts
@@ -3,9 +3,31 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { getVisRuntimeFeed, type VisRuntimeFeedEntry } from "../data/vis-runtime-feed.ts";
+import {
+  getVisRuntimeFeed,
+  type VisRuntimeActiveEntry,
+  type VisRuntimeFeedEntry,
+} from "../data/vis-runtime-feed.ts";
 
 const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function activeEntryErrors(entries: VisRuntimeActiveEntry[], section: string): string[] {
+  const errors: string[] = [];
+  if (entries.length === 0) {
+    errors.push(`${section} must have at least one entry`);
+    return errors;
+  }
+  for (const entry of entries) {
+    if (!entry.id?.trim()) errors.push(`${section} entry missing id`);
+    if (!entry.title?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing title`);
+    if (!entry.area?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing area`);
+    if (!entry.status?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing status`);
+    if (!entry.goal?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing goal`);
+    if (!entry.progress?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing progress`);
+    if (!entry.next?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing next`);
+  }
+  return errors;
+}
 
 function entryErrors(entries: VisRuntimeFeedEntry[], section: string): string[] {
   const errors: string[] = [];
@@ -59,7 +81,11 @@ export function validateVisRuntimeFeedGuard(): string[] {
     errors.push("visRuntimeFeed.statusLine is required");
   }
 
-  errors.push(...entryErrors(feed.activeNow, "activeNow"));
+  if (!feed.lastReturnTicketSummary?.trim()) {
+    errors.push("visRuntimeFeed.lastReturnTicketSummary is required");
+  }
+
+  errors.push(...activeEntryErrors(feed.activeNow, "activeNow"));
   errors.push(...entryErrors(feed.recentlyCompleted, "recentlyCompleted"));
 
   if (!feed.nextDecision?.title?.trim()) {

--- a/src/lib/vis-runtime-feed-guard.ts
+++ b/src/lib/vis-runtime-feed-guard.ts
@@ -7,6 +7,49 @@ import { getVisRuntimeFeed, type VisRuntimeActiveWork } from "../data/vis-runtim
 
 const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
+/** Patterns that indicate internal shorthand — not valid as human headline. */
+const INTERNAL_HEADLINE_PATTERNS = [
+  /solution assessment/i,
+  /thomas vurderer/i,
+  /^hybrid v0/i,
+  /— thomas/i,
+] as const;
+
+const MIN_HEADLINE_LENGTH = 40;
+const MIN_WHY_LENGTH = 30;
+const MIN_NEXT_DECISION_LENGTH = 15;
+
+function humanLanguageErrors(entry: VisRuntimeActiveWork): string[] {
+  const errors: string[] = [];
+  const key = entry.id || "?";
+  const headline = entry.headline.trim();
+
+  if (headline.length < MIN_HEADLINE_LENGTH) {
+    errors.push(
+      `activeNow "${key}" headline too short (${headline.length} chars) — use a full human sentence`,
+    );
+  }
+
+  for (const pattern of INTERNAL_HEADLINE_PATTERNS) {
+    if (pattern.test(headline)) {
+      errors.push(
+        `activeNow "${key}" headline looks like internal shorthand — write for Thomas/Vibeke`,
+      );
+      break;
+    }
+  }
+
+  if (entry.why.trim().length < MIN_WHY_LENGTH) {
+    errors.push(`activeNow "${key}" why too short — explain why in plain language`);
+  }
+
+  if (entry.nextDecision.trim().length < MIN_NEXT_DECISION_LENGTH) {
+    errors.push(`activeNow "${key}" nextDecision too short — state the decision clearly`);
+  }
+
+  return errors;
+}
+
 function activeWorkErrors(entries: VisRuntimeActiveWork[], section: string): string[] {
   const errors: string[] = [];
   if (entries.length === 0) {
@@ -26,6 +69,7 @@ function activeWorkErrors(entries: VisRuntimeActiveWork[], section: string): str
     if (!Array.isArray(entry.progressSteps) || entry.progressSteps.length === 0) {
       errors.push(`${section} entry "${key}" missing progressSteps`);
     }
+    errors.push(...humanLanguageErrors(entry));
   }
   return errors;
 }

--- a/src/lib/vis-runtime-feed-guard.ts
+++ b/src/lib/vis-runtime-feed-guard.ts
@@ -1,0 +1,86 @@
+/* CONTRACT: VIS Runtime Feed guard — build-time checks that feed registry is complete and wired to /vis/. */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getVisRuntimeFeed, type VisRuntimeFeedEntry } from "../data/vis-runtime-feed.ts";
+
+const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function entryErrors(entries: VisRuntimeFeedEntry[], section: string): string[] {
+  const errors: string[] = [];
+  if (entries.length === 0) {
+    errors.push(`${section} must have at least one entry`);
+    return errors;
+  }
+  for (const entry of entries) {
+    if (!entry.id?.trim()) {
+      errors.push(`${section} entry missing id`);
+    }
+    if (!entry.title?.trim()) {
+      errors.push(`${section} entry "${entry.id || "?"}" missing title`);
+    }
+    if (!entry.status?.trim()) {
+      errors.push(`${section} entry "${entry.id || "?"}" missing status`);
+    }
+  }
+  return errors;
+}
+
+/** Fail build if VIS runtime feed registry is incomplete or /vis/ does not import it. */
+export function validateVisRuntimeFeedGuard(): string[] {
+  const errors: string[] = [];
+
+  const feedData = join(srcRoot, "data/vis-runtime-feed.ts");
+  const visIndex = join(srcRoot, "pages/vis/index.astro");
+
+  if (!existsSync(feedData)) {
+    errors.push("Missing VIS runtime feed data: src/data/vis-runtime-feed.ts");
+    return errors;
+  }
+
+  if (!existsSync(visIndex)) {
+    errors.push("Missing VIS frontpage: src/pages/vis/index.astro");
+    return errors;
+  }
+
+  const visSource = readFileSync(visIndex, "utf8");
+  if (!visSource.includes("vis-runtime-feed")) {
+    errors.push("/vis/ must import vis-runtime-feed (src/data/vis-runtime-feed.ts)");
+  }
+
+  const feed = getVisRuntimeFeed();
+
+  if (!feed.updatedAt?.trim()) {
+    errors.push("visRuntimeFeed.updatedAt is required");
+  }
+
+  if (!feed.statusLine?.trim()) {
+    errors.push("visRuntimeFeed.statusLine is required");
+  }
+
+  errors.push(...entryErrors(feed.activeNow, "activeNow"));
+  errors.push(...entryErrors(feed.recentlyCompleted, "recentlyCompleted"));
+
+  if (!feed.nextDecision?.title?.trim()) {
+    errors.push("nextDecision.title is required");
+  }
+  if (!feed.nextDecision?.detail?.trim()) {
+    errors.push("nextDecision.detail is required");
+  }
+
+  if (!Array.isArray(feed.links) || feed.links.length === 0) {
+    errors.push("links must have at least one entry");
+  } else {
+    for (const link of feed.links) {
+      if (!link.label?.trim()) {
+        errors.push("links entry missing label");
+      }
+      if (!link.href?.trim()) {
+        errors.push(`links entry "${link.label || "?"}" missing href`);
+      }
+    }
+  }
+
+  return errors;
+}

--- a/src/lib/vis-runtime-feed-guard.ts
+++ b/src/lib/vis-runtime-feed-guard.ts
@@ -3,47 +3,28 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  getVisRuntimeFeed,
-  type VisRuntimeActiveEntry,
-  type VisRuntimeFeedEntry,
-} from "../data/vis-runtime-feed.ts";
+import { getVisRuntimeFeed, type VisRuntimeActiveWork } from "../data/vis-runtime-feed.ts";
 
 const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-function activeEntryErrors(entries: VisRuntimeActiveEntry[], section: string): string[] {
+function activeWorkErrors(entries: VisRuntimeActiveWork[], section: string): string[] {
   const errors: string[] = [];
   if (entries.length === 0) {
     errors.push(`${section} must have at least one entry`);
     return errors;
   }
   for (const entry of entries) {
+    const key = entry.id || "?";
     if (!entry.id?.trim()) errors.push(`${section} entry missing id`);
-    if (!entry.title?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing title`);
-    if (!entry.area?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing area`);
-    if (!entry.status?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing status`);
-    if (!entry.goal?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing goal`);
-    if (!entry.progress?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing progress`);
-    if (!entry.next?.trim()) errors.push(`${section} entry "${entry.id || "?"}" missing next`);
-  }
-  return errors;
-}
-
-function entryErrors(entries: VisRuntimeFeedEntry[], section: string): string[] {
-  const errors: string[] = [];
-  if (entries.length === 0) {
-    errors.push(`${section} must have at least one entry`);
-    return errors;
-  }
-  for (const entry of entries) {
-    if (!entry.id?.trim()) {
-      errors.push(`${section} entry missing id`);
-    }
-    if (!entry.title?.trim()) {
-      errors.push(`${section} entry "${entry.id || "?"}" missing title`);
-    }
-    if (!entry.status?.trim()) {
-      errors.push(`${section} entry "${entry.id || "?"}" missing status`);
+    if (!entry.headline?.trim()) errors.push(`${section} entry "${key}" missing headline`);
+    if (!entry.workTitle?.trim()) errors.push(`${section} entry "${key}" missing workTitle`);
+    if (!entry.area?.trim()) errors.push(`${section} entry "${key}" missing area`);
+    if (!entry.why?.trim()) errors.push(`${section} entry "${key}" missing why`);
+    if (!entry.status?.trim()) errors.push(`${section} entry "${key}" missing status`);
+    if (!entry.possibleSolution?.trim()) errors.push(`${section} entry "${key}" missing possibleSolution`);
+    if (!entry.nextDecision?.trim()) errors.push(`${section} entry "${key}" missing nextDecision`);
+    if (!Array.isArray(entry.progressSteps) || entry.progressSteps.length === 0) {
+      errors.push(`${section} entry "${key}" missing progressSteps`);
     }
   }
   return errors;
@@ -77,34 +58,29 @@ export function validateVisRuntimeFeedGuard(): string[] {
     errors.push("visRuntimeFeed.updatedAt is required");
   }
 
-  if (!feed.statusLine?.trim()) {
-    errors.push("visRuntimeFeed.statusLine is required");
+  if (!feed.recentlyCompletedSummary?.trim()) {
+    errors.push("visRuntimeFeed.recentlyCompletedSummary is required");
   }
 
   if (!feed.lastReturnTicketSummary?.trim()) {
     errors.push("visRuntimeFeed.lastReturnTicketSummary is required");
   }
 
-  errors.push(...activeEntryErrors(feed.activeNow, "activeNow"));
-  errors.push(...entryErrors(feed.recentlyCompleted, "recentlyCompleted"));
+  errors.push(...activeWorkErrors(feed.activeNow, "activeNow"));
 
-  if (!feed.nextDecision?.title?.trim()) {
-    errors.push("nextDecision.title is required");
-  }
-  if (!feed.nextDecision?.detail?.trim()) {
-    errors.push("nextDecision.detail is required");
-  }
-
-  if (!Array.isArray(feed.links) || feed.links.length === 0) {
-    errors.push("links must have at least one entry");
+  if (!Array.isArray(feed.links?.primary) || feed.links.primary.length === 0) {
+    errors.push("links.primary must have at least one entry");
   } else {
-    for (const link of feed.links) {
-      if (!link.label?.trim()) {
-        errors.push("links entry missing label");
-      }
-      if (!link.href?.trim()) {
-        errors.push(`links entry "${link.label || "?"}" missing href`);
-      }
+    for (const link of feed.links.primary) {
+      if (!link.label?.trim()) errors.push("links.primary entry missing label");
+      if (!link.href?.trim()) errors.push(`links.primary entry "${link.label || "?"}" missing href`);
+    }
+  }
+
+  if (feed.links.secondary) {
+    for (const link of feed.links.secondary) {
+      if (!link.label?.trim()) errors.push("links.secondary entry missing label");
+      if (!link.href?.trim()) errors.push(`links.secondary entry "${link.label || "?"}" missing href`);
     }
   }
 

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -10,6 +10,9 @@ import {
   visPrimaryNextWorkIds,
   visSourceOfTruthNotes,
 } from "../../data/vis-frontpage-hubs-v01.ts";
+import { getVisRuntimeFeed } from "../../data/vis-runtime-feed.ts";
+
+const runtimeFeed = getVisRuntimeFeed();
 
 const base = import.meta.env.BASE_URL;
 const mvpNowEntries = getVisFrontpageEntries(base);
@@ -43,6 +46,82 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
       <h1>{visFrontpageMandate.title}</h1>
       <p class="vis-room__lead">{visFrontpageMandate.lead}</p>
     </header>
+
+    <section class="vis-room__runtime" aria-label="Runtime feed">
+      <p class="vis-room__runtime-kicker">Runtime feed</p>
+      <p class="vis-room__runtime-status">{runtimeFeed.statusLine}</p>
+      <p class="vis-room__runtime-updated">Feed oppdatert {runtimeFeed.updatedAt}</p>
+
+      <div class="vis-room__runtime-grid">
+        <article class="vis-room__runtime-panel" aria-labelledby="vis-runtime-active">
+          <h2 id="vis-runtime-active" class="vis-room__runtime-label">Akkurat nå</h2>
+          <ul class="vis-room__runtime-list">
+            {runtimeFeed.activeNow.map((item) => (
+              <li class="vis-room__runtime-item">
+                {item.link ? (
+                  <a href={item.link} class="vis-room__runtime-link">
+                    <span class="vis-room__runtime-title">{item.title}</span>
+                  </a>
+                ) : (
+                  <span class="vis-room__runtime-title">{item.title}</span>
+                )}
+                <span class="vis-room__runtime-statusline">{item.status}</span>
+                {item.next ? <span class="vis-room__runtime-next">Neste: {item.next}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article class="vis-room__runtime-panel" aria-labelledby="vis-runtime-done">
+          <h2 id="vis-runtime-done" class="vis-room__runtime-label">Sist ferdigstilt</h2>
+          <ul class="vis-room__runtime-list">
+            {runtimeFeed.recentlyCompleted.map((item) => (
+              <li class="vis-room__runtime-item">
+                {item.link ? (
+                  <a href={item.link} class="vis-room__runtime-link">
+                    <span class="vis-room__runtime-title">{item.title}</span>
+                  </a>
+                ) : (
+                  <span class="vis-room__runtime-title">{item.title}</span>
+                )}
+                <span class="vis-room__runtime-statusline">{item.status}</span>
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article class="vis-room__runtime-panel" aria-labelledby="vis-runtime-decision">
+          <h2 id="vis-runtime-decision" class="vis-room__runtime-label">Neste beslutning</h2>
+          <div class="vis-room__runtime-item">
+            {runtimeFeed.nextDecision.link ? (
+              <a href={runtimeFeed.nextDecision.link} class="vis-room__runtime-link">
+                <span class="vis-room__runtime-title">{runtimeFeed.nextDecision.title}</span>
+              </a>
+            ) : (
+              <span class="vis-room__runtime-title">{runtimeFeed.nextDecision.title}</span>
+            )}
+            <span class="vis-room__runtime-statusline">{runtimeFeed.nextDecision.detail}</span>
+          </div>
+        </article>
+      </div>
+
+      {
+        runtimeFeed.links.length > 0 ? (
+          <nav class="vis-room__runtime-links" aria-label="Runtime-lenker">
+            <p class="vis-room__runtime-label">Lenker</p>
+            <ul class="vis-room__runtime-linklist">
+              {runtimeFeed.links.map((link) => (
+                <li>
+                  <a href={link.href} rel={link.kind === "external" || link.href.startsWith("http") ? "noopener noreferrer" : undefined}>
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ) : null
+      }
+    </section>
 
     <section class="vis-room__hero" aria-label="Kontrollrom-status">
       <div class="vis-room__hero-grid">
@@ -265,6 +344,126 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
       font-size: 0.92rem;
       line-height: 1.55;
       color: rgb(75 85 99);
+    }
+
+    .vis-room__runtime {
+      margin-top: 1.75rem;
+      padding: 1.15rem 1.1rem 1.05rem;
+      border: 1px solid rgb(229 231 235);
+      border-radius: 0.65rem;
+      background: rgb(249 250 251);
+    }
+
+    .vis-room__runtime-kicker {
+      margin: 0;
+      font-size: 0.65rem;
+      font-weight: 650;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-status {
+      margin: 0.45rem 0 0;
+      max-width: 42rem;
+      font-size: 0.88rem;
+      line-height: 1.5;
+      color: rgb(31 41 55);
+      font-weight: 550;
+    }
+
+    .vis-room__runtime-updated {
+      margin: 0.35rem 0 0;
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__runtime-grid {
+      display: grid;
+      gap: 1.15rem;
+      margin-top: 1rem;
+    }
+
+    .vis-room__runtime-label {
+      margin: 0 0 0.5rem;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .vis-room__runtime-item + .vis-room__runtime-item {
+      margin-top: 0.65rem;
+      padding-top: 0.65rem;
+      border-top: 1px solid rgb(229 231 235);
+    }
+
+    .vis-room__runtime-link {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .vis-room__runtime-link:hover .vis-room__runtime-title {
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .vis-room__runtime-title {
+      display: block;
+      font-size: 0.9rem;
+      font-weight: 650;
+      letter-spacing: -0.01em;
+      color: rgb(31 41 55);
+    }
+
+    .vis-room__runtime-statusline {
+      display: block;
+      margin-top: 0.2rem;
+      font-size: 0.8rem;
+      line-height: 1.45;
+      color: rgb(75 85 99);
+    }
+
+    .vis-room__runtime-next {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.75rem;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-links {
+      margin-top: 1rem;
+      padding-top: 0.85rem;
+      border-top: 1px solid rgb(229 231 235);
+    }
+
+    .vis-room__runtime-linklist {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem 1rem;
+    }
+
+    .vis-room__runtime-linklist a {
+      font-size: 0.8rem;
+      font-weight: 550;
+      color: rgb(55 65 81);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      text-decoration-color: rgb(209 213 219);
+    }
+
+    .vis-room__runtime-linklist a:hover {
+      text-decoration-color: rgb(107 114 128);
     }
 
     .vis-room__hero {
@@ -711,6 +910,12 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
     @media (min-width: 768px) {
       .vis-room {
         padding: 2.5rem 1.5rem 3.5rem;
+      }
+
+      .vis-room__runtime-grid {
+        grid-template-columns: 1.1fr 1fr 0.95fr;
+        gap: 1.25rem;
+        align-items: start;
       }
 
       .vis-room__hero-grid {

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -37,6 +37,8 @@ const archiveEntries = wireframeIndexEntries();
 const archiveGrouped = groupedVisEntries(archiveEntries);
 
 const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
+const activeWork = runtimeFeed.activeNow[0];
+const completedTitles = runtimeFeed.recentlyCompleted.map((item) => item.title).join(" · ");
 ---
 
 <PrototypeLayout title="VIS kontrollrom">
@@ -47,81 +49,80 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
       <p class="vis-room__lead">{visFrontpageMandate.lead}</p>
     </header>
 
-    <section class="vis-room__runtime" aria-label="Runtime feed">
-      <p class="vis-room__runtime-kicker">Runtime feed</p>
-      <p class="vis-room__runtime-status">{runtimeFeed.statusLine}</p>
-      <p class="vis-room__runtime-updated">Feed oppdatert {runtimeFeed.updatedAt}</p>
+    {
+      activeWork ? (
+        <aside class="vis-room__runtime" aria-label="Runtime feed">
+          <div class="vis-room__runtime-head">
+            <span class="vis-room__runtime-kicker">Runtime</span>
+            <span class="vis-room__runtime-updated">{runtimeFeed.updatedAt}</span>
+          </div>
 
-      <div class="vis-room__runtime-grid">
-        <article class="vis-room__runtime-panel" aria-labelledby="vis-runtime-active">
-          <h2 id="vis-runtime-active" class="vis-room__runtime-label">Akkurat nå</h2>
-          <ul class="vis-room__runtime-list">
-            {runtimeFeed.activeNow.map((item) => (
-              <li class="vis-room__runtime-item">
-                {item.link ? (
-                  <a href={item.link} class="vis-room__runtime-link">
-                    <span class="vis-room__runtime-title">{item.title}</span>
-                  </a>
-                ) : (
-                  <span class="vis-room__runtime-title">{item.title}</span>
-                )}
-                <span class="vis-room__runtime-statusline">{item.status}</span>
-                {item.next ? <span class="vis-room__runtime-next">Neste: {item.next}</span> : null}
-              </li>
-            ))}
-          </ul>
-        </article>
+          <p class="vis-room__runtime-line">
+            <span class="vis-room__runtime-key">Akkurat nå</span>
+            {activeWork.link ? (
+              <a href={activeWork.link} class="vis-room__runtime-em">{activeWork.title}</a>
+            ) : (
+              <span class="vis-room__runtime-em">{activeWork.title}</span>
+            )}
+            <span class="vis-room__runtime-dot" aria-hidden="true">·</span>
+            <span class="vis-room__runtime-area">{activeWork.area}</span>
+          </p>
 
-        <article class="vis-room__runtime-panel" aria-labelledby="vis-runtime-done">
-          <h2 id="vis-runtime-done" class="vis-room__runtime-label">Sist ferdigstilt</h2>
-          <ul class="vis-room__runtime-list">
-            {runtimeFeed.recentlyCompleted.map((item) => (
-              <li class="vis-room__runtime-item">
-                {item.link ? (
-                  <a href={item.link} class="vis-room__runtime-link">
-                    <span class="vis-room__runtime-title">{item.title}</span>
-                  </a>
-                ) : (
-                  <span class="vis-room__runtime-title">{item.title}</span>
-                )}
-                <span class="vis-room__runtime-statusline">{item.status}</span>
-              </li>
-            ))}
-          </ul>
-        </article>
+          <p class="vis-room__runtime-line vis-room__runtime-line--sub">{activeWork.status}</p>
 
-        <article class="vis-room__runtime-panel" aria-labelledby="vis-runtime-decision">
-          <h2 id="vis-runtime-decision" class="vis-room__runtime-label">Neste beslutning</h2>
-          <div class="vis-room__runtime-item">
+          <p class="vis-room__runtime-line vis-room__runtime-line--sub">
+            <span class="vis-room__runtime-key-inline">Mål</span> {activeWork.goal}
+            <span class="vis-room__runtime-dot" aria-hidden="true">·</span>
+            <span class="vis-room__runtime-key-inline">Fremdrift</span> {activeWork.progress}
+          </p>
+
+          <p class="vis-room__runtime-line vis-room__runtime-line--sub">
+            <span class="vis-room__runtime-key-inline">Neste</span> {activeWork.next}
+          </p>
+
+          <p class="vis-room__runtime-line">
+            <span class="vis-room__runtime-key">Sist ferdigstilt</span>
+            <span>{completedTitles}</span>
+          </p>
+
+          <p class="vis-room__runtime-line">
+            <span class="vis-room__runtime-key">Beslutning</span>
             {runtimeFeed.nextDecision.link ? (
-              <a href={runtimeFeed.nextDecision.link} class="vis-room__runtime-link">
-                <span class="vis-room__runtime-title">{runtimeFeed.nextDecision.title}</span>
+              <a href={runtimeFeed.nextDecision.link} class="vis-room__runtime-link-inline">
+                {runtimeFeed.nextDecision.title}
               </a>
             ) : (
-              <span class="vis-room__runtime-title">{runtimeFeed.nextDecision.title}</span>
+              <span>{runtimeFeed.nextDecision.title}</span>
             )}
-            <span class="vis-room__runtime-statusline">{runtimeFeed.nextDecision.detail}</span>
-          </div>
-        </article>
-      </div>
+            <span class="vis-room__runtime-dot" aria-hidden="true">—</span>
+            <span>{runtimeFeed.nextDecision.detail}</span>
+          </p>
 
-      {
-        runtimeFeed.links.length > 0 ? (
-          <nav class="vis-room__runtime-links" aria-label="Runtime-lenker">
-            <p class="vis-room__runtime-label">Lenker</p>
-            <ul class="vis-room__runtime-linklist">
-              {runtimeFeed.links.map((link) => (
-                <li>
-                  <a href={link.href} rel={link.kind === "external" || link.href.startsWith("http") ? "noopener noreferrer" : undefined}>
-                    {link.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </nav>
-        ) : null
-      }
-    </section>
+          <p class="vis-room__runtime-line vis-room__runtime-line--muted">
+            <span class="vis-room__runtime-key">Siste RT</span>
+            <span>{runtimeFeed.lastReturnTicketSummary}</span>
+          </p>
+
+          {
+            runtimeFeed.links.length > 0 ? (
+              <p class="vis-room__runtime-links">
+                {runtimeFeed.links.map((link, index) => (
+                  <span>
+                    {index > 0 ? <span class="vis-room__runtime-dot" aria-hidden="true"> · </span> : null}
+                    <a
+                      href={link.href}
+                      rel={link.kind === "external" || link.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                    >
+                      {link.label}
+                    </a>
+                  </span>
+                ))}
+              </p>
+            ) : null
+          }
+        </aside>
+      ) : null
+    }
 
     <section class="vis-room__hero" aria-label="Kontrollrom-status">
       <div class="vis-room__hero-grid">
@@ -347,127 +348,110 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
     }
 
     .vis-room__runtime {
-      margin-top: 1.75rem;
-      padding: 1.15rem 1.1rem 1.05rem;
-      border: 1px solid rgb(229 231 235);
-      border-radius: 0.65rem;
-      background: rgb(249 250 251);
+      margin-top: 1.35rem;
+      padding-bottom: 1.1rem;
+      border-bottom: 1px solid rgb(243 244 246);
+      max-width: 44rem;
+    }
+
+    .vis-room__runtime-head {
+      display: flex;
+      align-items: baseline;
+      gap: 0.5rem;
+      margin-bottom: 0.45rem;
     }
 
     .vis-room__runtime-kicker {
       margin: 0;
-      font-size: 0.65rem;
+      font-size: 0.62rem;
       font-weight: 650;
       letter-spacing: 0.12em;
       text-transform: uppercase;
-      color: rgb(107 114 128);
-    }
-
-    .vis-room__runtime-status {
-      margin: 0.45rem 0 0;
-      max-width: 42rem;
-      font-size: 0.88rem;
-      line-height: 1.5;
-      color: rgb(31 41 55);
-      font-weight: 550;
-    }
-
-    .vis-room__runtime-updated {
-      margin: 0.35rem 0 0;
-      font-size: 0.72rem;
       color: rgb(156 163 175);
     }
 
-    .vis-room__runtime-grid {
-      display: grid;
-      gap: 1.15rem;
-      margin-top: 1rem;
+    .vis-room__runtime-updated {
+      font-size: 0.68rem;
+      color: rgb(156 163 175);
     }
 
-    .vis-room__runtime-label {
-      margin: 0 0 0.5rem;
-      font-size: 0.68rem;
-      font-weight: 650;
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
+    .vis-room__runtime-line {
+      margin: 0;
+      font-size: 0.78rem;
+      line-height: 1.45;
+      color: rgb(55 65 81);
+    }
+
+    .vis-room__runtime-line + .vis-room__runtime-line {
+      margin-top: 0.22rem;
+    }
+
+    .vis-room__runtime-line--sub {
       color: rgb(107 114 128);
     }
 
-    .vis-room__runtime-list {
-      margin: 0;
-      padding: 0;
-      list-style: none;
+    .vis-room__runtime-line--muted {
+      color: rgb(156 163 175);
+      font-size: 0.72rem;
     }
 
-    .vis-room__runtime-item + .vis-room__runtime-item {
-      margin-top: 0.65rem;
-      padding-top: 0.65rem;
-      border-top: 1px solid rgb(229 231 235);
-    }
-
-    .vis-room__runtime-link {
-      color: inherit;
-      text-decoration: none;
-    }
-
-    .vis-room__runtime-link:hover .vis-room__runtime-title {
-      text-decoration: underline;
-      text-underline-offset: 2px;
-    }
-
-    .vis-room__runtime-title {
-      display: block;
-      font-size: 0.9rem;
+    .vis-room__runtime-key {
       font-weight: 650;
-      letter-spacing: -0.01em;
+      color: rgb(107 114 128);
+      margin-right: 0.35rem;
+    }
+
+    .vis-room__runtime-key-inline {
+      font-weight: 600;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__runtime-em {
+      font-weight: 650;
       color: rgb(31 41 55);
     }
 
-    .vis-room__runtime-statusline {
-      display: block;
-      margin-top: 0.2rem;
-      font-size: 0.8rem;
-      line-height: 1.45;
-      color: rgb(75 85 99);
-    }
-
-    .vis-room__runtime-next {
-      display: block;
-      margin-top: 0.25rem;
-      font-size: 0.75rem;
-      color: rgb(107 114 128);
-    }
-
-    .vis-room__runtime-links {
-      margin-top: 1rem;
-      padding-top: 0.85rem;
-      border-top: 1px solid rgb(229 231 235);
-    }
-
-    .vis-room__runtime-linklist {
-      margin: 0;
-      padding: 0;
-      list-style: none;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.35rem 1rem;
-    }
-
-    .vis-room__runtime-linklist a {
-      font-size: 0.8rem;
-      font-weight: 550;
-      color: rgb(55 65 81);
+    a.vis-room__runtime-em,
+    .vis-room__runtime-link-inline {
+      color: rgb(31 41 55);
       text-decoration: underline;
       text-underline-offset: 2px;
       text-decoration-color: rgb(209 213 219);
     }
 
-    .vis-room__runtime-linklist a:hover {
+    a.vis-room__runtime-em:hover,
+    .vis-room__runtime-link-inline:hover {
+      text-decoration-color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-area {
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-dot {
+      margin: 0 0.3rem;
+      color: rgb(209 213 219);
+    }
+
+    .vis-room__runtime-links {
+      margin: 0.45rem 0 0;
+      font-size: 0.72rem;
+    }
+
+    .vis-room__runtime-links a {
+      font-weight: 550;
+      color: rgb(75 85 99);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      text-decoration-color: rgb(209 213 219);
+    }
+
+    .vis-room__runtime-links a:hover {
       text-decoration-color: rgb(107 114 128);
     }
 
     .vis-room__hero {
-      margin-top: 2rem;
+      margin-top: 1.75rem;
     }
 
     .vis-room__hero-grid {
@@ -910,12 +894,6 @@ const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
     @media (min-width: 768px) {
       .vis-room {
         padding: 2.5rem 1.5rem 3.5rem;
-      }
-
-      .vis-room__runtime-grid {
-        grid-template-columns: 1.1fr 1fr 0.95fr;
-        gap: 1.25rem;
-        align-items: start;
       }
 
       .vis-room__hero-grid {

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -38,7 +38,8 @@ const archiveGrouped = groupedVisEntries(archiveEntries);
 
 const quickHubLinks = primaryHubs.filter((h) => h.href).slice(0, 3);
 const activeWork = runtimeFeed.activeNow[0];
-const completedTitles = runtimeFeed.recentlyCompleted.map((item) => item.title).join(" · ");
+const primaryLinks = runtimeFeed.links.primary;
+const secondaryLinks = runtimeFeed.links.secondary ?? [];
 ---
 
 <PrototypeLayout title="VIS kontrollrom">
@@ -51,73 +52,95 @@ const completedTitles = runtimeFeed.recentlyCompleted.map((item) => item.title).
 
     {
       activeWork ? (
-        <aside class="vis-room__runtime" aria-label="Runtime feed">
+        <aside class="vis-room__runtime" aria-label="Akkurat nå">
           <div class="vis-room__runtime-head">
-            <span class="vis-room__runtime-kicker">Runtime</span>
+            <h2 class="vis-room__runtime-title">Akkurat nå</h2>
             <span class="vis-room__runtime-updated">{runtimeFeed.updatedAt}</span>
           </div>
 
-          <p class="vis-room__runtime-line">
-            <span class="vis-room__runtime-key">Akkurat nå</span>
-            {activeWork.link ? (
-              <a href={activeWork.link} class="vis-room__runtime-em">{activeWork.title}</a>
-            ) : (
-              <span class="vis-room__runtime-em">{activeWork.title}</span>
-            )}
-            <span class="vis-room__runtime-dot" aria-hidden="true">·</span>
-            <span class="vis-room__runtime-area">{activeWork.area}</span>
+          <p class="vis-room__runtime-headline">{activeWork.headline}</p>
+
+          <ol class="vis-room__runtime-progress" aria-label="Fremdrift">
+            {activeWork.progressSteps.map((step, index) => (
+              <li
+                class:list={[
+                  "vis-room__runtime-step",
+                  step.state === "done" && "vis-room__runtime-step--done",
+                  step.state === "current" && "vis-room__runtime-step--current",
+                  step.state === "upcoming" && "vis-room__runtime-step--upcoming",
+                ]}
+              >
+                {index > 0 ? <span class="vis-room__runtime-step-arrow" aria-hidden="true">→</span> : null}
+                <span class="vis-room__runtime-step-label">{step.label}</span>
+              </li>
+            ))}
+          </ol>
+
+          <dl class="vis-room__runtime-meta">
+            <div class="vis-room__runtime-row">
+              <dt>Arbeid</dt>
+              <dd>
+                {activeWork.issueLink ? (
+                  <a href={activeWork.issueLink}>{activeWork.workTitle}</a>
+                ) : (
+                  activeWork.workTitle
+                )}
+              </dd>
+            </div>
+            <div class="vis-room__runtime-row">
+              <dt>Område</dt>
+              <dd>{activeWork.area}</dd>
+            </div>
+            <div class="vis-room__runtime-row">
+              <dt>Hvorfor</dt>
+              <dd>{activeWork.why}</dd>
+            </div>
+            <div class="vis-room__runtime-row">
+              <dt>Status</dt>
+              <dd>{activeWork.status}</dd>
+            </div>
+            <div class="vis-room__runtime-row">
+              <dt>Mulig løsning</dt>
+              <dd>{activeWork.possibleSolution}</dd>
+            </div>
+            <div class="vis-room__runtime-row vis-room__runtime-row--decision">
+              <dt>Neste beslutning</dt>
+              <dd>{activeWork.nextDecision}</dd>
+            </div>
+          </dl>
+
+          <p class="vis-room__runtime-foot">
+            <span class="vis-room__runtime-foot-label">Sist ferdigstilt</span>
+            {runtimeFeed.recentlyCompletedSummary}
           </p>
 
-          <p class="vis-room__runtime-line vis-room__runtime-line--sub">{activeWork.status}</p>
-
-          <p class="vis-room__runtime-line vis-room__runtime-line--sub">
-            <span class="vis-room__runtime-key-inline">Mål</span> {activeWork.goal}
-            <span class="vis-room__runtime-dot" aria-hidden="true">·</span>
-            <span class="vis-room__runtime-key-inline">Fremdrift</span> {activeWork.progress}
-          </p>
-
-          <p class="vis-room__runtime-line vis-room__runtime-line--sub">
-            <span class="vis-room__runtime-key-inline">Neste</span> {activeWork.next}
-          </p>
-
-          <p class="vis-room__runtime-line">
-            <span class="vis-room__runtime-key">Sist ferdigstilt</span>
-            <span>{completedTitles}</span>
-          </p>
-
-          <p class="vis-room__runtime-line">
-            <span class="vis-room__runtime-key">Beslutning</span>
-            {runtimeFeed.nextDecision.link ? (
-              <a href={runtimeFeed.nextDecision.link} class="vis-room__runtime-link-inline">
-                {runtimeFeed.nextDecision.title}
-              </a>
-            ) : (
-              <span>{runtimeFeed.nextDecision.title}</span>
-            )}
-            <span class="vis-room__runtime-dot" aria-hidden="true">—</span>
-            <span>{runtimeFeed.nextDecision.detail}</span>
-          </p>
-
-          <p class="vis-room__runtime-line vis-room__runtime-line--muted">
-            <span class="vis-room__runtime-key">Siste RT</span>
-            <span>{runtimeFeed.lastReturnTicketSummary}</span>
+          <p class="vis-room__runtime-foot vis-room__runtime-foot--muted">
+            <span class="vis-room__runtime-foot-label">Siste retur</span>
+            {runtimeFeed.lastReturnTicketSummary}
           </p>
 
           {
-            runtimeFeed.links.length > 0 ? (
-              <p class="vis-room__runtime-links">
-                {runtimeFeed.links.map((link, index) => (
-                  <span>
-                    {index > 0 ? <span class="vis-room__runtime-dot" aria-hidden="true"> · </span> : null}
-                    <a
-                      href={link.href}
-                      rel={link.kind === "external" || link.href.startsWith("http") ? "noopener noreferrer" : undefined}
-                    >
-                      {link.label}
-                    </a>
-                  </span>
+            primaryLinks.length > 0 || secondaryLinks.length > 0 ? (
+              <nav class="vis-room__runtime-nav" aria-label="Runtime-lenker">
+                {primaryLinks.map((link) => (
+                  <a
+                    href={link.href}
+                    class="vis-room__runtime-nav-link vis-room__runtime-nav-link--primary"
+                    rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                  >
+                    {link.label}
+                  </a>
                 ))}
-              </p>
+                {secondaryLinks.map((link) => (
+                  <a
+                    href={link.href}
+                    class="vis-room__runtime-nav-link vis-room__runtime-nav-link--secondary"
+                    rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                  >
+                    {link.label}
+                  </a>
+                ))}
+              </nav>
             ) : null
           }
         </aside>
@@ -349,7 +372,7 @@ const completedTitles = runtimeFeed.recentlyCompleted.map((item) => item.title).
 
     .vis-room__runtime {
       margin-top: 1.35rem;
-      padding-bottom: 1.1rem;
+      padding-bottom: 1.15rem;
       border-bottom: 1px solid rgb(243 244 246);
       max-width: 44rem;
     }
@@ -357,97 +380,178 @@ const completedTitles = runtimeFeed.recentlyCompleted.map((item) => item.title).
     .vis-room__runtime-head {
       display: flex;
       align-items: baseline;
-      gap: 0.5rem;
-      margin-bottom: 0.45rem;
+      justify-content: space-between;
+      gap: 0.75rem;
+      margin-bottom: 0.55rem;
     }
 
-    .vis-room__runtime-kicker {
+    .vis-room__runtime-title {
       margin: 0;
-      font-size: 0.62rem;
+      font-size: 0.68rem;
       font-weight: 650;
       letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-updated {
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__runtime-headline {
+      margin: 0;
+      max-width: 40rem;
+      font-size: 0.94rem;
+      line-height: 1.5;
+      font-weight: 550;
+      color: rgb(31 41 55);
+    }
+
+    .vis-room__runtime-progress {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.35rem 0.15rem;
+      margin: 0.75rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .vis-room__runtime-step {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.15rem;
+    }
+
+    .vis-room__runtime-step-label {
+      display: inline-block;
+      padding: 0.18rem 0.55rem;
+      border-radius: 999px;
+      font-size: 0.72rem;
+      font-weight: 550;
+      line-height: 1.3;
+      border: 1px solid rgb(229 231 235);
+      color: rgb(107 114 128);
+      background: rgb(255 255 255);
+    }
+
+    .vis-room__runtime-step--done .vis-room__runtime-step-label {
+      border-color: rgb(209 250 229);
+      color: rgb(6 95 70);
+      background: rgb(236 253 245);
+    }
+
+    .vis-room__runtime-step--current .vis-room__runtime-step-label {
+      border-color: rgb(191 219 254);
+      color: rgb(30 64 175);
+      background: rgb(239 246 255);
+    }
+
+    .vis-room__runtime-step-arrow {
+      margin: 0 0.15rem;
+      font-size: 0.68rem;
+      color: rgb(209 213 219);
+    }
+
+    .vis-room__runtime-meta {
+      margin: 0.85rem 0 0;
+      display: grid;
+      gap: 0.55rem;
+    }
+
+    .vis-room__runtime-row {
+      display: grid;
+      grid-template-columns: 7.5rem 1fr;
+      gap: 0.65rem;
+      align-items: start;
+    }
+
+    .vis-room__runtime-row dt {
+      margin: 0;
+      font-size: 0.72rem;
+      font-weight: 650;
+      color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-row dd {
+      margin: 0;
+      font-size: 0.82rem;
+      line-height: 1.48;
+      color: rgb(55 65 81);
+    }
+
+    .vis-room__runtime-row dd a {
+      color: rgb(31 41 55);
+      font-weight: 550;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      text-decoration-color: rgb(209 213 219);
+    }
+
+    .vis-room__runtime-row dd a:hover {
+      text-decoration-color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-row--decision dd {
+      font-weight: 550;
+      color: rgb(31 41 55);
+    }
+
+    .vis-room__runtime-foot {
+      margin: 0.75rem 0 0;
+      font-size: 0.8rem;
+      line-height: 1.45;
+      color: rgb(75 85 99);
+    }
+
+    .vis-room__runtime-foot--muted {
+      margin-top: 0.35rem;
+      font-size: 0.76rem;
+      color: rgb(156 163 175);
+    }
+
+    .vis-room__runtime-foot-label {
+      display: block;
+      margin-bottom: 0.12rem;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.06em;
       text-transform: uppercase;
       color: rgb(156 163 175);
     }
 
-    .vis-room__runtime-updated {
-      font-size: 0.68rem;
-      color: rgb(156 163 175);
+    .vis-room__runtime-nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 0.85rem;
+      margin-top: 0.75rem;
     }
 
-    .vis-room__runtime-line {
-      margin: 0;
-      font-size: 0.78rem;
-      line-height: 1.45;
-      color: rgb(55 65 81);
+    .vis-room__runtime-nav-link {
+      font-size: 0.8rem;
+      text-decoration: underline;
+      text-underline-offset: 2px;
     }
 
-    .vis-room__runtime-line + .vis-room__runtime-line {
-      margin-top: 0.22rem;
-    }
-
-    .vis-room__runtime-line--sub {
-      color: rgb(107 114 128);
-    }
-
-    .vis-room__runtime-line--muted {
-      color: rgb(156 163 175);
-      font-size: 0.72rem;
-    }
-
-    .vis-room__runtime-key {
-      font-weight: 650;
-      color: rgb(107 114 128);
-      margin-right: 0.35rem;
-    }
-
-    .vis-room__runtime-key-inline {
+    .vis-room__runtime-nav-link--primary {
       font-weight: 600;
+      color: rgb(31 41 55);
+      text-decoration-color: rgb(209 213 219);
+    }
+
+    .vis-room__runtime-nav-link--primary:hover {
+      text-decoration-color: rgb(107 114 128);
+    }
+
+    .vis-room__runtime-nav-link--secondary {
+      font-weight: 500;
       color: rgb(156 163 175);
+      text-decoration-color: rgb(229 231 235);
     }
 
-    .vis-room__runtime-em {
-      font-weight: 650;
-      color: rgb(31 41 55);
-    }
-
-    a.vis-room__runtime-em,
-    .vis-room__runtime-link-inline {
-      color: rgb(31 41 55);
-      text-decoration: underline;
-      text-underline-offset: 2px;
-      text-decoration-color: rgb(209 213 219);
-    }
-
-    a.vis-room__runtime-em:hover,
-    .vis-room__runtime-link-inline:hover {
-      text-decoration-color: rgb(107 114 128);
-    }
-
-    .vis-room__runtime-area {
+    .vis-room__runtime-nav-link--secondary:hover {
       color: rgb(107 114 128);
-    }
-
-    .vis-room__runtime-dot {
-      margin: 0 0.3rem;
-      color: rgb(209 213 219);
-    }
-
-    .vis-room__runtime-links {
-      margin: 0.45rem 0 0;
-      font-size: 0.72rem;
-    }
-
-    .vis-room__runtime-links a {
-      font-weight: 550;
-      color: rgb(75 85 99);
-      text-decoration: underline;
-      text-underline-offset: 2px;
-      text-decoration-color: rgb(209 213 219);
-    }
-
-    .vis-room__runtime-links a:hover {
-      text-decoration-color: rgb(107 114 128);
     }
 
     .vis-room__hero {
@@ -889,6 +993,13 @@ const completedTitles = runtimeFeed.recentlyCompleted.map((item) => item.title).
       font-size: 0.68rem;
       line-height: 1.5;
       color: rgb(156 163 175);
+    }
+
+    @media (max-width: 520px) {
+      .vis-room__runtime-row {
+        grid-template-columns: 1fr;
+        gap: 0.15rem;
+      }
     }
 
     @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- Data-drevet runtime-lag (`src/data/vis-runtime-feed.ts`) som kondenserer Return Tickets til kompakt status på `/vis/`
- Kompakt tekststripe under header (område, mål, fremdrift, beslutning, siste RT) — ikke stor kortflate
- Build-time guard + Return Ticket / Cursor-regel oppdateringer

## Test plan
- [ ] Preview `/vis/` — runtime stripe under tittel, over Nå-status hero
- [ ] #188 vises med område, mål, fremdrift og Hybrid v0.1 beslutning
- [ ] Eksisterende hero / MVP nå / huber uendret visuelt
- [ ] `/no/chat/`, `/backstage/`, `/designsystem/` uendret
- [ ] `npm run verify:vis-runtime-feed` og `npm run build` grønn

Relates to #188 (prep)

Made with [Cursor](https://cursor.com)