### PR TITLE
docs(vis): IA Inventory v0.1 — kartlegging før tremeny

### DIFF
--- a/src/components/vis/VisIaSurfaceCard.astro
+++ b/src/components/vis/VisIaSurfaceCard.astro
@@ -1,0 +1,337 @@
+---
+/* CONTRACT: Kort for én VIS-flate i IA inventory — skannbar Thomas/Vibeke-visning. */
+import {
+  visIaTopTaskLabels,
+  type VisIaEntry,
+  type VisIaStatus,
+} from "../../data/vis-ia-inventory-v01.ts";
+import type { VisIaConsolidationReadiness } from "../../data/vis-ia-consolidation-v03.ts";
+
+interface Props {
+  entry: VisIaEntry;
+  consolidation: VisIaConsolidationReadiness;
+  base: string;
+}
+
+const { entry, consolidation, base } = Astro.props;
+
+const statusLabels: Record<VisIaStatus, string> = {
+  active: "Aktiv",
+  canonical: "Canonical",
+  planned: "Planlagt",
+  reference: "Referanse",
+  lab: "Lab",
+  historical: "Historikk",
+  legacy: "Legacy",
+  unknown: "Ukjent",
+};
+
+const overlapLabels = {
+  ingen: "Ingen overlapp",
+  "route-navn": "Route/navn-overlapp",
+  "reelt behov": "Reelt behovsoverlapp",
+  "route og behov": "Route og behov",
+} as const;
+
+const futureClass: Record<string, string> = {
+  "behold som egen flate": "future-keep",
+  "behold som global flate og vis i VIS-tre": "future-global",
+  "slå sammen med annen flate": "future-merge",
+  "gjør om til seksjon under annen flate": "future-section",
+  "flytt til historikk / arkiv": "future-archive",
+  "vurder sletting senere": "future-delete",
+  "trenger Thomas-avklaring": "future-clarify",
+};
+
+const href =
+  entry.route.startsWith("/") && !entry.route.includes("(") && !entry.route.includes(" ")
+    ? `${base}${entry.route.replace(/^\//, "")}`
+    : null;
+---
+
+<article
+  class:list={["ia-surface", `ia-surface--${entry.status}`, consolidation.needsThomasReview && "ia-surface--review"]}
+  id={entry.id}
+>
+  <header class="ia-surface__head">
+    <div class="ia-surface__title-row">
+      <h3 class="ia-surface__title">
+        {href ? <a href={href}>{entry.title}</a> : entry.title}
+      </h3>
+      {consolidation.needsThomasReview ? (
+        <span class="ia-surface__flag">Trenger Thomas</span>
+      ) : null}
+    </div>
+    <div class="ia-surface__badges">
+      <span class={`ia-surface__status ia-surface__status--${entry.status}`}>
+        {statusLabels[entry.status]}
+      </span>
+      <span class={`ia-surface__future ${futureClass[consolidation.futurePlacement] ?? ""}`}>
+        {consolidation.futurePlacement}
+      </span>
+    </div>
+  </header>
+
+  <p class="ia-surface__mandate">{consolidation.mandatePlain}</p>
+
+  <div class="ia-surface__grid">
+    <div class="ia-surface__block">
+      <h4>Hva gjør vi her?</h4>
+      <p>{consolidation.whatToDoHere}</p>
+    </div>
+    <div class="ia-surface__block ia-surface__block--muted">
+      <h4>Hva gjør vi ikke her?</h4>
+      <p>{consolidation.whatNotToDoHere}</p>
+    </div>
+  </div>
+
+  <dl class="ia-surface__meta">
+    <div>
+      <dt>Top task</dt>
+      <dd>{visIaTopTaskLabels[entry.mandate.primaryTask]}</dd>
+    </div>
+    <div>
+      <dt>Hjelper oss med</dt>
+      <dd>{consolidation.practicalHelp}</dd>
+    </div>
+    <div>
+      <dt>Funksjon som må bevares</dt>
+      <dd>
+        {
+          consolidation.functionalValue.length ? (
+            <ul class="ia-surface__tags">
+              {consolidation.functionalValue.map((v) => (
+                <li>{v}</li>
+              ))}
+            </ul>
+          ) : (
+            "Ingen aktiv funksjon"
+          )
+        }
+      </dd>
+    </div>
+    <div>
+      <dt>Overlapp</dt>
+      <dd>
+        <span class="ia-surface__overlap">{overlapLabels[consolidation.overlapKind]}</span>
+        {consolidation.overlapNote}
+      </dd>
+    </div>
+    <div class="ia-surface__block--warn">
+      <dt>Risiko ved sammenslåing</dt>
+      <dd>{consolidation.mergeRisk}</dd>
+    </div>
+    {
+      consolidation.migrationNote ? (
+        <div>
+          <dt>Migration note</dt>
+          <dd>{consolidation.migrationNote}</dd>
+        </div>
+      ) : null
+    }
+  </dl>
+</article>
+
+<style>
+  .ia-surface {
+    padding: 1rem 1.1rem;
+    border: 1px solid rgb(229 231 235);
+    border-radius: 0.6rem;
+    background: rgb(255 255 255);
+  }
+
+  .ia-surface--review {
+    border-color: rgb(253 186 116);
+    box-shadow: 0 0 0 1px rgb(254 243 199);
+  }
+
+  .ia-surface--active {
+    border-left: 3px solid rgb(16 185 129);
+  }
+
+  .ia-surface--canonical {
+    border-left: 3px solid rgb(99 102 241);
+  }
+
+  .ia-surface--lab {
+    border-left: 3px solid rgb(59 130 246);
+  }
+
+  .ia-surface--reference {
+    border-left: 3px solid rgb(156 163 175);
+  }
+
+  .ia-surface--historical,
+  .ia-surface--legacy {
+    border-left: 3px solid rgb(209 213 219);
+    background: rgb(249 250 251);
+  }
+
+  .ia-surface__head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  .ia-surface__title-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .ia-surface__title {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+  }
+
+  .ia-surface__title a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: rgb(209 213 219);
+  }
+
+  .ia-surface__flag {
+    font-size: 0.65rem;
+    font-weight: 650;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgb(194 65 12);
+    background: rgb(255 247 237);
+    padding: 0.15rem 0.45rem;
+    border-radius: 999px;
+  }
+
+  .ia-surface__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .ia-surface__status,
+  .ia-surface__future {
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 0.12rem 0.45rem;
+    border-radius: 999px;
+    border: 1px solid rgb(229 231 235);
+  }
+
+  .ia-surface__future.future-merge,
+  .ia-surface__future.future-section {
+    border-color: rgb(191 219 254);
+    color: rgb(30 64 175);
+    background: rgb(239 246 255);
+  }
+
+  .ia-surface__future.future-archive {
+    border-color: rgb(254 243 199);
+    color: rgb(146 64 14);
+    background: rgb(255 251 235);
+  }
+
+  .ia-surface__future.future-delete {
+    border-color: rgb(254 202 202);
+    color: rgb(153 27 27);
+    background: rgb(254 242 242);
+  }
+
+  .ia-surface__future.future-clarify {
+    border-color: rgb(253 186 116);
+    color: rgb(194 65 12);
+    background: rgb(255 247 237);
+  }
+
+  .ia-surface__mandate {
+    margin: 0.65rem 0 0;
+    font-size: 0.88rem;
+    line-height: 1.5;
+    color: rgb(55 65 81);
+  }
+
+  .ia-surface__grid {
+    display: grid;
+    gap: 0.65rem;
+    margin-top: 0.75rem;
+  }
+
+  .ia-surface__block h4 {
+    margin: 0 0 0.2rem;
+    font-size: 0.68rem;
+    font-weight: 650;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgb(107 114 128);
+  }
+
+  .ia-surface__block p {
+    margin: 0;
+    font-size: 0.8rem;
+    line-height: 1.45;
+    color: rgb(75 85 99);
+  }
+
+  .ia-surface__block--muted h4 {
+    color: rgb(156 163 175);
+  }
+
+  .ia-surface__meta {
+    margin: 0.85rem 0 0;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgb(243 244 246);
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  .ia-surface__meta dt {
+    font-size: 0.62rem;
+    font-weight: 650;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgb(156 163 175);
+  }
+
+  .ia-surface__meta dd {
+    margin: 0.1rem 0 0;
+    font-size: 0.78rem;
+    line-height: 1.45;
+    color: rgb(75 85 99);
+  }
+
+  .ia-surface__block--warn dd {
+    color: rgb(146 64 14);
+  }
+
+  .ia-surface__tags {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+  }
+
+  .ia-surface__tags li {
+    font-size: 0.68rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    background: rgb(243 244 246);
+    color: rgb(75 85 99);
+  }
+
+  .ia-surface__overlap {
+    display: inline-block;
+    font-weight: 600;
+    margin-right: 0.35rem;
+    color: rgb(55 65 81);
+  }
+
+  @media (min-width: 768px) {
+    .ia-surface__grid {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+</style>

--- a/src/components/vis/VisIaTreeBranch.astro
+++ b/src/components/vis/VisIaTreeBranch.astro
@@ -1,0 +1,36 @@
+---
+/* CONTRACT: Rekursiv VIS IA tre-node for inventory-analyse. */
+import VisIaTreeBranch from "./VisIaTreeBranch.astro";
+import { visIaTopTaskLabels, type VisIaTreeNode } from "../../data/vis-ia-inventory-v01.ts";
+
+interface Props {
+  nodes: VisIaTreeNode[];
+  base: string;
+  depth?: number;
+}
+
+const { nodes, base, depth = 0 } = Astro.props;
+---
+
+<ul class:list={depth === 0 ? "ia-inv__tree" : undefined}>
+  {
+    nodes.map((node) => (
+      <li class:list={depth === 0 ? "ia-inv__tree-root" : undefined}>
+        <span class="ia-inv__tree-label">
+          {node.href ? (
+            <a href={`${base}${node.href.replace(/^\//, "")}`}>{node.label}</a>
+          ) : (
+            node.label
+          )}
+        </span>
+        {node.primaryTask ? (
+          <span class="ia-inv__tree-task">{visIaTopTaskLabels[node.primaryTask]}</span>
+        ) : null}
+        {node.note ? <span class="ia-inv__tree-note">{node.note}</span> : null}
+        {node.children ? (
+          <VisIaTreeBranch nodes={node.children} base={base} depth={depth + 1} />
+        ) : null}
+      </li>
+    ))
+  }
+</ul>

--- a/src/data/vis-ia-consolidation-v03.ts
+++ b/src/data/vis-ia-consolidation-v03.ts
@@ -63,10 +63,84 @@ export type VisIaMetadataStrategy = {
   headerRevival: string;
 };
 
+export type VisIaClosedDecision = {
+  id: string;
+  topic: string;
+  decision: string;
+  rationale: string;
+};
+
+/** Avklaringer lukket i Thomas QA — innarbeidet som anbefalinger, ikke åpne spørsmål. */
+export const visIaClosedDecisions: VisIaClosedDecision[] = [
+  {
+    id: "dam-label",
+    topic: "DAM / Editorial label",
+    decision:
+      "Ett område: hovedlabel «Redaksjonelle bilder», sekundær forklaring «DAM / bildebank». Route /vis/assets/editorial uendret.",
+    rationale: "Samme flate og innhold — kun navn var forvirrende. Hele Editorial Image Library UI bevares.",
+  },
+  {
+    id: "control-center-rename",
+    topic: "Control Center → Agentdrift / runbook",
+    decision:
+      "Ikke bruk «Control Center» (forveksles med VIS kontrollrom). Behold funksjonalitet under smalere navn «Agentdrift / runbook» under Forstå system. Ikke arkiver — egen agent-/runtime-verdi.",
+    rationale: "Dupliserer ikke Backstage fullt ut. Agent-runbook, filpeker og runtime-kontekst må bevares.",
+  },
+  {
+    id: "placeholders",
+    topic: "/vis/artikkel og /vis/hub",
+    decision:
+      "«Vurder sletting senere». Ikke primære trenoder. Nye previewflater bygges med page contract og konkret mandat.",
+    rationale: "Tomme placeholders uten funksjonell verdi i dag.",
+  },
+  {
+    id: "hub-registry",
+    topic: "Hub-registry / tremeny-data",
+    decision:
+      "Neste implementasjon (VIS Tree Navigation v0.1) konsoliderer hub-registry og tremeny til én felles datakilde eller tydelig delt kontrakt.",
+    rationale: "Unngå parallelle sannheter mellom VIS-frontpage, hub-kort og lokalmeny.",
+  },
+];
+
+/** Anbefalt neste steg etter merge av denne analysen — ikke implementert i denne PR. */
+export const visIaNextImplementation = {
+  id: "vis-tree-navigation-v01",
+  name: "VIS Tree Navigation v0.1",
+  summary:
+    "Tremeny, page contract og konsolidert hub/tre-data. Bygges som eget arbeid etter denne analysen er merget.",
+  includes: [
+    "Trebasert lokalmeny i VIS",
+    "Page contract på VIS-sider (VIS-header viser hensikt automatisk)",
+    "Én datakilde for hub-kort og tremeny",
+    "Label «Arbeidsflater» som navigasjonskategori",
+    "«Redaksjonelle bilder» som hovedlabel for assets",
+    "«Agentdrift / runbook» under Forstå system",
+  ],
+  pageContractFields: [
+    "title",
+    "type",
+    "status",
+    "purpose",
+    "primaryTask",
+    "audience",
+    "relatedArea",
+    "canonicalSource",
+    "lastReviewed",
+    "ownerRole",
+    "nextAction",
+  ] as const,
+  headerGoals: [
+    "Hva er denne siden?",
+    "Hva brukes den til?",
+    "Er den aktiv, canonical, lab, reference, historical eller legacy?",
+  ],
+} as const;
+
 export const visIaConsolidationMeta = {
-  version: "v0.3",
-  passName: "VIS IA Consolidation Readiness v0.3",
+  version: "v0.3.1",
+  passName: "VIS IA Consolidation Readiness v0.3.1",
   updatedAt: "2026-05-31",
+  treeNavCategoryLabel: "Arbeidsflater",
 } as const;
 
 /** Grundig vurdering av seks konfliktområder — Thomas/Vibeke-språk. */
@@ -126,12 +200,12 @@ export const visIaDeepDiveAreas: VisIaDeepDiveArea[] = [
       {
         question: "Skal Control Center fjernes som begrep?",
         answer:
-          "Begrepet «Control Center» forvirrer — det høres ut som forsiden. Behold siden som agent-runbook, men kall den noe tydeligere i tre (f.eks. «Agent-kontekst»). Den er ikke erstatning for Backstage.",
+          "Ja — bruk «Agentdrift / runbook» i stedet. Plassering under Forstå system, ikke egen toppkategori. Behold funksjonaliteten: siden dupliserer ikke Backstage, den har egen agent-/runtime-verdi.",
       },
     ],
     preserveWhenMerging: [
       "Backstage: hele pedagogiske systemreferansen",
-      "Control Center: filpeker og agent-instruksjoner",
+      "Agentdrift / runbook: filpeker og agent-instruksjoner",
       "IA-prinsipper og Hub Mandate: canonical dokumentasjon",
     ],
     doNotMix: ["Systemforklaring for mennesker", "Agent-runbook", "Flat link-liste"],
@@ -201,20 +275,22 @@ export const visIaDeepDiveAreas: VisIaDeepDiveArea[] = [
   {
     id: "area-e",
     letter: "E",
-    title: "DAM / Editorial Image Library",
-    summary: "Én flate, ett behov — navnet er det som er forvirrende, ikke funksjonen.",
+    title: "Redaksjonelle bilder (DAM / bildebank)",
+    summary:
+      "Avklart: ett område. Hovedlabel «Redaksjonelle bilder», sekundær «DAM / bildebank». Ikke to flater.",
     clarifications: [
       {
         question: "Ett område eller to?",
-        answer: "Ett. Hub-kort sier «DAM / bildebank», siden sier «Editorial Image Library». Samme rute, samme innhold.",
+        answer:
+          "Ett. Avklart label: hoved «Redaksjonelle bilder», sekundær «DAM / bildebank». Route /vis/assets/editorial uendret.",
       },
       {
         question: "Hva er mandatet?",
         answer: "Finne og velge redaksjonelle bilder til artikler og innhold. Støtte Vibeke og redaksjon.",
       },
       {
-        question: "Hva må bevares ved sammenslåing?",
-        answer: "Hele bildestrukturen, metadata, preview og eventuelle kategorier. Bare navnet i hub og meny endres.",
+        question: "Hva må bevares?",
+        answer: "Hele Editorial Image Library UI, bildestruktur, metadata og preview. Kun hub- og menylabel oppdateres ved tremeny.",
       },
     ],
     preserveWhenMerging: ["Editorial Image Library UI", "Asset-metadata", "Preview-funksjon"],
@@ -382,17 +458,19 @@ export const visIaConsolidationById: Record<string, VisIaConsolidationReadiness>
     needsThomasReview: false,
   }),
   "dam-editorial": c({
-    mandatePlain: "Finne og velge redaksjonelle bilder til artikler og innhold.",
+    mandatePlain:
+      "Redaksjonelle bilder — finne og velge bilder til artikler og innhold (sekundær: DAM / bildebank).",
     practicalHelp: "Vibeke og Thomas kan browse bilder uten å lete i mapper eller Storyblok blindt.",
     whatToDoHere: "Velg bilde til innhold. Noter valg til redaksjon/Storyblok.",
-    whatNotToDoHere: "Ikke splitt i to hub-navn (DAM vs Editorial) — det er samme flate.",
+    whatNotToDoHere: "Ikke behandle DAM og Editorial som to områder — avklart som én flate.",
     functionalValue: ["bilde-/assetstruktur", "nyttig preview", "lenker"],
     overlapKind: "route-navn",
-    overlapNote: "Kun navne-overlapp mellom hub-kort og sidetittel — ikke to løsninger.",
-    mergeRisk: "Endre bare label i hub og meny. Hele Editorial Image Library UI må bevares.",
-    futurePlacement: "slå sammen med annen flate",
-    migrationNote: "Én label: «Redaksjonelle bilder». Route /vis/assets/editorial uendret. Oppdater vis-frontpage-hubs-v01.ts.",
-    needsThomasReview: true,
+    overlapNote: "Var kun navne-overlapp — avklart: ett område, to label-nivåer.",
+    mergeRisk: "Kun label-endring i hub/meny. Hele Editorial Image Library UI må bevares urørt.",
+    futurePlacement: "behold som egen flate",
+    migrationNote:
+      "Hovedlabel «Redaksjonelle bilder», sekundær «DAM / bildebank». Route uendret. Hub-registry oppdateres i VIS Tree Navigation v0.1.",
+    needsThomasReview: false,
   }),
   review: c({
     mandatePlain: "QA-inngang: godkjenne design og sprint-labs før de blir canonical.",
@@ -493,17 +571,22 @@ export const visIaConsolidationById: Record<string, VisIaConsolidationReadiness>
     needsThomasReview: false,
   }),
   "control-center": c({
-    mandatePlain: "Agent-runbook: prosjektkontekst og filpeker for Cursor og agenter.",
-    practicalHelp: "Agenter finner riktig fil og kontekst raskere.",
-    whatToDoHere: "Start agent-oppgave her hvis du trenger filkart.",
-    whatNotToDoHere: "Ikke bruk som Thomas/Vibeke sin systemforklaring — det er Backstage.",
-    functionalValue: ["teknisk runbook", "lenker", "navigasjonshjelp"],
+    mandatePlain:
+      "Agentdrift / runbook — prosjektkontekst og filpeker for Cursor og agenter (ikke «Control Center»).",
+    practicalHelp: "Agenter finner riktig fil og runtime-kontekst raskere.",
+    whatToDoHere: "Start agent-oppgave her hvis du trenger filkart og driftsrunbook.",
+    whatNotToDoHere:
+      "Ikke kalle det Control Center — forveksles med VIS kontrollrom. Ikke erstatte Backstage.",
+    functionalValue: ["teknisk runbook", "lenker", "navigasjonshjelp", "runtime-status"],
     overlapKind: "reelt behov",
-    overlapNote: "Ligner Backstage — men Backstage er pedagogisk, Control Center er operativ agent-hjelp.",
-    mergeRisk: "Slå sammen med Backstage → mister agent-spesifikk filkart. Begrepet «Control Center» bør døpes om.",
+    overlapNote:
+      "Backstage er pedagogisk systemforklaring. Agentdrift / runbook er operativ agent-hjelp — ulikt mandat, begge bevares.",
+    mergeRisk:
+      "Slå sammen med Backstage → mister agent-spesifikk filkart. Arkivering avvist — egen runtime-verdi.",
     futurePlacement: "gjør om til seksjon under annen flate",
-    migrationNote: "Tremeny: «Agent-kontekst» under Forstå system. Vurder rename — ikke slett funksjon.",
-    needsThomasReview: true,
+    migrationNote:
+      "Tremeny under Forstå system: «Agentdrift / runbook». Route /vis/system/control-center uendret. Display-navn i tre og page contract.",
+    needsThomasReview: false,
   }),
   "ia-principles": c({
     mandatePlain: "Need-led IA-prinsipper — grunnmur for produktstruktur.",
@@ -656,30 +739,30 @@ export const visIaConsolidationById: Record<string, VisIaConsolidationReadiness>
     needsThomasReview: false,
   }),
   "vis-artikkel-placeholder": c({
-    mandatePlain: "Tom placeholder — ingen funksjon i dag.",
+    mandatePlain: "Tom placeholder — ingen funksjon i dag. Avklart: vurder sletting senere.",
     practicalHelp: "Ingen praktisk verdi.",
     whatToDoHere: "Ikke bruk. Gå til /no/artikkel/ eller sprint-labs.",
-    whatNotToDoHere: "Ikke lenke fra hub eller primær nav.",
+    whatNotToDoHere: "Ikke inkluder som primær trenode. Ikke lenke fra hub eller primær nav.",
     functionalValue: [],
     overlapKind: "route-navn",
-    overlapNote: "Route ligner production — men ingen reelt innhold.",
-    mergeRisk: "Sletting krever sjekk av inbound lenker.",
+    overlapNote: "Route ligner production — tom flate uten mandat.",
+    mergeRisk: "Sletting krever sjekk av inbound lenker. Ny preview bygges med page contract ved behov.",
     futurePlacement: "vurder sletting senere",
-    migrationNote: "Redirect til arkiv eller fjern lenker. QA inbound links.",
-    needsThomasReview: true,
+    migrationNote: "Ikke i tremeny. Ved sletting: QA inbound links. Eventuell ny flate krever konkret mandat.",
+    needsThomasReview: false,
   }),
   "vis-hub-placeholder": c({
-    mandatePlain: "Tom placeholder — ingen funksjon i dag.",
+    mandatePlain: "Tom placeholder — ingen funksjon i dag. Avklart: vurder sletting senere.",
     practicalHelp: "Ingen praktisk verdi.",
     whatToDoHere: "Ikke bruk. Gå til /no/hub/ eller sprint-labs.",
-    whatNotToDoHere: "Ikke lenke fra hub eller primær nav.",
+    whatNotToDoHere: "Ikke inkluder som primær trenode. Ikke lenke fra hub eller primær nav.",
     functionalValue: [],
     overlapKind: "route-navn",
-    overlapNote: "Route ligner production — tom flate.",
-    mergeRisk: "Sletting krever sjekk av inbound lenker.",
+    overlapNote: "Route ligner production — tom flate uten mandat.",
+    mergeRisk: "Sletting krever sjekk av inbound lenker. Ny preview bygges med page contract ved behov.",
     futurePlacement: "vurder sletting senere",
-    migrationNote: "Redirect til arkiv eller fjern lenker.",
-    needsThomasReview: true,
+    migrationNote: "Ikke i tremeny. Ved sletting: QA inbound links.",
+    needsThomasReview: false,
   }),
   "raw-wireframes": c({
     mandatePlain: "Samling eldre HTML-wireframes — historisk referanse.",
@@ -772,15 +855,16 @@ export const visIaConsolidationById: Record<string, VisIaConsolidationReadiness>
   "vis-frontpage-hubs": c({
     mandatePlain: "Definerer hub-kort på VIS-forsiden inntil tremeny finnes.",
     practicalHelp: "Styrer hvilke flater som vises som kort på /vis/.",
-    whatToDoHere: "Oppdater ved IA-endring. Konsolider med tremeny-data senere.",
-    whatNotToDoHere: "Ikke la hub-kort og tremeny divergere permanent.",
+    whatToDoHere: "Oppdater ved IA-endring inntil konsolidert datakilde finnes.",
+    whatNotToDoHere: "Ikke la hub-kort og tremeny divergere permanent — avklart løses i neste steg.",
     functionalValue: ["navigasjonshjelp", "lenker"],
     overlapKind: "route og behov",
-    overlapNote: "Samme behov som fremtidig tremeny — to kilder i dag.",
-    mergeRisk: "Slå sammen datakilder uten å miste hub-kort på forsiden under overgang.",
+    overlapNote: "Samme behov som fremtidig tremeny — parallelle kilder i dag.",
+    mergeRisk: "Konsolider uten å miste hub-kort på forsiden under overgang.",
     futurePlacement: "slå sammen med annen flate",
-    migrationNote: "vis-frontpage-hubs-v01.ts → vis-nav-tree.ts (forslag). Hub-kort filtreres fra tre.",
-    needsThomasReview: true,
+    migrationNote:
+      "VIS Tree Navigation v0.1: én felles datakilde (eller tydelig delt kontrakt) for hub-kort og tremeny. vis-frontpage-hubs-v01.ts merges inn.",
+    needsThomasReview: false,
   }),
 };
 
@@ -802,9 +886,10 @@ export function getVisIaConsolidationByFuture(
     .map(([id]) => id);
 }
 
-/** Tremodell v0.3 — etter mandat og konsolideringsvurdering. */
+/** Tremodell v0.3.1 — avklarte beslutninger innarbeidet. */
 export const visIaTreeProposalV03 = {
-  note: "Need-led tremodell etter Consolidation Readiness v0.3",
+  note: "Need-led tremodell v0.3.1 — «Arbeidsflater» som navigasjonskategori (top task 3 uendret)",
+  excludedFromTree: ["/vis/artikkel", "/vis/hub"],
   sections: [
     {
       id: "now",
@@ -816,13 +901,17 @@ export const visIaTreeProposalV03 = {
       ],
     },
     {
-      id: "find",
-      label: "Finn riktig flate",
+      id: "workspaces",
+      label: "Arbeidsflater",
       topTasks: ["finn-flate"] as VisIaTopTask[],
       items: [
         { label: "Designsystem", href: "/designsystem/", note: "Global canonical" },
         { label: "Review / QA", href: "/vis/review/", note: "Under Design i tre" },
-        { label: "Redaksjonelle bilder", href: "/vis/assets/editorial", note: "Ett navn — ikke DAM vs Editorial" },
+        {
+          label: "Redaksjonelle bilder",
+          href: "/vis/assets/editorial",
+          note: "Sekundær: DAM / bildebank — ett område",
+        },
         { label: "Gitbuss", href: "/vis/system/github-runtime-status", note: "Operativ GitHub" },
         { label: "Roadmap", href: "/vis/system/roadmap-timeline-v01", note: "Retning — ikke sprint" },
       ],
@@ -836,7 +925,11 @@ export const visIaTreeProposalV03 = {
         { label: "IA-prinsipper", href: "/vis/system/ia-principles-v01" },
         { label: "Hub Mandate", href: "/vis/system/hub-mandate-v01" },
         { label: "Artikkel-system", href: "/vis/system/article/" },
-        { label: "Agent-kontekst", href: "/vis/system/control-center", note: "Rename fra Control Center" },
+        {
+          label: "Agentdrift / runbook",
+          href: "/vis/system/control-center",
+          note: "Ikke «Control Center» — under Forstå system",
+        },
       ],
     },
     {
@@ -848,6 +941,7 @@ export const visIaTreeProposalV03 = {
         { label: "Design System v01 (legacy)", href: "/vis/system/design-system-v01" },
         { label: "Task bus live", href: "/vis/system/task-bus-live" },
         { label: "Lukkede sprintvisninger", note: "Ved sprintskifte" },
+        { label: "/vis/artikkel, /vis/hub", note: "Vurder sletting senere — ikke i tre" },
       ],
     },
   ],

--- a/src/data/vis-ia-consolidation-v03.ts
+++ b/src/data/vis-ia-consolidation-v03.ts
@@ -1,0 +1,854 @@
+/* CONTRACT: VIS IA Consolidation Readiness v0.3 — funksjonell verdi, migrasjon og Thomas QA. */
+
+import type { VisIaTopTask } from "./vis-ia-inventory-v01.ts";
+
+export type VisIaFunctionalValue =
+  | "god oversikt"
+  | "nyttig preview"
+  | "runtime-status"
+  | "lenker"
+  | "QA-funksjon"
+  | "historisk beslutningsgrunnlag"
+  | "bilde-/assetstruktur"
+  | "systemforklaring"
+  | "teknisk runbook"
+  | "designmønstre"
+  | "beslutningsgrunnlag"
+  | "navigasjonshjelp";
+
+export type VisIaOverlapKind = "ingen" | "route-navn" | "reelt behov" | "route og behov";
+
+export type VisIaFuturePlacement =
+  | "behold som egen flate"
+  | "behold som global flate og vis i VIS-tre"
+  | "slå sammen med annen flate"
+  | "gjør om til seksjon under annen flate"
+  | "flytt til historikk / arkiv"
+  | "vurder sletting senere"
+  | "trenger Thomas-avklaring";
+
+export type VisIaConsolidationReadiness = {
+  /** Kort menneskelig: «Hva er denne siden til for?» */
+  mandatePlain: string;
+  /** Hva hjelper den oss med i praksis? */
+  practicalHelp: string;
+  /** Hva gjør vi her? */
+  whatToDoHere: string;
+  /** Hva skal vi ikke gjøre her? */
+  whatNotToDoHere: string;
+  functionalValue: VisIaFunctionalValue[];
+  overlapKind: VisIaOverlapKind;
+  overlapNote: string;
+  mergeRisk: string;
+  futurePlacement: VisIaFuturePlacement;
+  migrationNote?: string;
+  needsThomasReview: boolean;
+};
+
+export type VisIaDeepDiveArea = {
+  id: string;
+  letter: string;
+  title: string;
+  summary: string;
+  clarifications: { question: string; answer: string }[];
+  preserveWhenMerging: string[];
+  doNotMix: string[];
+};
+
+export type VisIaMetadataStrategy = {
+  approach: "hybrid";
+  summary: string;
+  perPage: string;
+  centralRegistry: string;
+  headerRevival: string;
+};
+
+export const visIaConsolidationMeta = {
+  version: "v0.3",
+  passName: "VIS IA Consolidation Readiness v0.3",
+  updatedAt: "2026-05-31",
+} as const;
+
+/** Grundig vurdering av seks konfliktområder — Thomas/Vibeke-språk. */
+export const visIaDeepDiveAreas: VisIaDeepDiveArea[] = [
+  {
+    id: "area-a",
+    letter: "A",
+    title: "VIS kontrollrom / Runtime Feed / Gitbuss",
+    summary:
+      "Tre flater handler om «hvor er vi?», men med ulikt dybde og formål. De ligner — de løser ikke helt samme behov.",
+    clarifications: [
+      {
+        question: "Hva er forsiden (/vis/) sitt mandat?",
+        answer:
+          "Gi et raskt, samlet bilde: hva er MVP-status, hva jobber vi med nå, og hvor går du videre. Det er inngangen — ikke detaljarkivet.",
+      },
+      {
+        question: "Hva er Runtime Feed sitt mandat?",
+        answer:
+          "Kort, menneskelig «Akkurat nå»-stripe: hva skjer, hvorfor, og hva er neste beslutning. Oppdateres manuelt av agent/team — ikke auto-generert fra GitHub.",
+      },
+      {
+        question: "Hva er Gitbuss sitt mandat?",
+        answer:
+          "Operativ GitHub-oversikt: issues, PR-er og nylig aktivitet. For når du vil se hva som faktisk skjer i repoet — dypere enn forsiden.",
+      },
+      {
+        question: "Hva skal ikke blandes?",
+        answer:
+          "Ikke la forsiden bli en full GitHub-klone. Ikke la Runtime Feed erstatte Gitbuss. Ikke bruk Gitbuss som «god morgen»-oversikt for Vibeke.",
+      },
+    ],
+    preserveWhenMerging: [
+      "Forsiden: hub-kort, MVP-blokk og feed-stripe",
+      "Runtime Feed: headline/why/nextDecision og kommunikasjonsregelen",
+      "Gitbuss: generert GitHub-feed og lenker til issues/PR",
+    ],
+    doNotMix: ["Aggregert «nå»", "Manuell kommunikasjon", "GitHub-detalj"],
+  },
+  {
+    id: "area-b",
+    letter: "B",
+    title: "Backstage / System / Control Center / /vis/system/",
+    summary:
+      "Backstage er den vi peker til når noen spør «hvordan fungerer systemet?». Resten er støtte, agent-hjelp eller gammel navigasjon.",
+    clarifications: [
+      {
+        question: "Backstage som canonical systemforklaring?",
+        answer:
+          "Ja. Backstage er den autoritative flate for AI, API, guardrails og arbeidsregler. Den skal ikke flyttes inn i /vis/.",
+      },
+      {
+        question: "Er /vis/system/ overflødig når tremeny kommer?",
+        answer:
+          "Ja, som primær navigasjon. Flat link-liste dupliserer det tremenyen skal gjøre. Behold midlertidig som fallback — arkiver i menyen.",
+      },
+      {
+        question: "Skal Control Center fjernes som begrep?",
+        answer:
+          "Begrepet «Control Center» forvirrer — det høres ut som forsiden. Behold siden som agent-runbook, men kall den noe tydeligere i tre (f.eks. «Agent-kontekst»). Den er ikke erstatning for Backstage.",
+      },
+    ],
+    preserveWhenMerging: [
+      "Backstage: hele pedagogiske systemreferansen",
+      "Control Center: filpeker og agent-instruksjoner",
+      "IA-prinsipper og Hub Mandate: canonical dokumentasjon",
+    ],
+    doNotMix: ["Systemforklaring for mennesker", "Agent-runbook", "Flat link-liste"],
+  },
+  {
+    id: "area-c",
+    letter: "C",
+    title: "Roadmap / Sprint / GitHub Projects / Live Board",
+    summary:
+      "Retning, aktiv uke og daglige oppgaver er tre lag. Live Board er historikk — ikke aktiv flate.",
+    clarifications: [
+      {
+        question: "Hva er retning?",
+        answer: "Roadmap-tidslinjen: faser og milepæler over tid. «Hvor er vi på vei?» — ikke «hva gjør vi i dag?».",
+      },
+      {
+        question: "Hva er aktiv uke?",
+        answer: "Sprint 2026-W21 og labs: designbeslutninger denne sprinten. Stenger når sprinten stenger.",
+      },
+      {
+        question: "Hva er oppgavebuss?",
+        answer: "Gitbuss: issues og PR-er akkurat nå. Operativt — ikke strategisk.",
+      },
+      {
+        question: "Hva er historisk wireframe?",
+        answer: "Live Board HTML og gamle sprint-HTML i raw/. Nyttig som begrunnelse — ikke som aktiv plan.",
+      },
+    ],
+    preserveWhenMerging: [
+      "Roadmap: tidslinje-visualisering",
+      "Sprint: lab-struktur og beslutningsgrunnlag",
+      "Gitbuss: runtime GitHub-data",
+    ],
+    doNotMix: ["Retning", "Aktiv sprint", "Daglige issues", "Historisk wireframe"],
+  },
+  {
+    id: "area-d",
+    letter: "D",
+    title: "Designsystem / Review / design-system-v01",
+    summary:
+      "Ett canonical designsystem. Review er QA-inngang. Legacy v01 skal tydelig merkes som utdatert.",
+    clarifications: [
+      {
+        question: "Hva er canonical designsystem?",
+        answer: "/designsystem/ — production tokens, komponenter og mønstre. Dette er sannheten for UI.",
+      },
+      {
+        question: "Hva er QA/review?",
+        answer: "/vis/review/ — innganger til å godkjenne sprint-labs og sjekke at design er klart. Ikke eget designsystem.",
+      },
+      {
+        question: "Hva er legacy?",
+        answer: "/vis/system/design-system-v01 — gammel VIS-versjon. Behold URL, men merk «ikke canonical» og pek til /designsystem/.",
+      },
+      {
+        question: "Hva må ikke forveksles?",
+        answer: "Sprint-labs (forslag) vs designsystem (vedtatt). Review vs designsystem. Legacy v01 vs canonical.",
+      },
+    ],
+    preserveWhenMerging: [
+      "Designsystem: alle tokens og komponenter",
+      "Review: QA-registry og stakeholder-lenker",
+      "Sprint-labs: beslutningsgrunnlag til review",
+    ],
+    doNotMix: ["Canonical design", "QA-inngang", "Legacy referanse", "Aktiv lab"],
+  },
+  {
+    id: "area-e",
+    letter: "E",
+    title: "DAM / Editorial Image Library",
+    summary: "Én flate, ett behov — navnet er det som er forvirrende, ikke funksjonen.",
+    clarifications: [
+      {
+        question: "Ett område eller to?",
+        answer: "Ett. Hub-kort sier «DAM / bildebank», siden sier «Editorial Image Library». Samme rute, samme innhold.",
+      },
+      {
+        question: "Hva er mandatet?",
+        answer: "Finne og velge redaksjonelle bilder til artikler og innhold. Støtte Vibeke og redaksjon.",
+      },
+      {
+        question: "Hva må bevares ved sammenslåing?",
+        answer: "Hele bildestrukturen, metadata, preview og eventuelle kategorier. Bare navnet i hub og meny endres.",
+      },
+    ],
+    preserveWhenMerging: ["Editorial Image Library UI", "Asset-metadata", "Preview-funksjon"],
+    doNotMix: ["Hub-label", "Sideinnhold"],
+  },
+  {
+    id: "area-f",
+    letter: "F",
+    title: "Raw wireframes / /vis/artikkel / /vis/hub",
+    summary:
+      "Wireframes er historikk med verdi. Placeholders er tomme og bør ikke finnes i primær navigasjon.",
+    clarifications: [
+      {
+        question: "Hva er historikk?",
+        answer: "10+ HTML-filer i public/vis/raw — tidlige forsider, strategi, sprint-arkiv. Bevar som beslutningsgrunnlag.",
+      },
+      {
+        question: "Hva er tom placeholder?",
+        answer: "/vis/artikkel og /vis/hub — Astro-sider uten innhold. Ingen funksjonell verdi i dag.",
+      },
+      {
+        question: "Hva kan vurderes slettet senere?",
+        answer: "Placeholders og Live Board wireframe (har allerede canonical erstatning).",
+      },
+      {
+        question: "Hva må bevares som beslutningsgrunnlag?",
+        answer: "Strategisk IA v5, Sprint 01 Foundation, forside-varianter — merket historical, lenket fra arkiv.",
+      },
+    ],
+    preserveWhenMerging: [
+      "Raw HTML-filer og vis:meta i head",
+      "Wireframe-viewer (/vis/[slug])",
+      "Arkiv-seksjon på forsiden",
+    ],
+    doNotMix: ["Historisk referanse", "Tom placeholder", "Aktiv sprint-lab", "Production /no/"],
+  },
+];
+
+export const visIaMetadataStrategy: VisIaMetadataStrategy = {
+  approach: "hybrid",
+  summary:
+    "Canonical metadata i sentral registry; hver side kan overstyre med frontmatter eller eksportert konstant. VIS-header leser registry først, deretter side-local.",
+  perPage:
+    "VIS-sider under /vis/ og globale interne flater får `export const visPageContract = { … }` eller Astro frontmatter. Gir presis purpose og nextAction per side.",
+  centralRegistry:
+    "src/data/vis-page-contracts.ts samler alle kontrakter for header, tremeny og IA-inventar. Én kilde for «hva finnes» — sidene eier detaljene.",
+  headerRevival:
+    "PrototypeLayout (eller ny VisPageShell) leser contract og viser: tittel, purpose, status-badge (aktiv/canonical/lab/historikk), nextAction og lenke til canonicalSource. Samme nytte som gammel wireframe-infobar — ryddigere og konsistent på tvers av Astro-sider.",
+};
+
+export const visIaPageContractV03Fields = [
+  { field: "title", required: true, description: "Sidetittel i header", example: "Sprint lab — Color" },
+  { field: "type", required: true, description: "Flate-type", example: "sprint-lab" },
+  { field: "status", required: true, description: "active | canonical | lab | reference | historical | legacy", example: "lab" },
+  { field: "purpose", required: true, description: "Én setning: hva siden er til for", example: "Velge fargepalett for MVP Design Lock" },
+  { field: "primaryTask", required: true, description: "Primær top task (1–7)", example: "beslutninger-qa" },
+  { field: "audience", required: true, description: "Thomas, Vibeke, Cursor, …", example: "Thomas,Vibeke" },
+  { field: "relatedArea", required: false, description: "Overlappende flater (ID-er)", example: "designsystem,review" },
+  { field: "canonicalSource", required: false, description: "Operativ sannhet hvis lab/legacy", example: "/designsystem/" },
+  { field: "lastReviewed", required: true, description: "ISO-dato siste mandatvurdering", example: "2026-05-31" },
+  { field: "ownerRole", required: true, description: "Hvem eier innholdet", example: "Thomas" },
+  { field: "nextAction", required: false, description: "Hva brukeren bør gjøre etter besøk", example: "Godkjenn i Review eller oppdater designsystem" },
+] as const;
+
+export const visIaPageContractV03Example = {
+  title: "Sprint lab — Color",
+  type: "sprint-lab",
+  status: "lab",
+  purpose: "Velge fargepalett for MVP Design Lock",
+  primaryTask: "beslutninger-qa",
+  audience: ["Thomas", "Vibeke"],
+  relatedArea: ["designsystem", "review"],
+  canonicalSource: "/designsystem/",
+  lastReviewed: "2026-05-31",
+  ownerRole: "Thomas",
+  nextAction: "Godkjenn palett i Review — deretter oppdater tokens i designsystem",
+} as const;
+
+type C = VisIaConsolidationReadiness;
+
+const c = (
+  partial: Omit<C, "functionalValue" | "overlapKind"> & {
+    functionalValue: VisIaFunctionalValue[];
+    overlapKind?: VisIaOverlapKind;
+  },
+): C => ({
+  overlapKind: "ingen",
+  ...partial,
+});
+
+/** Konsolideringsvurdering per flate-ID. */
+export const visIaConsolidationById: Record<string, VisIaConsolidationReadiness> = {
+  "vis-frontpage": c({
+    mandatePlain: "VIS-forsiden er inngangen: «Hvor står vi, og hvor går jeg videre?»",
+    practicalHelp: "Du slipper GitHub og filsøk for å forstå status og finne riktig arbeidsflate.",
+    whatToDoHere: "Start dagen her. Les feed-stripe og MVP-blokk. Velg hub etter behov.",
+    whatNotToDoHere: "Ikke bruk forsiden som full issue-liste eller dyp systemdokumentasjon.",
+    functionalValue: ["god oversikt", "runtime-status", "lenker", "navigasjonshjelp"],
+    overlapKind: "reelt behov",
+    overlapNote: "Overlapper delvis med Gitbuss og Runtime Feed — men forsiden aggregerer, de andre går dypere.",
+    mergeRisk: "Hvis vi slår forsiden med Gitbuss mister Vibeke det rolige overblikket. Hub-kort og feed må bevares.",
+    futurePlacement: "behold som egen flate",
+    needsThomasReview: false,
+  }),
+  "runtime-feed": c({
+    mandatePlain: "Kort «Akkurat nå»-melding i menneskelig språk — hva skjer og hva er neste steg.",
+    practicalHelp: "Thomas og Vibeke ser hva team/agent jobber med uten å lese teknisk logg.",
+    whatToDoHere: "Les headline, why og nextDecision. Følg lenke til sprint eller beslutning.",
+    whatNotToDoHere: "Ikke behandle feed som komplett prosjektstatus eller erstatning for Gitbuss.",
+    functionalValue: ["runtime-status", "beslutningsgrunnlag"],
+    overlapKind: "reelt behov",
+    overlapNote: "Ligner Gitbuss tematisk — men feed er manuell kommunikasjon, Gitbuss er auto GitHub.",
+    mergeRisk: "Hvis feed slugges inn i Gitbuss forsvinner menneskelig tone og § B4-kommunikasjonsregelen.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    migrationNote: "Forblir innebygd på /vis/. Data i vis-runtime-feed.ts. Ingen route-endring.",
+    needsThomasReview: false,
+  }),
+  gitbuss: c({
+    mandatePlain: "Operativ GitHub-oversikt — issues, PR-er og nylig aktivitet.",
+    practicalHelp: "Se hva som faktisk skjer i repoet uten å åpne GitHub.",
+    whatToDoHere: "Sjekk åpne issues/PR. Prioriter arbeid. Knytt til sprint eller roadmap ved behov.",
+    whatNotToDoHere: "Ikke bruk Gitbuss som «god morgen»-forside for Vibeke. Ikke bland med roadmap-retning.",
+    functionalValue: ["runtime-status", "god oversikt", "lenker"],
+    overlapKind: "reelt behov",
+    overlapNote: "Tematisk lik forsiden — men løser dypere operativt behov, ikke aggregert inngang.",
+    mergeRisk: "Slå sammen med forsiden → overveldende for ikke-tekniske. Generert feed må beholdes separat.",
+    futurePlacement: "behold som egen flate",
+    migrationNote: "Under «Operativt» i tremeny. Behold /vis/system/github-runtime-status.",
+    needsThomasReview: false,
+  }),
+  designsystem: c({
+    mandatePlain: "Canonical referanse for UI: farger, typografi, komponenter og mønstre.",
+    practicalHelp: "Finn riktig design for produksjon — for deg, Vibeke og agenter.",
+    whatToDoHere: "Slå opp tokens og komponenter. Bruk som sannhet ved QA og implementasjon.",
+    whatNotToDoHere: "Ikke dupliser mønstre i VIS legacy. Ikke forveksle med sprint-labs (forslag).",
+    functionalValue: ["designmønstre", "nyttig preview", "systemforklaring"],
+    overlapKind: "route-navn",
+    overlapNote: "Route-navn overlapper med design-system-v01 — reelt behov er ulikt (canonical vs legacy).",
+    mergeRisk: "Ingen sammenslåing med legacy. Alt innhold i /designsystem/ må stå urørt.",
+    futurePlacement: "behold som global flate og vis i VIS-tre",
+    needsThomasReview: false,
+  }),
+  backstage: c({
+    mandatePlain: "Systemforklaring for AI, API og arbeidsregler — den autoritative interne referansen.",
+    practicalHelp: "Forstå hvordan Viddel fungerer uten å grave i repo eller GitHub.",
+    whatToDoHere: "Les operating rules. Referer agenter hit. Ta systembeslutninger informert.",
+    whatNotToDoHere: "Ikke erstatte med Control Center eller flat /vis/system/-liste.",
+    functionalValue: ["systemforklaring", "teknisk runbook", "lenker"],
+    overlapKind: "reelt behov",
+    overlapNote: "Control Center og /vis/system/ ligner — Backstage er canonical for mennesker og agenter.",
+    mergeRisk: "Slå sammen med Control Center → mister pedagogisk struktur Backstage har bygget opp.",
+    futurePlacement: "behold som global flate og vis i VIS-tre",
+    needsThomasReview: false,
+  }),
+  roadmap: c({
+    mandatePlain: "Se retning og faser over tid — «hvor er vi på vei?»",
+    practicalHelp: "Plasser sprint-arbeid i større bilde uten å blande med daglige issues.",
+    whatToDoHere: "Forstå faser og milepæler. Bruk som kontekst ved prioritering.",
+    whatNotToDoHere: "Ikke bruk roadmap som sprint-backlog eller erstatning for Gitbuss.",
+    functionalValue: ["god oversikt", "beslutningsgrunnlag", "historisk beslutningsgrunnlag"],
+    overlapKind: "reelt behov",
+    overlapNote: "Live Board wireframe løste samme behov — nå erstattet. Sprint er annet lag (aktiv uke).",
+    mergeRisk: "Slå sammen med sprint → forvirrer retning vs denne uken. Tidslinje-visualisering må bevares.",
+    futurePlacement: "behold som egen flate",
+    needsThomasReview: false,
+  }),
+  "dam-editorial": c({
+    mandatePlain: "Finne og velge redaksjonelle bilder til artikler og innhold.",
+    practicalHelp: "Vibeke og Thomas kan browse bilder uten å lete i mapper eller Storyblok blindt.",
+    whatToDoHere: "Velg bilde til innhold. Noter valg til redaksjon/Storyblok.",
+    whatNotToDoHere: "Ikke splitt i to hub-navn (DAM vs Editorial) — det er samme flate.",
+    functionalValue: ["bilde-/assetstruktur", "nyttig preview", "lenker"],
+    overlapKind: "route-navn",
+    overlapNote: "Kun navne-overlapp mellom hub-kort og sidetittel — ikke to løsninger.",
+    mergeRisk: "Endre bare label i hub og meny. Hele Editorial Image Library UI må bevares.",
+    futurePlacement: "slå sammen med annen flate",
+    migrationNote: "Én label: «Redaksjonelle bilder». Route /vis/assets/editorial uendret. Oppdater vis-frontpage-hubs-v01.ts.",
+    needsThomasReview: true,
+  }),
+  review: c({
+    mandatePlain: "QA-inngang: godkjenne design og sprint-labs før de blir canonical.",
+    practicalHelp: "Thomas og Vibeke har ett sted å sjekke «er dette klart?»",
+    whatToDoHere: "Gå gjennom review-lenker. Godkjenn eller send tilbake til lab.",
+    whatNotToDoHere: "Ikke behandle Review som eget designsystem eller primær hub.",
+    functionalValue: ["QA-funksjon", "lenker", "beslutningsgrunnlag"],
+    overlapKind: "reelt behov",
+    overlapNote: "Knyttet til sprint-labs og designsystem — ulikt mandat (godkjenning vs referanse).",
+    mergeRisk: "Flytt under Design i tre — ikke slå sammen innhold. QA-registry må bevares.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    migrationNote: "Tremeny: Design → Review. Route og funksjon uendret.",
+    needsThomasReview: false,
+  }),
+  "sprint-2026-w21": c({
+    mandatePlain: "Aktiv sprint: designarbeid og beslutninger denne uken (W21).",
+    practicalHelp: "Se hva som jobbes med nå og finn riktig lab.",
+    whatToDoHere: "Åpne relevant lab. Ta beslutning. Oppdater review/designsystem.",
+    whatNotToDoHere: "Ikke forveksle med roadmap (retning) eller gamle sprint-HTML i arkiv.",
+    functionalValue: ["god oversikt", "lenker", "beslutningsgrunnlag"],
+    overlapKind: "route-navn",
+    overlapNote: "Sprint 01 Foundation i raw/ ligner navn — men er lukket historikk.",
+    mergeRisk: "Ved sprintskifte: flytt til arkiv, ikke slett labs. Struktur er modell for neste sprint.",
+    futurePlacement: "behold som egen flate",
+    migrationNote: "Ved ny sprint: opprett ny mappe, flytt W21 til Historikk i tre. Behold URL som arkiv.",
+    needsThomasReview: false,
+  }),
+  "sprint-color": c({
+    mandatePlain: "Beslutte fargepalett for MVP Design Lock.",
+    practicalHelp: "Se og vurdere fargevalg i kontekst — stakeholder-safe.",
+    whatToDoHere: "Sammenlign alternativer. Beslut. Send til Review.",
+    whatNotToDoHere: "Ikke behandle som canonical — designsystem er sannhet etter godkjenning.",
+    functionalValue: ["nyttig preview", "beslutningsgrunnlag", "QA-funksjon"],
+    overlapKind: "ingen",
+    overlapNote: "Del av sprint — ingen reelt behovsoverlapp med andre flater.",
+    mergeRisk: "Grupper under sprint i tre — ikke slå sammen labs med hverandre.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "sprint-typography": c({
+    mandatePlain: "Vurdere typografi mot production tokens.",
+    practicalHelp: "Typografi-pass knyttet til designsystem.",
+    whatToDoHere: "Sammenlign med /designsystem/. Beslut. Oppdater tokens ved godkjenning.",
+    whatNotToDoHere: "Ikke dupliser token-definisjon her — pek til canonical.",
+    functionalValue: ["nyttig preview", "designmønstre", "beslutningsgrunnlag"],
+    overlapKind: "ingen",
+    overlapNote: "Knyttet til designsystem etter beslutning — ikke overlapp i dag.",
+    mergeRisk: "Behold som lab under sprint.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "sprint-hub-types": c({
+    mandatePlain: "Beslutte hub-typer for produkt-IA.",
+    practicalHelp: "IA-beslutning visualisert for Thomas og Vibeke.",
+    whatToDoHere: "Vurdere hub-typer. Knytt til IA-prinsipper og Review.",
+    whatNotToDoHere: "Ikke implementer i /no/ direkte — beslutning først.",
+    functionalValue: ["beslutningsgrunnlag", "nyttig preview", "QA-funksjon"],
+    overlapKind: "reelt behov",
+    overlapNote: "Knyttet til IA-prinsipper og Hub Mandate — samme tema, ulikt format (lab vs doc).",
+    mergeRisk: "Lab-visualisering må bevares — ikke slå sammen med ia-principles doc.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "sprint-editorial-hub": c({
+    mandatePlain: "Visualisere redaksjonell hub-struktur.",
+    practicalHelp: "Se hvordan redaksjonell IA kan se ut.",
+    whatToDoHere: "Vurdere struktur. Diskuter med Vibeke. Oppdater mandat-doc ved beslutning.",
+    whatNotToDoHere: "Ikke forveksle med production /no/hub.",
+    functionalValue: ["nyttig preview", "beslutningsgrunnlag"],
+    overlapKind: "ingen",
+    overlapNote: "Ingen reelt overlapp — lab for redaksjonell IA.",
+    mergeRisk: "Behold under sprint.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "sprint-frontpage-mandate": c({
+    mandatePlain: "Definere forsidemandat for VIS og produkt.",
+    practicalHelp: "Arbeidsflate for IA-beslutninger om forsiden.",
+    whatToDoHere: "Les og kommenter mandat. Koble til inventory og IA-prinsipper.",
+    whatNotToDoHere: "Ikke erstatte /vis/ eller /no/ — dette er beslutningsgrunnlag.",
+    functionalValue: ["beslutningsgrunnlag", "systemforklaring"],
+    overlapKind: "reelt behov",
+    overlapNote: "Knyttet til IA inventory-arbeid — samme problemområde, ulikt format.",
+    mergeRisk: "Behold som lab — verdifullt for pågående IA-arbeid.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "sprint-primitives": c({
+    mandatePlain: "QA primitives (13 + 3 context) før canonical i designsystem.",
+    practicalHelp: "Se alle grunnleggende UI-elementer samlet for Design Lock.",
+    whatToDoHere: "Gå gjennom hver primitive. Godkjenn i Review. Oppdater designsystem.",
+    whatNotToDoHere: "Ikke flat liste i tremeny — grupper under Primitives-node.",
+    functionalValue: ["nyttig preview", "designmønstre", "QA-funksjon"],
+    overlapKind: "reelt behov",
+    overlapNote: "Overlapper designsystem tematisk — lab er forslag, designsystem er vedtatt.",
+    mergeRisk: "Mange undersider — grupper i tre. Ikke slå sammen med /designsystem/.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "control-center": c({
+    mandatePlain: "Agent-runbook: prosjektkontekst og filpeker for Cursor og agenter.",
+    practicalHelp: "Agenter finner riktig fil og kontekst raskere.",
+    whatToDoHere: "Start agent-oppgave her hvis du trenger filkart.",
+    whatNotToDoHere: "Ikke bruk som Thomas/Vibeke sin systemforklaring — det er Backstage.",
+    functionalValue: ["teknisk runbook", "lenker", "navigasjonshjelp"],
+    overlapKind: "reelt behov",
+    overlapNote: "Ligner Backstage — men Backstage er pedagogisk, Control Center er operativ agent-hjelp.",
+    mergeRisk: "Slå sammen med Backstage → mister agent-spesifikk filkart. Begrepet «Control Center» bør døpes om.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    migrationNote: "Tremeny: «Agent-kontekst» under Forstå system. Vurder rename — ikke slett funksjon.",
+    needsThomasReview: true,
+  }),
+  "ia-principles": c({
+    mandatePlain: "Need-led IA-prinsipper — grunnmur for produktstruktur.",
+    practicalHelp: "Forstå hvorfor IA er bygget slik — uten Notion eller GitHub.",
+    whatToDoHere: "Les prinsipper ved IA-beslutninger. Referer i review og labs.",
+    whatNotToDoHere: "Ikke erstatte med gammel Strategisk IA v5 wireframe.",
+    functionalValue: ["systemforklaring", "beslutningsgrunnlag", "historisk beslutningsgrunnlag"],
+    overlapKind: "reelt behov",
+    overlapNote: "Strategisk IA v5 i raw/ er forgjenger — canonical er denne siden.",
+    mergeRisk: "Dokumentet er canonical — ingen sammenslåing.",
+    futurePlacement: "behold som egen flate",
+    needsThomasReview: false,
+  }),
+  "ia-inventory": c({
+    mandatePlain: "Kartlegge VIS-flater, mandat og konsolidering før tremeny bygges.",
+    practicalHelp: "Thomas QA-er hvilke sider som bør finnes og hva som kan slås sammen.",
+    whatToDoHere: "Les deep dives A–F. Godkjenn anbefalinger. Merk det som trenger avklaring.",
+    whatNotToDoHere: "Ikke implementer tremeny her — dette er analyseflate.",
+    functionalValue: ["beslutningsgrunnlag", "god oversikt", "systemforklaring"],
+    overlapKind: "route-navn",
+    overlapNote: "Erstatter delvis flat /vis/system/ som navigasjonshjelp — ulikt mandat.",
+    mergeRisk: "Meta-dokument — kan skjules i prod-meny etter tremeny.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    migrationNote: "Skjul i prod-tre etter godkjenning. Behold URL for IA-arbeid.",
+    needsThomasReview: false,
+  }),
+  "hub-mandate": c({
+    mandatePlain: "Canonical mandat for hver hub-type i produktet.",
+    practicalHelp: "Forstå hva hver hub skal løse for brukeren.",
+    whatToDoHere: "Slå opp ved hub-beslutninger. Koble til sprint-labs.",
+    whatNotToDoHere: "Ikke dupliser i sprint-labs permanent — lab skal peke hit.",
+    functionalValue: ["systemforklaring", "beslutningsgrunnlag"],
+    overlapKind: "ingen",
+    overlapNote: "Referanse-doc — lite overlapp.",
+    mergeRisk: "Behold som doc under Forstå system.",
+    futurePlacement: "behold som egen flate",
+    needsThomasReview: false,
+  }),
+  "design-system-v01-overview": c({
+    mandatePlain: "Gammel designreferanse i VIS — ikke lenger canonical.",
+    practicalHelp: "Historisk sammenligning hvis noen lurer på «hva var før /designsystem/».",
+    whatToDoHere: "Sjekk canonical /designsystem/ i stedet.",
+    whatNotToDoHere: "Ikke bruk som aktiv designreferanse.",
+    functionalValue: ["historisk beslutningsgrunnlag"],
+    overlapKind: "route og behov",
+    overlapNote: "Samme behov som designsystem — men legacy. Route og innhold overlapper.",
+    mergeRisk: "Redirect til /designsystem/ kan miste historisk diff. Behold URL med tydelig legacy-badge.",
+    futurePlacement: "flytt til historikk / arkiv",
+    migrationNote: "Page contract: status=legacy, canonicalSource=/designsystem/. Fjern fra primær nav.",
+    needsThomasReview: false,
+  }),
+  "article-system": c({
+    mandatePlain: "Oversikt over artikkel-systemet — komponenter og maler for redaksjon.",
+    practicalHelp: "Forstå hvordan artikler bygges i produktet.",
+    whatToDoHere: "Start her for artikkel-dok. Gå til foundations/components/templates.",
+    whatNotToDoHere: "Ikke flat liste — grupper under Artikkel-node i tre.",
+    functionalValue: ["systemforklaring", "lenker", "nyttig preview"],
+    overlapKind: "route-navn",
+    overlapNote: "article/ index overlapper — samme område, bør være én tre-node.",
+    mergeRisk: "Slå sammen index med undersider som gruppe — ikke slett undersider.",
+    futurePlacement: "slå sammen med annen flate",
+    migrationNote: "Tre: Artikkel-system → Foundations, Components, Templates, Changelog.",
+    needsThomasReview: false,
+  }),
+  "article-foundations": c({
+    mandatePlain: "Grunnmur for artikkel-systemet.",
+    practicalHelp: "Forstå grunnleggende struktur før komponenter.",
+    whatToDoHere: "Les foundations før du endrer artikkel-komponenter.",
+    whatNotToDoHere: "Ikke dupliser designsystem — pek til canonical.",
+    functionalValue: ["systemforklaring"],
+    overlapKind: "ingen",
+    overlapNote: "Del av artikkel-gruppe.",
+    mergeRisk: "Behold som underside — grupper i tre.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "article-components": c({
+    mandatePlain: "Preview av artikkel-komponenter.",
+    practicalHelp: "Se komponenter i kontekst.",
+    whatToDoHere: "Sjekk komponent før bruk i artikkel.",
+    whatNotToDoHere: "Ikke erstatte /designsystem/.",
+    functionalValue: ["nyttig preview", "designmønstre"],
+    overlapKind: "ingen",
+    overlapNote: "Artikkel-spesifikk — ikke overlapp med designsystem.",
+    mergeRisk: "Behold preview-funksjon.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "article-templates": c({
+    mandatePlain: "Oppskrifter for artikkel-maler.",
+    practicalHelp: "Finn riktig mal for ny artikkel-type.",
+    whatToDoHere: "Velg mal. Følg oppskrift.",
+    whatNotToDoHere: "Ikke hardkod maler i /no/ uten doc her.",
+    functionalValue: ["systemforklaring", "lenker"],
+    overlapKind: "ingen",
+    overlapNote: "Del av artikkel-gruppe.",
+    mergeRisk: "Behold mal-dokumentasjon.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "article-changelog": c({
+    mandatePlain: "Historikk for endringer i artikkel-systemet.",
+    practicalHelp: "Finn begrunnelse for tidligere artikkel-endringer.",
+    whatToDoHere: "Slå opp ved «hvorfor er det slik?»",
+    whatNotToDoHere: "Ikke bruk som aktiv utviklingsflate.",
+    functionalValue: ["historisk beslutningsgrunnlag"],
+    overlapKind: "ingen",
+    overlapNote: "Historikk — lav frekvens.",
+    mergeRisk: "Behold som changelog under Artikkel.",
+    futurePlacement: "gjør om til seksjon under annen flate",
+    needsThomasReview: false,
+  }),
+  "article-index": c({
+    mandatePlain: "Inngang til artikkel-dokumentasjon.",
+    practicalHelp: "Navigere til riktig artikkel-doc.",
+    whatToDoHere: "Velg underside (foundations, components, …).",
+    whatNotToDoHere: "Ikke dupliser system/ flat liste.",
+    functionalValue: ["lenker", "navigasjonshjelp"],
+    overlapKind: "route-navn",
+    overlapNote: "Overlapper article-system oversikt — én tre-node holder.",
+    mergeRisk: "Slå sammen navigasjon — behold alle undersider.",
+    futurePlacement: "slå sammen med annen flate",
+    migrationNote: "article-system + article/index → én «Artikkel-system» node.",
+    needsThomasReview: false,
+  }),
+  "vis-system-index": c({
+    mandatePlain: "Gammel flat liste over system-sider — midlertidig navigasjon.",
+    practicalHelp: "Fallback til alle /vis/system/-lenker finnes.",
+    whatToDoHere: "Bruk til overgang hvis tremeny ikke er klar.",
+    whatNotToDoHere: "Ikke bruk som primær navigasjon når tremeny finnes.",
+    functionalValue: ["lenker", "navigasjonshjelp"],
+    overlapKind: "route og behov",
+    overlapNote: "Dupliserer det tremeny skal løse — samme behov (finn system-side).",
+    mergeRisk: "Arkiver i meny — lenker kan brytes hvis slettet for tidlig.",
+    futurePlacement: "flytt til historikk / arkiv",
+    migrationNote: "Behold URL som fallback. Fjern fra hub og primær nav. Redirect ikke nødvendig.",
+    needsThomasReview: false,
+  }),
+  "task-bus-live": c({
+    mandatePlain: "Pensjonert oppgavebuss — erstattet av Gitbuss og roadmap.",
+    practicalHelp: "Historisk referanse til gammel task-flyt.",
+    whatToDoHere: "Bruk Gitbuss og roadmap i stedet.",
+    whatNotToDoHere: "Ikke bruk som aktiv verktøyflate.",
+    functionalValue: ["historisk beslutningsgrunnlag"],
+    overlapKind: "reelt behov",
+    overlapNote: "Løste samme behov som Gitbuss — nå erstattet.",
+    mergeRisk: "Sletting mister historikk — arkiver med legacy-lenke til Gitbuss.",
+    futurePlacement: "flytt til historikk / arkiv",
+    migrationNote: "Legacy-badge + canonicalSource=Gitbuss.",
+    needsThomasReview: false,
+  }),
+  "vis-artikkel-placeholder": c({
+    mandatePlain: "Tom placeholder — ingen funksjon i dag.",
+    practicalHelp: "Ingen praktisk verdi.",
+    whatToDoHere: "Ikke bruk. Gå til /no/artikkel/ eller sprint-labs.",
+    whatNotToDoHere: "Ikke lenke fra hub eller primær nav.",
+    functionalValue: [],
+    overlapKind: "route-navn",
+    overlapNote: "Route ligner production — men ingen reelt innhold.",
+    mergeRisk: "Sletting krever sjekk av inbound lenker.",
+    futurePlacement: "vurder sletting senere",
+    migrationNote: "Redirect til arkiv eller fjern lenker. QA inbound links.",
+    needsThomasReview: true,
+  }),
+  "vis-hub-placeholder": c({
+    mandatePlain: "Tom placeholder — ingen funksjon i dag.",
+    practicalHelp: "Ingen praktisk verdi.",
+    whatToDoHere: "Ikke bruk. Gå til /no/hub/ eller sprint-labs.",
+    whatNotToDoHere: "Ikke lenke fra hub eller primær nav.",
+    functionalValue: [],
+    overlapKind: "route-navn",
+    overlapNote: "Route ligner production — tom flate.",
+    mergeRisk: "Sletting krever sjekk av inbound lenker.",
+    futurePlacement: "vurder sletting senere",
+    migrationNote: "Redirect til arkiv eller fjern lenker.",
+    needsThomasReview: true,
+  }),
+  "raw-wireframes": c({
+    mandatePlain: "Samling eldre HTML-wireframes — historisk referanse.",
+    practicalHelp: "Finn tidlig design eller strategi når du trenger begrunnelse.",
+    whatToDoHere: "Bruk arkiv på /vis/ eller direkte slug. Sammenlign med canonical.",
+    whatNotToDoHere: "Ikke bruk som gjeldende produkt eller aktiv beslutningsflate.",
+    functionalValue: ["historisk beslutningsgrunnlag", "nyttig preview"],
+    overlapKind: "reelt behov",
+    overlapNote: "Sprint-labs er aktiv beslutning — wireframes er historikk. Ikke samme behov.",
+    mergeRisk: "Slå sammen med sprint-labs → forveksling. Wireframe-viewer og vis:meta må bevares.",
+    futurePlacement: "flytt til historikk / arkiv",
+    migrationNote: "Kun Historikk i tre. Page contract status=historical på alle.",
+    needsThomasReview: false,
+  }),
+  "raw-klarlyd-forside-a": c({
+    mandatePlain: "Tidlig forside-variant A — historikk.",
+    practicalHelp: "Se hvordan forsiden så ut tidlig.",
+    whatToDoHere: "Sammenlign med /no/.",
+    whatNotToDoHere: "Ikke implementer fra denne filen.",
+    functionalValue: ["historisk beslutningsgrunnlag", "nyttig preview"],
+    overlapKind: "reelt behov",
+    overlapNote: "Production er /no/ — wireframe er historikk.",
+    mergeRisk: "Behold HTML og viewer.",
+    futurePlacement: "flytt til historikk / arkiv",
+    needsThomasReview: false,
+  }),
+  "raw-klarlyd-forside-b": c({
+    mandatePlain: "AI-first forsidespike — historikk.",
+    practicalHelp: "Begrunnelse for AI-first retning tidlig i prosjektet.",
+    whatToDoHere: "Les som historikk. Sammenlign med nåværende /no/chat/.",
+    whatNotToDoHere: "Ikke bruk som aktiv spec.",
+    functionalValue: ["historisk beslutningsgrunnlag"],
+    overlapKind: "ingen",
+    overlapNote: "Unik historisk artefakt.",
+    mergeRisk: "Behold i arkiv.",
+    futurePlacement: "flytt til historikk / arkiv",
+    needsThomasReview: false,
+  }),
+  "raw-strategi-notion": c({
+    mandatePlain: "Tidlig strategisk IA (Notion v5) — erstattet av ia-principles.",
+    practicalHelp: "Finn gammel begrunnelse for IA-valg.",
+    whatToDoHere: "Sammenlign med ia-principles-v01 og hub-mandate.",
+    whatNotToDoHere: "Ikke bruk som gjeldende strategi.",
+    functionalValue: ["historisk beslutningsgrunnlag"],
+    overlapKind: "reelt behov",
+    overlapNote: "Samme behov som ia-principles — men denne er utdatert.",
+    mergeRisk: "Behold som arkiv — canonical er ia-principles.",
+    futurePlacement: "flytt til historikk / arkiv",
+    migrationNote: "canonicalSource=/vis/system/ia-principles-v01",
+    needsThomasReview: false,
+  }),
+  "raw-sprint-foundation": c({
+    mandatePlain: "Lukket Sprint 01 — modell for fremtidige arkivsprint.",
+    practicalHelp: "Se hvordan vi dokumenterte lukket sprint.",
+    whatToDoHere: "Bruk som mal når W21 stenger.",
+    whatNotToDoHere: "Ikke forveksle med aktiv W21.",
+    functionalValue: ["historisk beslutningsgrunnlag"],
+    overlapKind: "route-navn",
+    overlapNote: "Navn ligner aktiv sprint — ulik status (lukket vs aktiv).",
+    mergeRisk: "Tydelig «lukket»-merke. Ikke slett — modell for closedSprints.",
+    futurePlacement: "flytt til historikk / arkiv",
+    needsThomasReview: false,
+  }),
+  "raw-live-board": c({
+    mandatePlain: "Gammel live board wireframe — erstattet av roadmap-timeline.",
+    practicalHelp: "Ingen aktiv verdi — canonical er roadmap-siden.",
+    whatToDoHere: "Bruk /vis/system/roadmap-timeline-v01.",
+    whatNotToDoHere: "Ikke bruk som aktiv roadmap.",
+    functionalValue: ["historisk beslutningsgrunnlag"],
+    overlapKind: "reelt behov",
+    overlapNote: "Samme behov som roadmap — fullt erstattet.",
+    mergeRisk: "Har allerede retired-banner i viewer. Sletting OK etter QA.",
+    futurePlacement: "vurder sletting senere",
+    migrationNote: "Redirect finnes delvis. QA inbound lenker før sletting.",
+    needsThomasReview: false,
+  }),
+  "mvp-current-state": c({
+    mandatePlain: "Data som driver MVP-status og sprint-info på forsiden.",
+    practicalHelp: "Operativ sannhet for «hvor står MVP» — ikke egen side.",
+    whatToDoHere: "Oppdater ved sprintskifte eller MVP-endring.",
+    whatNotToDoHere: "Ikke lag egen route — datakilde for kontrollrom.",
+    functionalValue: ["runtime-status", "god oversikt"],
+    overlapKind: "ingen",
+    overlapNote: "Backend for kontrollrom — ikke overlapp med brukerflate.",
+    mergeRisk: "Kritisk data — må bevares uansett tremeny.",
+    futurePlacement: "behold som egen flate",
+    migrationNote: "Forblir i mvp-current-state.ts. Dokumenter i page contract for /vis/.",
+    needsThomasReview: false,
+  }),
+  "vis-frontpage-hubs": c({
+    mandatePlain: "Definerer hub-kort på VIS-forsiden inntil tremeny finnes.",
+    practicalHelp: "Styrer hvilke flater som vises som kort på /vis/.",
+    whatToDoHere: "Oppdater ved IA-endring. Konsolider med tremeny-data senere.",
+    whatNotToDoHere: "Ikke la hub-kort og tremeny divergere permanent.",
+    functionalValue: ["navigasjonshjelp", "lenker"],
+    overlapKind: "route og behov",
+    overlapNote: "Samme behov som fremtidig tremeny — to kilder i dag.",
+    mergeRisk: "Slå sammen datakilder uten å miste hub-kort på forsiden under overgang.",
+    futurePlacement: "slå sammen med annen flate",
+    migrationNote: "vis-frontpage-hubs-v01.ts → vis-nav-tree.ts (forslag). Hub-kort filtreres fra tre.",
+    needsThomasReview: true,
+  }),
+};
+
+export function getVisIaConsolidation(id: string): VisIaConsolidationReadiness | undefined {
+  return visIaConsolidationById[id];
+}
+
+export function getVisIaThomasReviewEntries(): string[] {
+  return Object.entries(visIaConsolidationById)
+    .filter(([, c]) => c.needsThomasReview)
+    .map(([id]) => id);
+}
+
+export function getVisIaConsolidationByFuture(
+  placement: VisIaFuturePlacement,
+): string[] {
+  return Object.entries(visIaConsolidationById)
+    .filter(([, c]) => c.futurePlacement === placement)
+    .map(([id]) => id);
+}
+
+/** Tremodell v0.3 — etter mandat og konsolideringsvurdering. */
+export const visIaTreeProposalV03 = {
+  note: "Need-led tremodell etter Consolidation Readiness v0.3",
+  sections: [
+    {
+      id: "now",
+      label: "Nå — status og sprint",
+      topTasks: ["status-nå", "jobber-med"] as VisIaTopTask[],
+      items: [
+        { label: "VIS kontrollrom (forside)", href: "/vis/", note: "Aggregert inngang + feed + hub-kort" },
+        { label: "Sprint 2026-W21", href: "/vis/sprints/2026-w21/", note: "Aktiv sprint + labs" },
+      ],
+    },
+    {
+      id: "find",
+      label: "Finn riktig flate",
+      topTasks: ["finn-flate"] as VisIaTopTask[],
+      items: [
+        { label: "Designsystem", href: "/designsystem/", note: "Global canonical" },
+        { label: "Review / QA", href: "/vis/review/", note: "Under Design i tre" },
+        { label: "Redaksjonelle bilder", href: "/vis/assets/editorial", note: "Ett navn — ikke DAM vs Editorial" },
+        { label: "Gitbuss", href: "/vis/system/github-runtime-status", note: "Operativ GitHub" },
+        { label: "Roadmap", href: "/vis/system/roadmap-timeline-v01", note: "Retning — ikke sprint" },
+      ],
+    },
+    {
+      id: "understand",
+      label: "Forstå system og innhold",
+      topTasks: ["forstå-system"] as VisIaTopTask[],
+      items: [
+        { label: "Backstage", href: "/backstage/", note: "Canonical systemforklaring" },
+        { label: "IA-prinsipper", href: "/vis/system/ia-principles-v01" },
+        { label: "Hub Mandate", href: "/vis/system/hub-mandate-v01" },
+        { label: "Artikkel-system", href: "/vis/system/article/" },
+        { label: "Agent-kontekst", href: "/vis/system/control-center", note: "Rename fra Control Center" },
+      ],
+    },
+    {
+      id: "history",
+      label: "Historikk — begrunnelse og arkiv",
+      topTasks: ["historikk", "unngå-forveksling"] as VisIaTopTask[],
+      items: [
+        { label: "Raw wireframes", note: "public/vis/raw — status historical" },
+        { label: "Design System v01 (legacy)", href: "/vis/system/design-system-v01" },
+        { label: "Task bus live", href: "/vis/system/task-bus-live" },
+        { label: "Lukkede sprintvisninger", note: "Ved sprintskifte" },
+      ],
+    },
+  ],
+} as const;

--- a/src/data/vis-ia-inventory-v01.ts
+++ b/src/data/vis-ia-inventory-v01.ts
@@ -131,11 +131,11 @@ export const visIaTopTaskLabels: Record<VisIaTopTask, string> = {
 };
 
 export const visIaInventoryMeta = {
-  version: "v0.3",
+  version: "v0.3.1",
   updatedAt: "2026-05-31",
   purpose:
-    "Konsolideringsklarhet før trebasert lokalmeny i VIS. Analyse og anbefaling — ingen routes slettet, flyttet eller slått sammen fysisk.",
-  mandatePass: "VIS IA Consolidation Readiness v0.3",
+    "Konsolideringsklarhet før trebasert lokalmeny i VIS. Avklarte beslutninger innarbeidet — ingen routes endret.",
+  mandatePass: "VIS IA Consolidation Readiness v0.3.1",
 } as const;
 
 /** Forslag til maskinlesbart page contract for VIS-sider. */
@@ -227,7 +227,7 @@ export const visIaOverlapClusters: VisIaOverlapCluster[] = [
     conflict:
       "Backstage er canonical systemreferanse. Control Center er agent/prosjektkontekst. /vis/system/ er flat link-liste som dupliserer begge.",
     resolution:
-      "Backstage = canonical under «Forstå system». Control Center = agent-sekundær. Flat /vis/system/ → arkiver når tremeny finnes. IA-prinsipper beholdes som dokumentasjon, ikke hub.",
+      "Backstage = canonical under «Forstå system». Agentdrift / runbook = agent-sekundær (ikke «Control Center»). Flat /vis/system/ → arkiver når tremeny finnes.",
   },
   {
     id: "roadmap-sprint-github",
@@ -252,7 +252,7 @@ export const visIaOverlapClusters: VisIaOverlapCluster[] = [
     title: "DAM / bildebank vs Editorial Image Library",
     surfaces: ["DAM / Editorial Image Library", "VIS frontpage hubs registry"],
     conflict: "Hub-kort sier «DAM / bildebank», side sier «Editorial Image Library v0.2». Samme rute, ulike navn.",
-    resolution: "Én label: «Innhold og assets» eller «Redaksjonelle bilder». Slå sammen hub-registry med fremtidig tre-data.",
+    resolution: "Én flate: hovedlabel «Redaksjonelle bilder», sekundær «DAM / bildebank». Hub-registry konsolideres i VIS Tree Navigation v0.1.",
   },
   {
     id: "sprint-active-history",
@@ -318,9 +318,9 @@ export const visIaTreeProposalV02: VisIaTreeNode[] = [
   },
   {
     id: "task-navigate",
-    label: "Finn flate — arbeidsområder",
+    label: "Arbeidsflater",
     primaryTask: "finn-flate",
-    note: "Top task 3: rask navigasjon til riktig intern sone",
+    note: "Top task 3 — navigasjonskategori (ikke «Finn flate»)",
     children: [
       {
         id: "design",
@@ -334,7 +334,7 @@ export const visIaTreeProposalV02: VisIaTreeNode[] = [
         id: "content",
         label: "Innhold og assets",
         children: [
-          { id: "dam", label: "Redaksjonelle bilder", href: "/vis/assets/editorial", note: "Slå sammen DAM + Editorial label" },
+          { id: "dam", label: "Redaksjonelle bilder", href: "/vis/assets/editorial", note: "Sekundær: DAM / bildebank" },
         ],
       },
       {
@@ -362,7 +362,7 @@ export const visIaTreeProposalV02: VisIaTreeNode[] = [
         href: "/vis/system/article/",
         note: "Foundations, components, templates, changelog",
       },
-      { id: "control-center", label: "Control Center (agenter)", href: "/vis/system/control-center", note: "Sekundær — Cursor/@rigger" },
+      { id: "control-center", label: "Agentdrift / runbook", href: "/vis/system/control-center", note: "Under Forstå system — ikke Control Center" },
     ],
   },
   {
@@ -466,8 +466,8 @@ export const visIaConsolidationNotes: VisIaConsolidationNote[] = [
   {
     id: "dam-editorial",
     title: "DAM / bildebank vs Editorial Image Library",
-    recommendation: "Slå sammen label → «Redaksjonelle bilder» eller «Innhold og assets»",
-    rationale: "Samme rute /vis/assets/editorial — én node, ett navn.",
+    recommendation: "Behold én flate — hovedlabel «Redaksjonelle bilder», sekundær «DAM / bildebank»",
+    rationale: "Avklart: ett område. Kun label oppdateres ved tremeny — innhold bevares.",
     surfaces: ["DAM / Editorial Image Library", "VIS frontpage hubs registry"],
   },
   {
@@ -494,8 +494,8 @@ export const visIaConsolidationNotes: VisIaConsolidationNote[] = [
   {
     id: "frontpage-hubs-merge",
     title: "vis-frontpage-hubs-v01.ts",
-    recommendation: "Slå sammen med fremtidig tre-data i v0.3",
-    rationale: "Hub-kort og tremeny definerer samme flater — én kilde.",
+    recommendation: "Konsolider i VIS Tree Navigation v0.1 — én datakilde med tremeny",
+    rationale: "Avklart: unngå parallelle sannheter mellom frontpage, hub-kort og lokalmeny.",
     surfaces: ["VIS frontpage hubs registry"],
   },
 ];
@@ -762,7 +762,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "canonical-external",
     status: "canonical",
     currentPlacement: "Global intern rute + primær VIS-hub",
-    suggestedPlacement: "Finn flate → Design → Designsystem",
+    suggestedPlacement: "Arbeidsflater → Design → Designsystem",
     recommendation: "behold",
     rationale: "Canonical UI/mønstre.",
     mandate: M.designsystem,
@@ -788,7 +788,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "runtime-tool",
     status: "active",
     currentPlacement: "VIS system — primær hub «Gitbuss»",
-    suggestedPlacement: "Finn flate → Operativt → Gitbuss",
+    suggestedPlacement: "Arbeidsflater → Operativt → Gitbuss",
     recommendation: "behold",
     rationale: "GitHub-feed — ikke kontrollrom.",
     mandate: M.gitbuss,
@@ -801,7 +801,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "runtime-tool",
     status: "active",
     currentPlacement: "VIS system — primær hub",
-    suggestedPlacement: "Finn flate → Operativt → Roadmap",
+    suggestedPlacement: "Arbeidsflater → Operativt → Roadmap",
     recommendation: "behold",
     rationale: "Retning/faser — ikke sprint-backlog.",
     mandate: M.roadmap,
@@ -810,13 +810,13 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     id: "dam-editorial",
     route: "/vis/assets/editorial",
     sourceFile: "src/pages/vis/assets/editorial.astro",
-    title: "DAM / Editorial Image Library",
+    title: "Redaksjonelle bilder",
     surfaceType: "assets",
     status: "active",
-    currentPlacement: "Sekundær hub «DAM / bildebank»",
-    suggestedPlacement: "Finn flate → Innhold og assets",
-    recommendation: "slå sammen",
-    rationale: "Hub-navn og sideinnhold — konsolider label.",
+    currentPlacement: "Sekundær hub — label oppdateres til «Redaksjonelle bilder» (sekundær: DAM / bildebank)",
+    suggestedPlacement: "Arbeidsflater → Redaksjonelle bilder",
+    recommendation: "behold",
+    rationale: "Avklart ett område. Editorial Image Library UI bevares — kun navn harmoniseres.",
     mandate: M.dam,
   },
   {
@@ -827,7 +827,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "review",
     status: "active",
     currentPlacement: "Sekundær hub",
-    suggestedPlacement: "Finn flate → Design og QA → Review",
+    suggestedPlacement: "Arbeidsflater → Design og QA → Review",
     recommendation: "flytt under",
     rationale: "QA hører til design-spor.",
     mandate: M.review,
@@ -927,13 +927,13 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     id: "control-center",
     route: "/vis/system/control-center",
     sourceFile: "src/pages/vis/system/control-center.astro",
-    title: "Viddel Control Center",
+    title: "Agentdrift / runbook",
     surfaceType: "system-doc",
     status: "reference",
-    currentPlacement: "VIS system — featured inngang",
-    suggestedPlacement: "Forstå system → Control Center (sekundær)",
+    currentPlacement: "VIS system — route /vis/system/control-center",
+    suggestedPlacement: "Forstå system → Agentdrift / runbook",
     recommendation: "behold",
-    rationale: "Agent-kontekst — ikke Thomas daglig.",
+    rationale: "Avklart: ikke «Control Center». Behold agent-runbook under Forstå system.",
     mandate: M.controlCenter,
   },
   {
@@ -953,7 +953,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     id: "ia-inventory",
     route: "/vis/system/ia-inventory-v01",
     sourceFile: "src/pages/vis/system/ia-inventory-v01.astro",
-    title: "VIS IA Inventory v0.3",
+    title: "VIS IA Inventory v0.3.1",
     surfaceType: "system-doc",
     status: "active",
     currentPlacement: "VIS system (meta)",
@@ -1219,7 +1219,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     currentPlacement: "Data — driver hub-kort på /vis/",
     suggestedPlacement: "Konsolider med tremeny-data",
     recommendation: "slå sammen",
-    rationale: "Overlapper med fremtidig tre.",
+    rationale: "Konsolideres med tremeny i VIS Tree Navigation v0.1 — avklart neste steg.",
     mandate: M.hubsRegistry,
   },
 ];

--- a/src/data/vis-ia-inventory-v01.ts
+++ b/src/data/vis-ia-inventory-v01.ts
@@ -1,4 +1,9 @@
-/* CONTRACT: VIS IA Inventory v0.2 — kartlegging, mandatvurdering og foreslått tremeny (analyse, ikke implementasjon). */
+/* CONTRACT: VIS IA Inventory v0.3 — kartlegging, mandat og konsolideringsklarhet (analyse, ikke implementasjon). */
+
+import {
+  visIaConsolidationById,
+  type VisIaConsolidationReadiness,
+} from "./vis-ia-consolidation-v03.ts";
 
 export type VisIaStatus =
   | "active"
@@ -79,6 +84,10 @@ export type VisIaEntry = {
   mandate: VisIaMandate;
 };
 
+export type VisIaEntryFull = VisIaEntry & {
+  consolidation: VisIaConsolidationReadiness;
+};
+
 export type VisIaTreeNode = {
   id: string;
   label: string;
@@ -122,11 +131,11 @@ export const visIaTopTaskLabels: Record<VisIaTopTask, string> = {
 };
 
 export const visIaInventoryMeta = {
-  version: "v0.2",
+  version: "v0.3",
   updatedAt: "2026-05-31",
   purpose:
-    "Mandatpass og kartlegging før trebasert lokalmeny i VIS. Analyse og forslag — ingen routes slettet eller flyttet.",
-  mandatePass: "VIS IA Mandate Pass v0.2",
+    "Konsolideringsklarhet før trebasert lokalmeny i VIS. Analyse og anbefaling — ingen routes slettet, flyttet eller slått sammen fysisk.",
+  mandatePass: "VIS IA Consolidation Readiness v0.3",
 } as const;
 
 /** Forslag til maskinlesbart page contract for VIS-sider. */
@@ -944,7 +953,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     id: "ia-inventory",
     route: "/vis/system/ia-inventory-v01",
     sourceFile: "src/pages/vis/system/ia-inventory-v01.astro",
-    title: "VIS IA Inventory v0.2",
+    title: "VIS IA Inventory v0.3",
     surfaceType: "system-doc",
     status: "active",
     currentPlacement: "VIS system (meta)",
@@ -1217,6 +1226,28 @@ export const visIaInventoryEntries: VisIaEntry[] = [
 
 export function getVisIaInventoryEntries(): VisIaEntry[] {
   return visIaInventoryEntries;
+}
+
+export function getVisIaInventoryEntriesFull(): VisIaEntryFull[] {
+  return visIaInventoryEntries.map((entry) => ({
+    ...entry,
+    consolidation: visIaConsolidationById[entry.id] ?? {
+      mandatePlain: entry.mandate.userNeed,
+      practicalHelp: entry.mandate.coreContent,
+      whatToDoHere: entry.mandate.postUseAction,
+      whatNotToDoHere: "—",
+      functionalValue: [],
+      overlapKind: "ingen" as const,
+      overlapNote: entry.mandate.overlappingSurfaces.join(", ") || "—",
+      mergeRisk: "Ikke vurdert",
+      futurePlacement: "trenger Thomas-avklaring" as const,
+      needsThomasReview: true,
+    },
+  }));
+}
+
+export function getVisIaThomasReviewEntries(): VisIaEntryFull[] {
+  return getVisIaInventoryEntriesFull().filter((e) => e.consolidation.needsThomasReview);
 }
 
 export function getVisIaEntriesByStatus(status: VisIaStatus): VisIaEntry[] {

--- a/src/data/vis-ia-inventory-v01.ts
+++ b/src/data/vis-ia-inventory-v01.ts
@@ -1,4 +1,4 @@
-/* CONTRACT: VIS IA Inventory v0.1 — kartlegging av flater, status og foreslått tremeny (analyse, ikke implementasjon). */
+/* CONTRACT: VIS IA Inventory v0.2 — kartlegging, mandatvurdering og foreslått tremeny (analyse, ikke implementasjon). */
 
 export type VisIaStatus =
   | "active"
@@ -13,9 +13,29 @@ export type VisIaStatus =
 export type VisIaRecommendation =
   | "behold"
   | "slå sammen"
-  | "flytt"
+  | "flytt under"
   | "arkiver"
-  | "vurder sletting";
+  | "vurder sletting"
+  | "trenger avklaring";
+
+/** Top tasks VIS skal støtte — grunnlag for tremodell v0.2. */
+export type VisIaTopTask =
+  | "status-nå"
+  | "jobber-med"
+  | "finn-flate"
+  | "beslutninger-qa"
+  | "forstå-system"
+  | "historikk"
+  | "unngå-forveksling";
+
+export type VisIaAudience = "Thomas" | "Vibeke" | "Cursor" | "@rigger" | "@navigator";
+
+export type VisIaHubPlacement =
+  | "egen hub"
+  | "seksjon under annen hub"
+  | "ren historikk"
+  | "skjult/arkivert"
+  | "vurdert slettet senere";
 
 export type VisIaSurfaceType =
   | "kontrollrom"
@@ -31,6 +51,20 @@ export type VisIaSurfaceType =
   | "wireframe-raw"
   | "placeholder";
 
+export type VisIaMandate = {
+  userNeed: string;
+  primaryTask: VisIaTopTask;
+  secondaryTask?: VisIaTopTask;
+  audience: VisIaAudience[];
+  coreContent: string;
+  postUseAction: string;
+  overlappingSurfaces: string[];
+  hubPlacement: VisIaHubPlacement;
+  mandateRecommendation: VisIaRecommendation;
+  needsPageContract: boolean;
+  pageContractNote?: string;
+};
+
 export type VisIaEntry = {
   id: string;
   route: string;
@@ -42,6 +76,7 @@ export type VisIaEntry = {
   suggestedPlacement: string;
   recommendation: VisIaRecommendation;
   rationale: string;
+  mandate: VisIaMandate;
 };
 
 export type VisIaTreeNode = {
@@ -49,6 +84,7 @@ export type VisIaTreeNode = {
   label: string;
   href?: string;
   note?: string;
+  primaryTask?: VisIaTopTask;
   children?: VisIaTreeNode[];
 };
 
@@ -57,16 +93,294 @@ export type VisIaConsolidationNote = {
   title: string;
   recommendation: string;
   rationale: string;
+  surfaces?: string[];
+};
+
+export type VisIaOverlapCluster = {
+  id: string;
+  title: string;
+  surfaces: string[];
+  conflict: string;
+  resolution: string;
+};
+
+export type VisIaPageContractField = {
+  field: string;
+  required: boolean;
+  description: string;
+  example?: string;
+};
+
+export const visIaTopTaskLabels: Record<VisIaTopTask, string> = {
+  "status-nå": "1. Se hvor prosjektet står akkurat nå",
+  "jobber-med": "2. Se hva vi jobber med og hva som nettopp er ferdig",
+  "finn-flate": "3. Finne riktig intern flate raskt",
+  "beslutninger-qa": "4. Ta beslutninger / QA",
+  "forstå-system": "5. Forstå system, design og innhold uten GitHub",
+  historikk: "6. Finne historikk når vi trenger begrunnelse",
+  "unngå-forveksling": "7. Unngå at gamle prototyper forveksles med sannhet",
 };
 
 export const visIaInventoryMeta = {
-  version: "v0.1",
+  version: "v0.2",
   updatedAt: "2026-05-31",
   purpose:
-    "Kartlegging før trebasert lokalmeny i VIS. Analyse og forslag — ingen routes slettet eller flyttet.",
+    "Mandatpass og kartlegging før trebasert lokalmeny i VIS. Analyse og forslag — ingen routes slettet eller flyttet.",
+  mandatePass: "VIS IA Mandate Pass v0.2",
 } as const;
 
-/** Foreslått tremeny v0.1 — Thomas QA før implementasjon. */
+/** Forslag til maskinlesbart page contract for VIS-sider. */
+export const visIaPageContractProposal: VisIaPageContractField[] = [
+  {
+    field: "title",
+    required: true,
+    description: "Menneskelig sidetittel",
+    example: "Sprint lab — Color",
+  },
+  {
+    field: "type",
+    required: true,
+    description: "Surface-type: kontrollrom, sprint-lab, system-doc, review, assets, wireframe, …",
+    example: "sprint-lab",
+  },
+  {
+    field: "status",
+    required: true,
+    description: "active | canonical | lab | reference | historical | legacy",
+    example: "lab",
+  },
+  {
+    field: "purpose",
+    required: true,
+    description: "Én setning: hva siden er til for",
+    example: "Beslutningsgrunnlag for fargepalett i MVP Design Lock",
+  },
+  {
+    field: "primaryTask",
+    required: true,
+    description: "Primær top task fra visIaTopTaskLabels",
+    example: "beslutninger-qa",
+  },
+  {
+    field: "audience",
+    required: true,
+    description: "Kommaseparert målgruppe",
+    example: "Thomas,Vibeke",
+  },
+  {
+    field: "canonicalSource",
+    required: false,
+    description: "URL eller datafil som er operativ sannhet hvis siden er lab/legacy",
+    example: "/designsystem/",
+  },
+  {
+    field: "relatedArea",
+    required: false,
+    description: "ID-er til overlappende flater i inventaret",
+    example: "designsystem,review",
+  },
+  {
+    field: "lastReviewed",
+    required: true,
+    description: "ISO-dato for siste mandatvurdering",
+    example: "2026-05-31",
+  },
+];
+
+/** Eksempel på page contract som frontmatter eller eksportert konstant. */
+export const visIaPageContractExample = {
+  title: "Sprint lab — Color",
+  type: "sprint-lab",
+  status: "lab",
+  purpose: "Beslutningsgrunnlag for fargepalett i MVP Design Lock",
+  primaryTask: "beslutninger-qa",
+  audience: ["Thomas", "Vibeke"],
+  canonicalSource: "/designsystem/",
+  relatedArea: ["designsystem", "review"],
+  lastReviewed: "2026-05-31",
+} as const;
+
+/** Overlap-analyse — dobbel konfekt og konflikter. */
+export const visIaOverlapClusters: VisIaOverlapCluster[] = [
+  {
+    id: "kontrollrom-gitbuss-feed",
+    title: "VIS kontrollrom vs Gitbuss vs Runtime Feed",
+    surfaces: ["VIS kontrollrom", "Runtime feed", "Gitbuss", "MVP current-state"],
+    conflict:
+      "Tre flater viser «prosjektstatus»: kontrollrom (MVP + feed), Gitbuss (GitHub runtime), Runtime feed (manuell agent-status). Risiko for at Thomas leser én og tror det er full bilde.",
+    resolution:
+      "Kontrollrom = aggregert «nå» (feed + MVP). Gitbuss = dypere GitHub-detalj under System. Runtime feed = kort manuell kommunikasjon, ikke erstatning for Gitbuss. Merk roller tydelig i page contract.",
+  },
+  {
+    id: "backstage-control-system",
+    title: "Backstage vs Control Center vs /vis/system/",
+    surfaces: ["Backstage", "Viddel Control Center", "Systemreferanse (legacy hub)", "IA-prinsipper"],
+    conflict:
+      "Backstage er canonical systemreferanse. Control Center er agent/prosjektkontekst. /vis/system/ er flat link-liste som dupliserer begge.",
+    resolution:
+      "Backstage = canonical under «Forstå system». Control Center = agent-sekundær. Flat /vis/system/ → arkiver når tremeny finnes. IA-prinsipper beholdes som dokumentasjon, ikke hub.",
+  },
+  {
+    id: "roadmap-sprint-github",
+    title: "Roadmap vs Sprint vs GitHub Projects",
+    surfaces: ["Roadmap timeline", "Sprint 2026-W21", "Gitbuss", "KlarLyd Live Board (legacy)"],
+    conflict:
+      "Roadmap = retning/faser. Sprint = aktivt designarbeid denne uken. Gitbuss = issues/PR nå. Live Board wireframe dupliserer roadmap.",
+    resolution:
+      "Tre nivåer i tre: Nå (sprint + feed) → Retning (roadmap) → Operativt (Gitbuss). Live Board → vurder sletting. GitHub Projects = ekstern kilde, ikke egen VIS-side.",
+  },
+  {
+    id: "design-trio",
+    title: "Designsystem vs Review vs design-system-v01",
+    surfaces: ["Designsystem", "Review", "Design System Overview (VIS legacy)"],
+    conflict:
+      "To designreferanser: /designsystem/ (canonical) og /vis/system/design-system-v01 (legacy). Review peker til sprint-labs og QA — overlapper med designsystem for visuell sannhet.",
+    resolution:
+      "Designsystem = canonical. Review = QA-inngang under Design. design-system-v01 → arkiv med tydelig «ikke canonical»-merke.",
+  },
+  {
+    id: "dam-editorial",
+    title: "DAM / bildebank vs Editorial Image Library",
+    surfaces: ["DAM / Editorial Image Library", "VIS frontpage hubs registry"],
+    conflict: "Hub-kort sier «DAM / bildebank», side sier «Editorial Image Library v0.2». Samme rute, ulike navn.",
+    resolution: "Én label: «Innhold og assets» eller «Redaksjonelle bilder». Slå sammen hub-registry med fremtidig tre-data.",
+  },
+  {
+    id: "sprint-active-history",
+    title: "Sprint 2026-W21 vs sprint-historikk",
+    surfaces: ["Sprint 2026-W21", "Sprint 01 Foundation (arkiv)", "Lukkede sprintvisninger (plan)"],
+    conflict:
+      "Aktiv sprint er primær hub i dag. Eldre sprint-HTML i raw/ kan forveksles med aktiv sprint-lab.",
+    resolution:
+      "Aktiv sprint under «Nå og sprint». Ved sprintskifte → flytt til Historikk. Raw sprint-arkiv merkes «lukket» og «ikke aktiv beslutningsflate».",
+  },
+  {
+    id: "wireframes-vs-labs",
+    title: "Raw wireframes vs aktive beslutningsflater",
+    surfaces: ["Raw HTML wireframes", "Sprint labs", "/vis/artikkel", "/vis/hub"],
+    conflict:
+      "10+ eldre HTML-wireframes og tomme placeholders kan oppleves som gjeldende produkt. Sprint-labs er derimot aktive beslutningsflater.",
+    resolution:
+      "Wireframes + placeholders kun i Historikk/arkiv. Sprint-labs merkes «lab» og «aktiv beslutning». Page contract status=historical|legacy for alt arkivert.",
+  },
+  {
+    id: "placeholders",
+    title: "/vis/artikkel og /vis/hub placeholders",
+    surfaces: ["VIS wireframe — Artikkel", "VIS wireframe — NAV-Hub"],
+    conflict: "Tomme Astro-placeholders på rot-nivå — ingen innhold, kan forveksles med production /no/.",
+    resolution: "Vurder sletting eller omdiriger til arkiv. Fjern fra hub-kort og primær nav.",
+  },
+];
+
+/** Foreslått tremeny v0.2 — organisert etter top tasks, ikke bare routes. */
+export const visIaTreeProposalV02: VisIaTreeNode[] = [
+  {
+    id: "task-now",
+    label: "Nå — status og sprint",
+    primaryTask: "status-nå",
+    note: "Top task 1+2: hvor står vi, hva jobber vi med",
+    children: [
+      {
+        id: "kontrollrom",
+        label: "VIS kontrollrom",
+        href: "/vis/",
+        note: "Aggregert inngang — MVP-status + runtime feed",
+      },
+      {
+        id: "runtime-feed",
+        label: "Runtime feed (innebygd)",
+        note: "Manuell «Akkurat nå» — ikke egen route",
+      },
+      {
+        id: "sprint-active",
+        label: "Sprint 2026-W21",
+        href: "/vis/sprints/2026-w21/",
+        note: "Aktiv sprint + labs — beslutningsflater",
+        children: [
+          { id: "sprint-color", label: "Color", href: "/vis/sprints/2026-w21/color/" },
+          { id: "sprint-typography", label: "Typography", href: "/vis/sprints/2026-w21/typography/" },
+          { id: "sprint-hub-types", label: "Hub types", href: "/vis/sprints/2026-w21/hub-types/" },
+          { id: "sprint-editorial-hub", label: "Editorial hub", href: "/vis/sprints/2026-w21/editorial-hub/" },
+          { id: "sprint-frontpage-mandate", label: "Frontpage mandate", href: "/vis/sprints/2026-w21/frontpage-mandate/" },
+          { id: "sprint-primitives", label: "Primitives", href: "/vis/sprints/2026-w21/primitives/" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "task-navigate",
+    label: "Finn flate — arbeidsområder",
+    primaryTask: "finn-flate",
+    note: "Top task 3: rask navigasjon til riktig intern sone",
+    children: [
+      {
+        id: "design",
+        label: "Design og QA",
+        children: [
+          { id: "designsystem", label: "Designsystem (canonical)", href: "/designsystem/" },
+          { id: "review", label: "Review / QA", href: "/vis/review/", note: "Under Design — ikke egen hub" },
+        ],
+      },
+      {
+        id: "content",
+        label: "Innhold og assets",
+        children: [
+          { id: "dam", label: "Redaksjonelle bilder", href: "/vis/assets/editorial", note: "Slå sammen DAM + Editorial label" },
+        ],
+      },
+      {
+        id: "operativt",
+        label: "Operativt og GitHub",
+        children: [
+          { id: "gitbuss", label: "Gitbuss", href: "/vis/system/github-runtime-status", note: "Issues/PR — ikke kontrollrom" },
+          { id: "roadmap", label: "Roadmap", href: "/vis/system/roadmap-timeline-v01", note: "Retning/faser — ikke sprint-backlog" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "task-understand",
+    label: "Forstå system",
+    primaryTask: "forstå-system",
+    note: "Top task 5: system, design og innhold uten GitHub-graving",
+    children: [
+      { id: "backstage", label: "Backstage (canonical)", href: "/backstage/", note: "AI/API/guard — primær systemreferanse" },
+      { id: "ia-principles", label: "IA-prinsipper", href: "/vis/system/ia-principles-v01" },
+      { id: "hub-mandate", label: "Hub Mandate", href: "/vis/system/hub-mandate-v01" },
+      {
+        id: "article-docs",
+        label: "Artikkel-system",
+        href: "/vis/system/article/",
+        note: "Foundations, components, templates, changelog",
+      },
+      { id: "control-center", label: "Control Center (agenter)", href: "/vis/system/control-center", note: "Sekundær — Cursor/@rigger" },
+    ],
+  },
+  {
+    id: "task-history",
+    label: "Historikk og arkiv",
+    primaryTask: "historikk",
+    note: "Top task 6+7: begrunnelse og unngå forveksling",
+    children: [
+      { id: "raw-wireframes", label: "Raw wireframes (HTML)", note: "public/vis/raw — status historical" },
+      { id: "legacy-design-v01", label: "Design System v01 (legacy)", href: "/vis/system/design-system-v01" },
+      { id: "task-bus-live", label: "Task bus live (pensjonert)", href: "/vis/system/task-bus-live" },
+      { id: "closed-sprints", label: "Lukkede sprintvisninger", note: "Ved sprintskifte" },
+      { id: "strategi-notion", label: "Strategisk IA v5 (arkiv)", note: "Erstattet av ia-principles" },
+    ],
+  },
+  {
+    id: "task-meta",
+    label: "Meta / IA-arbeid",
+    primaryTask: "finn-flate",
+    note: "Internt — kan skjules i prod-meny",
+    children: [
+      { id: "ia-inventory", label: "IA Inventory v0.2", href: "/vis/system/ia-inventory-v01" },
+    ],
+  },
+];
+
+/** v0.1 route-basert tre — beholdt for sammenligning. */
 export const visIaTreeProposal: VisIaTreeNode[] = [
   {
     id: "kontrollrom",
@@ -77,96 +391,40 @@ export const visIaTreeProposal: VisIaTreeNode[] = [
         id: "now-sprint",
         label: "Nå og sprint",
         children: [
-          {
-            id: "runtime-feed",
-            label: "Runtime feed",
-            note: "Innebygd i /vis/ — data i vis-runtime-feed.ts",
-          },
-          {
-            id: "sprint-active",
-            label: "Sprint 2026-W21",
-            href: "/vis/sprints/2026-w21/",
-            note: "Aktiv sprint — labs under denne noden i detaljvisning",
-          },
+          { id: "runtime-feed", label: "Runtime feed", note: "Innebygd i /vis/" },
+          { id: "sprint-active", label: "Sprint 2026-W21", href: "/vis/sprints/2026-w21/" },
         ],
       },
       {
         id: "system",
         label: "System",
         children: [
-          {
-            id: "backstage",
-            label: "Backstage",
-            href: "/backstage/",
-            note: "Egen global rute — vises i VIS-tre som systemreferanse",
-          },
-          {
-            id: "gitbuss",
-            label: "Gitbuss",
-            href: "/vis/system/github-runtime-status",
-          },
-          {
-            id: "roadmap",
-            label: "Roadmap",
-            href: "/vis/system/roadmap-timeline-v01",
-          },
-          {
-            id: "control-center",
-            label: "Control Center",
-            href: "/vis/system/control-center",
-            note: "Prosjektkontekst for agenter — sekundær inngang",
-          },
+          { id: "backstage", label: "Backstage", href: "/backstage/" },
+          { id: "gitbuss", label: "Gitbuss", href: "/vis/system/github-runtime-status" },
+          { id: "roadmap", label: "Roadmap", href: "/vis/system/roadmap-timeline-v01" },
+          { id: "control-center", label: "Control Center", href: "/vis/system/control-center" },
         ],
       },
       {
         id: "design",
         label: "Design",
         children: [
-          {
-            id: "designsystem",
-            label: "Designsystem",
-            href: "/designsystem/",
-            note: "Egen global canonical rute — vises i VIS-tre",
-          },
-          {
-            id: "review",
-            label: "Review",
-            href: "/vis/review/",
-            note: "QA-innganger — under Design, ikke egen topp-hub",
-          },
+          { id: "designsystem", label: "Designsystem", href: "/designsystem/" },
+          { id: "review", label: "Review", href: "/vis/review/" },
         ],
       },
       {
         id: "content-assets",
         label: "Innhold og assets",
-        children: [
-          {
-            id: "dam",
-            label: "DAM / bildebank",
-            href: "/vis/assets/editorial",
-            note: "Slå sammen navn med Editorial Image Library",
-          },
-        ],
+        children: [{ id: "dam", label: "DAM / bildebank", href: "/vis/assets/editorial" }],
       },
       {
         id: "archive",
         label: "Historikk / arkiv",
         children: [
-          {
-            id: "raw-wireframes",
-            label: "Raw wireframes (HTML)",
-            note: "public/vis/raw + /vis/[slug] — kun via arkiv/details",
-          },
-          {
-            id: "legacy-system",
-            label: "Legacy system-docs",
-            note: "design-system-v01, task-bus-live, m.fl.",
-          },
-          {
-            id: "closed-sprints",
-            label: "Lukkede sprintvisninger",
-            note: "Når currentSprint.status = closed",
-          },
+          { id: "raw-wireframes", label: "Raw wireframes (HTML)" },
+          { id: "legacy-system", label: "Legacy system-docs" },
+          { id: "closed-sprints", label: "Lukkede sprintvisninger" },
         ],
       },
     ],
@@ -175,48 +433,290 @@ export const visIaTreeProposal: VisIaTreeNode[] = [
 
 export const visIaConsolidationNotes: VisIaConsolidationNote[] = [
   {
+    id: "kontrollrom-gitbuss-feed",
+    title: "Kontrollrom ≠ Gitbuss ≠ Runtime Feed",
+    recommendation: "Behold alle tre — tydeliggjør roller i page contract og VIS-header",
+    rationale:
+      "Kontrollrom aggregerer. Feed = manuell kortstatus. Gitbuss = GitHub-detalj. Ikke slå sammen — merk mandat.",
+    surfaces: ["VIS kontrollrom", "Runtime feed", "Gitbuss"],
+  },
+  {
     id: "designsystem-global",
     title: "/designsystem/ som global intern flate",
-    recommendation: "Behold egen rute; vis som tre-node under Design",
-    rationale:
-      "Canonical UI-referanse brukes også utenfor VIS. Tremeny lenker hit — flytter ikke innhold inn i /vis/.",
+    recommendation: "Behold egen rute; canonical under Design i tre v0.2",
+    rationale: "Canonical UI-referanse. Review peker hit for visuell sannhet.",
+    surfaces: ["Designsystem", "Review"],
   },
   {
     id: "backstage-global",
-    title: "/backstage/ som global intern flate",
-    recommendation: "Behold egen rute; vis som tre-node under System",
-    rationale:
-      "Systemreferanse for AI/API/guard. Samme mønster som designsystem — egen URL, VIS-tre peker hit.",
+    title: "/backstage/ som canonical systemreferanse",
+    recommendation: "Behold egen rute; erstatt ikke med Control Center",
+    rationale: "Backstage = Thomas/Vibeke + agenter. Control Center = sekundær agentkontekst.",
+    surfaces: ["Backstage", "Viddel Control Center"],
   },
   {
     id: "dam-editorial",
     title: "DAM / bildebank vs Editorial Image Library",
-    recommendation: "Slå sammen til ett område: «Innhold og assets»",
-    rationale:
-      "Hub heter DAM; ruten er /vis/assets/editorial med Editorial Image Library v0.2. Samme funksjon — én node i tre.",
+    recommendation: "Slå sammen label → «Redaksjonelle bilder» eller «Innhold og assets»",
+    rationale: "Samme rute /vis/assets/editorial — én node, ett navn.",
+    surfaces: ["DAM / Editorial Image Library", "VIS frontpage hubs registry"],
   },
   {
     id: "review-under-design",
     title: "Review-plassering",
-    recommendation: "Under Design — ikke egen primær hub",
-    rationale:
-      "Review er QA/godkjenning av design/spinter, ikke eget arbeidsområde. Sekundær hub i dag er riktig.",
+    recommendation: "Flytt under Design i tre — ikke egen primær hub",
+    rationale: "QA/godkjenning, ikke eget arbeidsområde. Top task: beslutninger-qa.",
+    surfaces: ["Review", "Sprint labs"],
   },
   {
-    id: "sprint-under-now",
-    title: "Sprint 2026-W21",
-    recommendation: "Under «Nå og sprint» mens aktiv",
-    rationale:
-      "Matcher mvp-current-state.currentSprint og VIS sprint guard. Ved sprintskifte → Historikk.",
+    id: "system-index-archive",
+    title: "Flat /vis/system/ hub",
+    recommendation: "Arkiver når tremeny v0.2 implementeres",
+    rationale: "Dupliserer tre. Behold som fallback til overgang.",
+    surfaces: ["Systemreferanse (legacy hub)"],
   },
   {
     id: "raw-archive-only",
-    title: "Raw VIS HTML",
-    recommendation: "Kun Historikk / arkiv — ikke primær nav",
-    rationale:
-      "10+ eldre wireframes/strategidok i public/vis/raw. Nyttig referanse, men skal ikke konkurrere med kontrollrom.",
+    title: "Raw VIS HTML + placeholders",
+    recommendation: "Kun Historikk — vurder sletting av /vis/artikkel og /vis/hub",
+    rationale: "Top task 7: unngå forveksling med /no/ og aktive labs.",
+    surfaces: ["Raw HTML wireframes", "VIS wireframe — Artikkel", "VIS wireframe — NAV-Hub"],
+  },
+  {
+    id: "frontpage-hubs-merge",
+    title: "vis-frontpage-hubs-v01.ts",
+    recommendation: "Slå sammen med fremtidig tre-data i v0.3",
+    rationale: "Hub-kort og tremeny definerer samme flater — én kilde.",
+    surfaces: ["VIS frontpage hubs registry"],
   },
 ];
+
+const M = {
+  visFrontpage: {
+    userNeed: "Få et raskt overblikk over prosjektstatus uten å åpne GitHub eller grave i filer",
+    primaryTask: "status-nå" as VisIaTopTask,
+    secondaryTask: "jobber-med" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke"] as VisIaAudience[],
+    coreContent: "MVP current-state, runtime feed, hub-kort til arbeidsområder",
+    postUseAction: "Velg neste flate (sprint, review, system) basert på hva som trengs nå",
+    overlappingSurfaces: ["Runtime feed", "Gitbuss", "MVP current-state"],
+    hubPlacement: "egen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "type=kontrollrom, status=active, canonicalSource=mvp-current-state.ts",
+  },
+  runtimeFeed: {
+    userNeed: "Se hva agent/team kommuniserer akkurat nå i menneskelig språk",
+    primaryTask: "status-nå" as VisIaTopTask,
+    secondaryTask: "jobber-med" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke"] as VisIaAudience[],
+    coreContent: "Headline, why, nextDecision — manuell data i vis-runtime-feed.ts",
+    postUseAction: "Forstå neste beslutning; gå dypere via sprint eller Gitbuss hvis nødvendig",
+    overlappingSurfaces: ["VIS kontrollrom", "Gitbuss"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: false,
+    pageContractNote: "Datakilde, ikke egen side — dokumenter i vis-runtime-feed.ts",
+  },
+  designsystem: {
+    userNeed: "Finne canonical UI-mønstre, tokens og komponenter for produksjon",
+    primaryTask: "forstå-system" as VisIaTopTask,
+    secondaryTask: "finn-flate" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke", "Cursor", "@rigger"] as VisIaAudience[],
+    coreContent: "Tokens, komponenter, mønstre — production-ready referanse",
+    postUseAction: "Bruk mønstre i sprint-labs eller /no/ — ikke dupliser i VIS legacy",
+    overlappingSurfaces: ["Review", "Design System Overview (VIS legacy)", "Sprint labs"],
+    hubPlacement: "egen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "type=canonical-external, status=canonical",
+  },
+  backstage: {
+    userNeed: "Forstå hvordan AI, API og guardrails fungerer uten å lese repo-dokumentasjon",
+    primaryTask: "forstå-system" as VisIaTopTask,
+    secondaryTask: "finn-flate" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke", "Cursor", "@rigger", "@navigator"] as VisIaAudience[],
+    coreContent: "Operating rules, API-kontekst, agent-guardrails, Return Ticket-felt",
+    postUseAction: "Referer agenter hit; ta beslutninger om systemendringer informert",
+    overlappingSurfaces: ["Viddel Control Center", "Systemreferanse (legacy hub)"],
+    hubPlacement: "egen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "type=canonical-external, status=canonical",
+  },
+  gitbuss: {
+    userNeed: "Se operativ GitHub-status (issues, PR, merges) uten å åpne GitHub",
+    primaryTask: "jobber-med" as VisIaTopTask,
+    secondaryTask: "status-nå" as VisIaTopTask,
+    audience: ["Thomas", "Cursor", "@navigator"] as VisIaAudience[],
+    coreContent: "Generert feed fra GitHub — issues, PR, nylig aktivitet",
+    postUseAction: "Prioriter arbeid; koble til roadmap eller sprint hvis strategisk",
+    overlappingSurfaces: ["VIS kontrollrom", "Runtime feed", "Roadmap timeline"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "Ikke kontrollrom — merk «operativ GitHub-detalj»",
+  },
+  roadmap: {
+    userNeed: "Forstå retning og faser — ikke daglig task-backlog",
+    primaryTask: "forstå-system" as VisIaTopTask,
+    secondaryTask: "historikk" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke", "@navigator"] as VisIaAudience[],
+    coreContent: "Roadmap-tidslinje generert fra GitHub milestones/labels",
+    postUseAction: "Plasser sprint-arbeid i større bilde; unngå å blande med aktiv sprint",
+    overlappingSurfaces: ["Gitbuss", "Sprint 2026-W21", "KlarLyd Live Board (legacy)"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+  },
+  dam: {
+    userNeed: "Finne og velge redaksjonelle bilder for innhold",
+    primaryTask: "finn-flate" as VisIaTopTask,
+    secondaryTask: "beslutninger-qa" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke", "Cursor"] as VisIaAudience[],
+    coreContent: "Editorial Image Library v0.2 — bildebank for artikler",
+    postUseAction: "Velg bilde til innhold; referer i Storyblok/redaksjon",
+    overlappingSurfaces: ["VIS frontpage hubs registry"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "slå sammen" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "Én label — fjern DAM vs Editorial splitt",
+  },
+  review: {
+    userNeed: "QA og godkjenne design/spinter før de blir canonical",
+    primaryTask: "beslutninger-qa" as VisIaTopTask,
+    secondaryTask: "finn-flate" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke"] as VisIaAudience[],
+    coreContent: "Review-registry med lenker til sprint-labs og stakeholder-safe visninger",
+    postUseAction: "Godkjenn eller send tilbake; oppdater designsystem hvis canonical",
+    overlappingSurfaces: ["Designsystem", "Sprint labs", "Sprint lab — Hub types"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "flytt under" as VisIaRecommendation,
+    needsPageContract: true,
+  },
+  sprint: {
+    userNeed: "Se og jobbe med aktiv sprint — designbeslutninger denne uken",
+    primaryTask: "jobber-med" as VisIaTopTask,
+    secondaryTask: "beslutninger-qa" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke", "Cursor"] as VisIaAudience[],
+    coreContent: "Sprint 2026-W21 oversikt + lenker til labs",
+    postUseAction: "Åpne relevant lab; ta beslutning; oppdater review/designsystem",
+    overlappingSurfaces: ["Roadmap timeline", "Review", "MVP current-state"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "Ved sprintskifte: status→historical, flytt til arkiv-tre",
+  },
+  sprintLab: {
+    userNeed: "Vurdere konkret designbeslutning (farge, type, hub-type, …) i sprint",
+    primaryTask: "beslutninger-qa" as VisIaTopTask,
+    secondaryTask: "jobber-med" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke"] as VisIaAudience[],
+    coreContent: "Lab-spesifikt beslutningsgrunnlag og visualisering",
+    postUseAction: "Beslut; registrer i review; oppdater canonical kilde",
+    overlappingSurfaces: ["Designsystem", "Review"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "status=lab, canonicalSource=/designsystem/",
+  },
+  controlCenter: {
+    userNeed: "Agenter trenger prosjektkontekst og filpeker uten å søke i repo",
+    primaryTask: "forstå-system" as VisIaTopTask,
+    audience: ["Cursor", "@rigger", "@navigator"] as VisIaAudience[],
+    coreContent: "Prosjektkontekst, filreferanser, agent-instruksjoner",
+    postUseAction: "Start agent-oppgave informert; ikke bruk som Thomas' daglige inngang",
+    overlappingSurfaces: ["Backstage", "Systemreferanse (legacy hub)"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "audience primært agenter — sekundær i tre",
+  },
+  systemDoc: {
+    userNeed: "Finne canonical dokumentasjon for IA, hub-mandat eller artikkel-system",
+    primaryTask: "forstå-system" as VisIaTopTask,
+    secondaryTask: "historikk" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke", "Cursor"] as VisIaAudience[],
+    coreContent: "Strukturert dokumentasjon — prinsipper, mandat, komponenter",
+    postUseAction: "Referer ved beslutninger; oppdater ved endring i modell",
+    overlappingSurfaces: ["Backstage", "IA-prinsipper"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+  },
+  legacyDoc: {
+    userNeed: "Historisk referanse — ikke daglig bruk",
+    primaryTask: "historikk" as VisIaTopTask,
+    secondaryTask: "unngå-forveksling" as VisIaTopTask,
+    audience: ["Thomas", "Cursor"] as VisIaAudience[],
+    coreContent: "Utdatert dokumentasjon eller erstattet verktøy",
+    postUseAction: "Sjekk canonical erstatning; ikke bruk som sannhet",
+    overlappingSurfaces: ["Designsystem", "Gitbuss"],
+    hubPlacement: "ren historikk" as VisIaHubPlacement,
+    mandateRecommendation: "arkiver" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "status=legacy, canonicalSource peker til erstatning",
+  },
+  placeholder: {
+    userNeed: "Ingen — tom placeholder uten innhold",
+    primaryTask: "unngå-forveksling" as VisIaTopTask,
+    audience: [] as VisIaAudience[],
+    coreContent: "Tom Astro-side — ingen funksjon",
+    postUseAction: "Ikke bruk — gå til production /no/ eller sprint-labs",
+    overlappingSurfaces: ["Raw HTML wireframes"],
+    hubPlacement: "vurdert slettet senere" as VisIaHubPlacement,
+    mandateRecommendation: "vurder sletting" as VisIaRecommendation,
+    needsPageContract: false,
+  },
+  wireframe: {
+    userNeed: "Finne begrunnelse eller tidlig design når historikk trengs",
+    primaryTask: "historikk" as VisIaTopTask,
+    secondaryTask: "unngå-forveksling" as VisIaTopTask,
+    audience: ["Thomas", "Vibeke"] as VisIaAudience[],
+    coreContent: "Eldre HTML-wireframes og strategidokumenter",
+    postUseAction: "Sammenlign med canonical; ikke implementer direkte",
+    overlappingSurfaces: ["Sprint labs", "IA-prinsipper"],
+    hubPlacement: "ren historikk" as VisIaHubPlacement,
+    mandateRecommendation: "arkiver" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "status=historical, canonicalSource=/no/ eller ia-principles",
+  },
+  runtimeData: {
+    userNeed: "Datakilde — ikke egen brukerflate",
+    primaryTask: "status-nå" as VisIaTopTask,
+    audience: ["Cursor", "@rigger"] as VisIaAudience[],
+    coreContent: "TypeScript-registry som driver VIS UI",
+    postUseAction: "Oppdater ved endring i operativ sannhet",
+    overlappingSurfaces: ["VIS kontrollrom", "VIS frontpage hubs registry"],
+    hubPlacement: "seksjon under annen hub" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: false,
+  },
+  hubsRegistry: {
+    userNeed: "Definere hub-kort på kontrollrom — midlertidig til tremeny finnes",
+    primaryTask: "finn-flate" as VisIaTopTask,
+    audience: ["Cursor", "@rigger"] as VisIaAudience[],
+    coreContent: "Hub-definisjoner for /vis/ frontpage",
+    postUseAction: "Konsolider med tremeny-data i v0.3",
+    overlappingSurfaces: ["VIS kontrollrom", "IA Inventory"],
+    hubPlacement: "skjult/arkivert" as VisIaHubPlacement,
+    mandateRecommendation: "slå sammen" as VisIaRecommendation,
+    needsPageContract: false,
+  },
+  iaInventory: {
+    userNeed: "Kartlegge VIS-flater, mandat og overlapp før tremeny bygges",
+    primaryTask: "beslutninger-qa" as VisIaTopTask,
+    secondaryTask: "forstå-system" as VisIaTopTask,
+    audience: ["Thomas", "Cursor"] as VisIaAudience[],
+    coreContent: "Inventar, mandatpass, overlap, tre-forslag v0.2",
+    postUseAction: "QA tremodell; godkjenn konsolidering; deretter implementer meny",
+    overlappingSurfaces: ["Systemreferanse (legacy hub)"],
+    hubPlacement: "skjult/arkivert" as VisIaHubPlacement,
+    mandateRecommendation: "behold" as VisIaRecommendation,
+    needsPageContract: true,
+    pageContractNote: "Meta-dokument — kan skjules i prod-meny",
+  },
+};
 
 export const visIaInventoryEntries: VisIaEntry[] = [
   {
@@ -227,9 +727,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "kontrollrom",
     status: "active",
     currentPlacement: "VIS rot — hub-and-spoke frontpage",
-    suggestedPlacement: "VIS kontrollrom (rot)",
+    suggestedPlacement: "Nå — status og sprint → Kontrollrom",
     recommendation: "behold",
-    rationale: "Primær inngang. Runtime feed + MVP-status + huber. Ikke backlog.",
+    rationale: "Primær inngang. Runtime feed + MVP-status + huber.",
+    mandate: M.visFrontpage,
   },
   {
     id: "runtime-feed",
@@ -239,9 +740,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "runtime-data",
     status: "active",
     currentPlacement: "Innebygd øverst på /vis/",
-    suggestedPlacement: "Nå og sprint → Runtime feed",
+    suggestedPlacement: "Nå → Runtime feed (innebygd)",
     recommendation: "behold",
-    rationale: "Manuell agent-status. Kommunikasjonsregel § B4. Ikke egen route.",
+    rationale: "Manuell agent-status. Kommunikasjonsregel § B4.",
+    mandate: M.runtimeFeed,
   },
   {
     id: "designsystem",
@@ -251,9 +753,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "canonical-external",
     status: "canonical",
     currentPlacement: "Global intern rute + primær VIS-hub",
-    suggestedPlacement: "Design → Designsystem (lenke til global rute)",
+    suggestedPlacement: "Finn flate → Design → Designsystem",
     recommendation: "behold",
-    rationale: "Canonical UI/mønstre. Bør forbli egen flate — vises i VIS-tre.",
+    rationale: "Canonical UI/mønstre.",
+    mandate: M.designsystem,
   },
   {
     id: "backstage",
@@ -263,9 +766,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "canonical-external",
     status: "canonical",
     currentPlacement: "Global intern rute + primær VIS-hub",
-    suggestedPlacement: "System → Backstage (lenke til global rute)",
+    suggestedPlacement: "Forstå system → Backstage",
     recommendation: "behold",
-    rationale: "Systemreferanse AI/API/guard. Egen URL riktig — pekes til fra VIS-tre.",
+    rationale: "Canonical systemreferanse AI/API/guard.",
+    mandate: M.backstage,
   },
   {
     id: "gitbuss",
@@ -275,9 +779,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "runtime-tool",
     status: "active",
     currentPlacement: "VIS system — primær hub «Gitbuss»",
-    suggestedPlacement: "System → Gitbuss",
+    suggestedPlacement: "Finn flate → Operativt → Gitbuss",
     recommendation: "behold",
-    rationale: "Generert GitHub-feed. Operativ — ikke design-dok.",
+    rationale: "GitHub-feed — ikke kontrollrom.",
+    mandate: M.gitbuss,
   },
   {
     id: "roadmap",
@@ -287,9 +792,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "runtime-tool",
     status: "active",
     currentPlacement: "VIS system — primær hub",
-    suggestedPlacement: "System → Roadmap",
+    suggestedPlacement: "Finn flate → Operativt → Roadmap",
     recommendation: "behold",
-    rationale: "Retning/faser fra GitHub — ikke task-backlog.",
+    rationale: "Retning/faser — ikke sprint-backlog.",
+    mandate: M.roadmap,
   },
   {
     id: "dam-editorial",
@@ -299,9 +805,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "assets",
     status: "active",
     currentPlacement: "Sekundær hub «DAM / bildebank»",
-    suggestedPlacement: "Innhold og assets → DAM / bildebank",
+    suggestedPlacement: "Finn flate → Innhold og assets",
     recommendation: "slå sammen",
-    rationale: "Hub-navn og sideinnhold bruker ulike navn — konsolider label til ett område.",
+    rationale: "Hub-navn og sideinnhold — konsolider label.",
+    mandate: M.dam,
   },
   {
     id: "review",
@@ -311,9 +818,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "review",
     status: "active",
     currentPlacement: "Sekundær hub",
-    suggestedPlacement: "Design → Review",
-    recommendation: "flytt",
-    rationale: "QA/godkjenning hører til design-spor — ikke egen toppkategori i tremeny.",
+    suggestedPlacement: "Finn flate → Design og QA → Review",
+    recommendation: "flytt under",
+    rationale: "QA hører til design-spor.",
+    mandate: M.review,
   },
   {
     id: "sprint-2026-w21",
@@ -323,9 +831,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "sprint-lab",
     status: "active",
     currentPlacement: "Primær hub (aktiv sprint)",
-    suggestedPlacement: "Nå og sprint → Sprint 2026-W21",
+    suggestedPlacement: "Nå → Sprint 2026-W21",
     recommendation: "behold",
-    rationale: "Aktiv currentSprint. Labs og beslutningsgrunnlag for MVP Design Lock.",
+    rationale: "Aktiv currentSprint.",
+    mandate: M.sprint,
   },
   {
     id: "sprint-color",
@@ -335,9 +844,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "sprint-lab",
     status: "lab",
     currentPlacement: "Under aktiv sprint",
-    suggestedPlacement: "Nå og sprint → Sprint → Color",
+    suggestedPlacement: "Nå → Sprint → Color",
     recommendation: "behold",
-    rationale: "Design Lock lab — aktiv beslutningsflate for sprint.",
+    rationale: "Design Lock lab — farge.",
+    mandate: { ...M.sprintLab, userNeed: "Vurdere fargepalett for MVP Design Lock" },
   },
   {
     id: "sprint-typography",
@@ -347,9 +857,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "sprint-lab",
     status: "lab",
     currentPlacement: "Under aktiv sprint",
-    suggestedPlacement: "Nå og sprint → Sprint → Typography",
+    suggestedPlacement: "Nå → Sprint → Typography",
     recommendation: "behold",
-    rationale: "Typografi-pass for sprint — referanse til production tokens.",
+    rationale: "Typografi-pass — production tokens.",
+    mandate: { ...M.sprintLab, userNeed: "Vurdere typografi mot production tokens" },
   },
   {
     id: "sprint-hub-types",
@@ -359,9 +870,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "sprint-lab",
     status: "lab",
     currentPlacement: "Under aktiv sprint + Review registry",
-    suggestedPlacement: "Nå og sprint → Sprint → Hub types",
+    suggestedPlacement: "Nå → Sprint → Hub types",
     recommendation: "behold",
-    rationale: "IA-beslutning hub-typer — stakeholder-safe i review.",
+    rationale: "IA-beslutning hub-typer.",
+    mandate: { ...M.sprintLab, userNeed: "Beslutte hub-typer for produkt-IA", overlappingSurfaces: ["Review", "IA-prinsipper", "Hub Mandate v0.1"] },
   },
   {
     id: "sprint-editorial-hub",
@@ -371,9 +883,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "sprint-lab",
     status: "lab",
     currentPlacement: "Under aktiv sprint",
-    suggestedPlacement: "Nå og sprint → Sprint → Editorial hub",
+    suggestedPlacement: "Nå → Sprint → Editorial hub",
     recommendation: "behold",
-    rationale: "Hub-visualisering for redaksjonell IA.",
+    rationale: "Hub-visualisering redaksjonell IA.",
+    mandate: { ...M.sprintLab, userNeed: "Visualisere redaksjonell hub-struktur" },
   },
   {
     id: "sprint-frontpage-mandate",
@@ -383,9 +896,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "sprint-lab",
     status: "lab",
     currentPlacement: "Under aktiv sprint",
-    suggestedPlacement: "Nå og sprint → Sprint → Frontpage mandate",
+    suggestedPlacement: "Nå → Sprint → Frontpage mandate",
     recommendation: "behold",
-    rationale: "Forsidemandat-lab knyttet til VIS IA-arbeid.",
+    rationale: "Forsidemandat-lab.",
+    mandate: { ...M.sprintLab, userNeed: "Definere forsidemandat for VIS og produkt" },
   },
   {
     id: "sprint-primitives",
@@ -394,10 +908,11 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     title: "Sprint lab — Primitives (13 + 3 context)",
     surfaceType: "sprint-lab",
     status: "lab",
-    currentPlacement: "Under aktiv sprint — surfaces, buttons, cards, m.fl.",
-    suggestedPlacement: "Nå og sprint → Sprint → Primitives",
+    currentPlacement: "Under aktiv sprint",
+    suggestedPlacement: "Nå → Sprint → Primitives",
     recommendation: "behold",
-    rationale: "MVP Design Lock primitives. Mange undersider — grupper i tre, ikke flat liste.",
+    rationale: "MVP Design Lock primitives — grupper i tre.",
+    mandate: { ...M.sprintLab, userNeed: "QA primitives før canonical i designsystem" },
   },
   {
     id: "control-center",
@@ -407,9 +922,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "reference",
     currentPlacement: "VIS system — featured inngang",
-    suggestedPlacement: "System → Control Center (sekundær)",
+    suggestedPlacement: "Forstå system → Control Center (sekundær)",
     recommendation: "behold",
-    rationale: "Agent/prosjektkontekst. Nyttig — men ikke primær for Thomas/Vibeke daglig.",
+    rationale: "Agent-kontekst — ikke Thomas daglig.",
+    mandate: M.controlCenter,
   },
   {
     id: "ia-principles",
@@ -419,21 +935,23 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "canonical",
     currentPlacement: "VIS system",
-    suggestedPlacement: "System → IA-prinsipper (dokumentasjon)",
+    suggestedPlacement: "Forstå system → IA-prinsipper",
     recommendation: "behold",
-    rationale: "Need-led IA-grunnmur — canonical for produkt-IA, ikke sprint-lab.",
+    rationale: "Need-led IA-grunnmur.",
+    mandate: { ...M.systemDoc, userNeed: "Forstå need-led IA-prinsipper for produktet", overlappingSurfaces: ["Hub Mandate v0.1", "KlarLyd – Strategisk IA v5"] },
   },
   {
     id: "ia-inventory",
     route: "/vis/system/ia-inventory-v01",
     sourceFile: "src/pages/vis/system/ia-inventory-v01.astro",
-    title: "VIS IA Inventory v0.1",
+    title: "VIS IA Inventory v0.2",
     surfaceType: "system-doc",
     status: "active",
-    currentPlacement: "VIS system (ny)",
-    suggestedPlacement: "System → IA inventory (meta — kan skjules i prod-meny senere)",
+    currentPlacement: "VIS system (meta)",
+    suggestedPlacement: "Meta / IA-arbeid",
     recommendation: "behold",
-    rationale: "Dette dokumentet — kartlegging før tremeny.",
+    rationale: "Mandatpass før tremeny.",
+    mandate: M.iaInventory,
   },
   {
     id: "hub-mandate",
@@ -443,9 +961,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "reference",
     currentPlacement: "VIS system",
-    suggestedPlacement: "System → Hub mandate",
+    suggestedPlacement: "Forstå system → Hub mandate",
     recommendation: "behold",
-    rationale: "Canonical hub-mandat — referanse, ikke daglig navigasjon.",
+    rationale: "Canonical hub-mandat.",
+    mandate: { ...M.systemDoc, userNeed: "Forstå mandat for hver hub-type i produktet" },
   },
   {
     id: "design-system-v01-overview",
@@ -454,10 +973,11 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     title: "Design System Overview (VIS legacy)",
     surfaceType: "system-doc",
     status: "legacy",
-    currentPlacement: "VIS system — merket legacy i system-index",
-    suggestedPlacement: "Historikk / arkiv → Legacy system-docs",
+    currentPlacement: "VIS system — merket legacy",
+    suggestedPlacement: "Historikk → Legacy design v01",
     recommendation: "arkiver",
-    rationale: "Erstattet av /designsystem/ som canonical. Behold URL, fjern fra primær nav.",
+    rationale: "Erstattet av /designsystem/.",
+    mandate: { ...M.legacyDoc, userNeed: "Historisk designreferanse", overlappingSurfaces: ["Designsystem"], postUseAction: "Bruk /designsystem/ i stedet" },
   },
   {
     id: "article-system",
@@ -467,9 +987,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "reference",
     currentPlacement: "VIS system",
-    suggestedPlacement: "System → Article docs (undergruppe)",
+    suggestedPlacement: "Forstå system → Artikkel-system",
     recommendation: "behold",
-    rationale: "Artikkelkomponent-referanse — støtter redaksjon og designsystem.",
+    rationale: "Artikkelkomponent-referanse.",
+    mandate: { ...M.systemDoc, userNeed: "Forstå artikkel-system for redaksjon og design" },
   },
   {
     id: "article-foundations",
@@ -479,9 +1000,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "reference",
     currentPlacement: "VIS system/article/",
-    suggestedPlacement: "System → Article → Foundations",
+    suggestedPlacement: "Forstå system → Artikkel → Foundations",
     recommendation: "behold",
-    rationale: "Dokumentasjon — grupper article/* under én tre-node.",
+    rationale: "Grunnmur artikkel.",
+    mandate: { ...M.systemDoc, userNeed: "Forstå artikkel-grunnmur" },
   },
   {
     id: "article-components",
@@ -491,9 +1013,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "reference",
     currentPlacement: "VIS system/article/",
-    suggestedPlacement: "System → Article → Components",
+    suggestedPlacement: "Forstå system → Artikkel → Components",
     recommendation: "behold",
-    rationale: "Komponent-preview referanse.",
+    rationale: "Komponent-preview.",
+    mandate: { ...M.systemDoc, userNeed: "Se artikkel-komponenter i kontekst" },
   },
   {
     id: "article-templates",
@@ -503,9 +1026,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "reference",
     currentPlacement: "VIS system/article/",
-    suggestedPlacement: "System → Article → Templates",
+    suggestedPlacement: "Forstå system → Artikkel → Templates",
     recommendation: "behold",
-    rationale: "Template-oppskrift — referanse.",
+    rationale: "Template-oppskrift.",
+    mandate: { ...M.systemDoc, userNeed: "Finne riktig artikkel-mal" },
   },
   {
     id: "article-changelog",
@@ -515,9 +1039,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "reference",
     currentPlacement: "VIS system/article/",
-    suggestedPlacement: "System → Article → Changelog",
+    suggestedPlacement: "Forstå system → Artikkel → Changelog",
     recommendation: "behold",
-    rationale: "Historikk for artikkel-system — lav frekvens.",
+    rationale: "Historikk artikkel-system.",
+    mandate: { ...M.systemDoc, userNeed: "Finne begrunnelse for artikkel-endringer", primaryTask: "historikk", secondaryTask: "forstå-system" },
   },
   {
     id: "article-index",
@@ -527,9 +1052,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "reference",
     currentPlacement: "VIS system/article/",
-    suggestedPlacement: "System → Article (gruppe)",
+    suggestedPlacement: "Forstå system → Artikkel (gruppe)",
     recommendation: "slå sammen",
-    rationale: "Kan være tre-node for article-underdokumenter — unngå flat system-liste.",
+    rationale: "Tre-node for article-underdokumenter.",
+    mandate: { ...M.systemDoc, userNeed: "Navigere artikkel-dokumentasjon", mandateRecommendation: "slå sammen" },
   },
   {
     id: "vis-system-index",
@@ -539,9 +1065,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "system-doc",
     status: "legacy",
     currentPlacement: "VIS /system — manuell link-liste",
-    suggestedPlacement: "Erstattes av tremeny — behold som fallback til overgang",
+    suggestedPlacement: "Arkiver når tremeny finnes",
     recommendation: "arkiver",
-    rationale: "Flat hub dupliserer det nye treet skal løse. Behold midlertidig.",
+    rationale: "Flat hub dupliserer tre.",
+    mandate: { ...M.legacyDoc, userNeed: "Fallback navigasjon til system-sider", overlappingSurfaces: ["Backstage", "IA Inventory", "Gitbuss"], postUseAction: "Bruk tremeny v0.2 i stedet" },
   },
   {
     id: "task-bus-live",
@@ -553,7 +1080,8 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     currentPlacement: "VIS system — merket pensjonert",
     suggestedPlacement: "Historikk / arkiv",
     recommendation: "arkiver",
-    rationale: "Erstattet av GitHub runtime + roadmap. Vurder sletting etter tremeny.",
+    rationale: "Erstattet av Gitbuss + roadmap.",
+    mandate: { ...M.legacyDoc, userNeed: "Historisk task-bus", overlappingSurfaces: ["Gitbuss"], postUseAction: "Bruk Gitbuss" },
   },
   {
     id: "vis-artikkel-placeholder",
@@ -563,9 +1091,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "placeholder",
     status: "historical",
     currentPlacement: "VIS rot — placeholder",
-    suggestedPlacement: "Historikk / arkiv eller fjern lenker",
+    suggestedPlacement: "Historikk eller slett",
     recommendation: "vurder sletting",
-    rationale: "Tom placeholder — rå wireframes nå via /vis/[slug].",
+    rationale: "Tom placeholder.",
+    mandate: M.placeholder,
   },
   {
     id: "vis-hub-placeholder",
@@ -575,9 +1104,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "placeholder",
     status: "historical",
     currentPlacement: "VIS rot — placeholder",
-    suggestedPlacement: "Historikk / arkiv eller fjern lenker",
+    suggestedPlacement: "Historikk eller slett",
     recommendation: "vurder sletting",
-    rationale: "Tom placeholder — erstattet av production hubs og sprint-labs.",
+    rationale: "Tom placeholder.",
+    mandate: M.placeholder,
   },
   {
     id: "raw-wireframes",
@@ -586,10 +1116,11 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     title: "Raw HTML wireframes (10 filer)",
     surfaceType: "wireframe-render",
     status: "historical",
-    currentPlacement: "Arkiv/details på /vis/ + direkte slug-URL",
-    suggestedPlacement: "Historikk / arkiv → Raw wireframes",
+    currentPlacement: "Arkiv/details på /vis/",
+    suggestedPlacement: "Historikk → Raw wireframes",
     recommendation: "arkiver",
-    rationale: "KlarLyd wireframes, strategi, sprint-arkiv. Kun søkbar referanse — ikke primær nav.",
+    rationale: "Kun referanse — ikke primær nav.",
+    mandate: M.wireframe,
   },
   {
     id: "raw-klarlyd-forside-a",
@@ -602,6 +1133,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     suggestedPlacement: "Historikk / arkiv",
     recommendation: "arkiver",
     rationale: "Tidlig wireframe — produksjon er /no/.",
+    mandate: { ...M.wireframe, userNeed: "Se tidlig forside-variant A", postUseAction: "Sammenlign med /no/ — ikke implementer" },
   },
   {
     id: "raw-klarlyd-forside-b",
@@ -614,6 +1146,7 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     suggestedPlacement: "Historikk / arkiv",
     recommendation: "arkiver",
     rationale: "Historisk AI-first forsidespike.",
+    mandate: { ...M.wireframe, userNeed: "Se AI-first forsidespike" },
   },
   {
     id: "raw-strategi-notion",
@@ -623,9 +1156,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "wireframe-raw",
     status: "historical",
     currentPlacement: "Historikk / arkiv",
-    suggestedPlacement: "Historikk / arkiv → Strategi",
+    suggestedPlacement: "Historikk → Strategi",
     recommendation: "arkiver",
-    rationale: "Strategidok — erstattet av ia-principles-v01 og hub-mandate.",
+    rationale: "Erstattet av ia-principles + hub-mandate.",
+    mandate: { ...M.wireframe, userNeed: "Finne tidlig strategisk IA-begrunnelse", overlappingSurfaces: ["IA-prinsipper v0.1", "Hub Mandate v0.1"] },
   },
   {
     id: "raw-sprint-foundation",
@@ -635,9 +1169,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "wireframe-raw",
     status: "historical",
     currentPlacement: "Historikk / arkiv",
-    suggestedPlacement: "Historikk / arkiv → Lukkede sprintvisninger",
+    suggestedPlacement: "Historikk → Lukkede sprintvisninger",
     recommendation: "arkiver",
-    rationale: "Eksplisitt arkivert sprint — modell for fremtidige closedSprints.",
+    rationale: "Eksplisitt arkivert sprint.",
+    mandate: { ...M.wireframe, userNeed: "Se lukket sprint som modell for fremtidige", overlappingSurfaces: ["Sprint 2026-W21"], postUseAction: "Modell for closedSprints — ikke aktiv lab" },
   },
   {
     id: "raw-live-board",
@@ -646,10 +1181,11 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     title: "KlarLyd Live Board / Roadmap v0.4",
     surfaceType: "wireframe-raw",
     status: "legacy",
-    currentPlacement: "Historikk — merket pensjonert i system-index",
+    currentPlacement: "Historikk — merket pensjonert",
     suggestedPlacement: "Historikk / arkiv",
     recommendation: "vurder sletting",
-    rationale: "Erstattet av roadmap-timeline-v01. Duplikat formål.",
+    rationale: "Erstattet av roadmap-timeline-v01.",
+    mandate: { ...M.legacyDoc, userNeed: "Historisk live board", overlappingSurfaces: ["Roadmap timeline"], postUseAction: "Bruk roadmap-timeline-v01", mandateRecommendation: "vurder sletting" },
   },
   {
     id: "mvp-current-state",
@@ -659,9 +1195,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "runtime-data",
     status: "canonical",
     currentPlacement: "Data — driver /vis/ MVP nå og sprint",
-    suggestedPlacement: "Nå og sprint (datakilde)",
+    suggestedPlacement: "Nå (datakilde)",
     recommendation: "behold",
-    rationale: "Operativ sannhet — ikke egen side, men kritisk for kontrollrom.",
+    rationale: "Operativ sannhet for kontrollrom.",
+    mandate: { ...M.runtimeData, userNeed: "Drive MVP-status og sprint-info på kontrollrom", overlappingSurfaces: ["VIS kontrollrom", "Sprint 2026-W21"] },
   },
   {
     id: "vis-frontpage-hubs",
@@ -671,9 +1208,10 @@ export const visIaInventoryEntries: VisIaEntry[] = [
     surfaceType: "runtime-data",
     status: "active",
     currentPlacement: "Data — driver hub-kort på /vis/",
-    suggestedPlacement: "Erstattes gradvis av tremeny-data",
+    suggestedPlacement: "Konsolider med tremeny-data",
     recommendation: "slå sammen",
-    rationale: "Hub-definisjon overlapper med fremtidig tre — konsolider i v0.2.",
+    rationale: "Overlapper med fremtidig tre.",
+    mandate: M.hubsRegistry,
   },
 ];
 
@@ -687,4 +1225,22 @@ export function getVisIaEntriesByStatus(status: VisIaStatus): VisIaEntry[] {
 
 export function getVisIaEntriesByRecommendation(rec: VisIaRecommendation): VisIaEntry[] {
   return visIaInventoryEntries.filter((e) => e.recommendation === rec);
+}
+
+export function getVisIaEntriesByTopTask(task: VisIaTopTask): VisIaEntry[] {
+  return visIaInventoryEntries.filter(
+    (e) => e.mandate.primaryTask === task || e.mandate.secondaryTask === task,
+  );
+}
+
+export function getVisIaMergeCandidates(): VisIaEntry[] {
+  return visIaInventoryEntries.filter((e) => e.recommendation === "slå sammen");
+}
+
+export function getVisIaArchiveCandidates(): VisIaEntry[] {
+  return visIaInventoryEntries.filter((e) => e.recommendation === "arkiver");
+}
+
+export function getVisIaDeleteCandidates(): VisIaEntry[] {
+  return visIaInventoryEntries.filter((e) => e.recommendation === "vurder sletting");
 }

--- a/src/data/vis-ia-inventory-v01.ts
+++ b/src/data/vis-ia-inventory-v01.ts
@@ -1,0 +1,690 @@
+/* CONTRACT: VIS IA Inventory v0.1 — kartlegging av flater, status og foreslått tremeny (analyse, ikke implementasjon). */
+
+export type VisIaStatus =
+  | "active"
+  | "canonical"
+  | "planned"
+  | "reference"
+  | "lab"
+  | "historical"
+  | "legacy"
+  | "unknown";
+
+export type VisIaRecommendation =
+  | "behold"
+  | "slå sammen"
+  | "flytt"
+  | "arkiver"
+  | "vurder sletting";
+
+export type VisIaSurfaceType =
+  | "kontrollrom"
+  | "runtime-data"
+  | "hub"
+  | "canonical-external"
+  | "system-doc"
+  | "runtime-tool"
+  | "sprint-lab"
+  | "review"
+  | "assets"
+  | "wireframe-render"
+  | "wireframe-raw"
+  | "placeholder";
+
+export type VisIaEntry = {
+  id: string;
+  route: string;
+  sourceFile?: string;
+  title: string;
+  surfaceType: VisIaSurfaceType;
+  status: VisIaStatus;
+  currentPlacement: string;
+  suggestedPlacement: string;
+  recommendation: VisIaRecommendation;
+  rationale: string;
+};
+
+export type VisIaTreeNode = {
+  id: string;
+  label: string;
+  href?: string;
+  note?: string;
+  children?: VisIaTreeNode[];
+};
+
+export type VisIaConsolidationNote = {
+  id: string;
+  title: string;
+  recommendation: string;
+  rationale: string;
+};
+
+export const visIaInventoryMeta = {
+  version: "v0.1",
+  updatedAt: "2026-05-31",
+  purpose:
+    "Kartlegging før trebasert lokalmeny i VIS. Analyse og forslag — ingen routes slettet eller flyttet.",
+} as const;
+
+/** Foreslått tremeny v0.1 — Thomas QA før implementasjon. */
+export const visIaTreeProposal: VisIaTreeNode[] = [
+  {
+    id: "kontrollrom",
+    label: "VIS kontrollrom",
+    href: "/vis/",
+    children: [
+      {
+        id: "now-sprint",
+        label: "Nå og sprint",
+        children: [
+          {
+            id: "runtime-feed",
+            label: "Runtime feed",
+            note: "Innebygd i /vis/ — data i vis-runtime-feed.ts",
+          },
+          {
+            id: "sprint-active",
+            label: "Sprint 2026-W21",
+            href: "/vis/sprints/2026-w21/",
+            note: "Aktiv sprint — labs under denne noden i detaljvisning",
+          },
+        ],
+      },
+      {
+        id: "system",
+        label: "System",
+        children: [
+          {
+            id: "backstage",
+            label: "Backstage",
+            href: "/backstage/",
+            note: "Egen global rute — vises i VIS-tre som systemreferanse",
+          },
+          {
+            id: "gitbuss",
+            label: "Gitbuss",
+            href: "/vis/system/github-runtime-status",
+          },
+          {
+            id: "roadmap",
+            label: "Roadmap",
+            href: "/vis/system/roadmap-timeline-v01",
+          },
+          {
+            id: "control-center",
+            label: "Control Center",
+            href: "/vis/system/control-center",
+            note: "Prosjektkontekst for agenter — sekundær inngang",
+          },
+        ],
+      },
+      {
+        id: "design",
+        label: "Design",
+        children: [
+          {
+            id: "designsystem",
+            label: "Designsystem",
+            href: "/designsystem/",
+            note: "Egen global canonical rute — vises i VIS-tre",
+          },
+          {
+            id: "review",
+            label: "Review",
+            href: "/vis/review/",
+            note: "QA-innganger — under Design, ikke egen topp-hub",
+          },
+        ],
+      },
+      {
+        id: "content-assets",
+        label: "Innhold og assets",
+        children: [
+          {
+            id: "dam",
+            label: "DAM / bildebank",
+            href: "/vis/assets/editorial",
+            note: "Slå sammen navn med Editorial Image Library",
+          },
+        ],
+      },
+      {
+        id: "archive",
+        label: "Historikk / arkiv",
+        children: [
+          {
+            id: "raw-wireframes",
+            label: "Raw wireframes (HTML)",
+            note: "public/vis/raw + /vis/[slug] — kun via arkiv/details",
+          },
+          {
+            id: "legacy-system",
+            label: "Legacy system-docs",
+            note: "design-system-v01, task-bus-live, m.fl.",
+          },
+          {
+            id: "closed-sprints",
+            label: "Lukkede sprintvisninger",
+            note: "Når currentSprint.status = closed",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const visIaConsolidationNotes: VisIaConsolidationNote[] = [
+  {
+    id: "designsystem-global",
+    title: "/designsystem/ som global intern flate",
+    recommendation: "Behold egen rute; vis som tre-node under Design",
+    rationale:
+      "Canonical UI-referanse brukes også utenfor VIS. Tremeny lenker hit — flytter ikke innhold inn i /vis/.",
+  },
+  {
+    id: "backstage-global",
+    title: "/backstage/ som global intern flate",
+    recommendation: "Behold egen rute; vis som tre-node under System",
+    rationale:
+      "Systemreferanse for AI/API/guard. Samme mønster som designsystem — egen URL, VIS-tre peker hit.",
+  },
+  {
+    id: "dam-editorial",
+    title: "DAM / bildebank vs Editorial Image Library",
+    recommendation: "Slå sammen til ett område: «Innhold og assets»",
+    rationale:
+      "Hub heter DAM; ruten er /vis/assets/editorial med Editorial Image Library v0.2. Samme funksjon — én node i tre.",
+  },
+  {
+    id: "review-under-design",
+    title: "Review-plassering",
+    recommendation: "Under Design — ikke egen primær hub",
+    rationale:
+      "Review er QA/godkjenning av design/spinter, ikke eget arbeidsområde. Sekundær hub i dag er riktig.",
+  },
+  {
+    id: "sprint-under-now",
+    title: "Sprint 2026-W21",
+    recommendation: "Under «Nå og sprint» mens aktiv",
+    rationale:
+      "Matcher mvp-current-state.currentSprint og VIS sprint guard. Ved sprintskifte → Historikk.",
+  },
+  {
+    id: "raw-archive-only",
+    title: "Raw VIS HTML",
+    recommendation: "Kun Historikk / arkiv — ikke primær nav",
+    rationale:
+      "10+ eldre wireframes/strategidok i public/vis/raw. Nyttig referanse, men skal ikke konkurrere med kontrollrom.",
+  },
+];
+
+export const visIaInventoryEntries: VisIaEntry[] = [
+  {
+    id: "vis-frontpage",
+    route: "/vis/",
+    sourceFile: "src/pages/vis/index.astro",
+    title: "VIS kontrollrom",
+    surfaceType: "kontrollrom",
+    status: "active",
+    currentPlacement: "VIS rot — hub-and-spoke frontpage",
+    suggestedPlacement: "VIS kontrollrom (rot)",
+    recommendation: "behold",
+    rationale: "Primær inngang. Runtime feed + MVP-status + huber. Ikke backlog.",
+  },
+  {
+    id: "runtime-feed",
+    route: "/vis/ (embedded)",
+    sourceFile: "src/data/vis-runtime-feed.ts",
+    title: "Runtime feed",
+    surfaceType: "runtime-data",
+    status: "active",
+    currentPlacement: "Innebygd øverst på /vis/",
+    suggestedPlacement: "Nå og sprint → Runtime feed",
+    recommendation: "behold",
+    rationale: "Manuell agent-status. Kommunikasjonsregel § B4. Ikke egen route.",
+  },
+  {
+    id: "designsystem",
+    route: "/designsystem/",
+    sourceFile: "src/pages/designsystem/index.astro",
+    title: "Designsystem",
+    surfaceType: "canonical-external",
+    status: "canonical",
+    currentPlacement: "Global intern rute + primær VIS-hub",
+    suggestedPlacement: "Design → Designsystem (lenke til global rute)",
+    recommendation: "behold",
+    rationale: "Canonical UI/mønstre. Bør forbli egen flate — vises i VIS-tre.",
+  },
+  {
+    id: "backstage",
+    route: "/backstage/",
+    sourceFile: "src/pages/backstage/index.astro",
+    title: "Backstage",
+    surfaceType: "canonical-external",
+    status: "canonical",
+    currentPlacement: "Global intern rute + primær VIS-hub",
+    suggestedPlacement: "System → Backstage (lenke til global rute)",
+    recommendation: "behold",
+    rationale: "Systemreferanse AI/API/guard. Egen URL riktig — pekes til fra VIS-tre.",
+  },
+  {
+    id: "gitbuss",
+    route: "/vis/system/github-runtime-status",
+    sourceFile: "src/pages/vis/system/github-runtime-status.astro",
+    title: "Gitbuss / GitHub runtime status",
+    surfaceType: "runtime-tool",
+    status: "active",
+    currentPlacement: "VIS system — primær hub «Gitbuss»",
+    suggestedPlacement: "System → Gitbuss",
+    recommendation: "behold",
+    rationale: "Generert GitHub-feed. Operativ — ikke design-dok.",
+  },
+  {
+    id: "roadmap",
+    route: "/vis/system/roadmap-timeline-v01",
+    sourceFile: "src/pages/vis/system/roadmap-timeline-v01.astro",
+    title: "Roadmap timeline",
+    surfaceType: "runtime-tool",
+    status: "active",
+    currentPlacement: "VIS system — primær hub",
+    suggestedPlacement: "System → Roadmap",
+    recommendation: "behold",
+    rationale: "Retning/faser fra GitHub — ikke task-backlog.",
+  },
+  {
+    id: "dam-editorial",
+    route: "/vis/assets/editorial",
+    sourceFile: "src/pages/vis/assets/editorial.astro",
+    title: "DAM / Editorial Image Library",
+    surfaceType: "assets",
+    status: "active",
+    currentPlacement: "Sekundær hub «DAM / bildebank»",
+    suggestedPlacement: "Innhold og assets → DAM / bildebank",
+    recommendation: "slå sammen",
+    rationale: "Hub-navn og sideinnhold bruker ulike navn — konsolider label til ett område.",
+  },
+  {
+    id: "review",
+    route: "/vis/review/",
+    sourceFile: "src/pages/vis/review/index.astro",
+    title: "Review",
+    surfaceType: "review",
+    status: "active",
+    currentPlacement: "Sekundær hub",
+    suggestedPlacement: "Design → Review",
+    recommendation: "flytt",
+    rationale: "QA/godkjenning hører til design-spor — ikke egen toppkategori i tremeny.",
+  },
+  {
+    id: "sprint-2026-w21",
+    route: "/vis/sprints/2026-w21/",
+    sourceFile: "src/pages/vis/sprints/2026-w21/index.astro",
+    title: "Sprint 2026-W21",
+    surfaceType: "sprint-lab",
+    status: "active",
+    currentPlacement: "Primær hub (aktiv sprint)",
+    suggestedPlacement: "Nå og sprint → Sprint 2026-W21",
+    recommendation: "behold",
+    rationale: "Aktiv currentSprint. Labs og beslutningsgrunnlag for MVP Design Lock.",
+  },
+  {
+    id: "sprint-color",
+    route: "/vis/sprints/2026-w21/color/",
+    sourceFile: "src/pages/vis/sprints/2026-w21/color/index.astro",
+    title: "Sprint lab — Color",
+    surfaceType: "sprint-lab",
+    status: "lab",
+    currentPlacement: "Under aktiv sprint",
+    suggestedPlacement: "Nå og sprint → Sprint → Color",
+    recommendation: "behold",
+    rationale: "Design Lock lab — aktiv beslutningsflate for sprint.",
+  },
+  {
+    id: "sprint-typography",
+    route: "/vis/sprints/2026-w21/typography/",
+    sourceFile: "src/pages/vis/sprints/2026-w21/typography/index.astro",
+    title: "Sprint lab — Typography",
+    surfaceType: "sprint-lab",
+    status: "lab",
+    currentPlacement: "Under aktiv sprint",
+    suggestedPlacement: "Nå og sprint → Sprint → Typography",
+    recommendation: "behold",
+    rationale: "Typografi-pass for sprint — referanse til production tokens.",
+  },
+  {
+    id: "sprint-hub-types",
+    route: "/vis/sprints/2026-w21/hub-types/",
+    sourceFile: "src/pages/vis/sprints/2026-w21/hub-types/index.astro",
+    title: "Sprint lab — Hub types",
+    surfaceType: "sprint-lab",
+    status: "lab",
+    currentPlacement: "Under aktiv sprint + Review registry",
+    suggestedPlacement: "Nå og sprint → Sprint → Hub types",
+    recommendation: "behold",
+    rationale: "IA-beslutning hub-typer — stakeholder-safe i review.",
+  },
+  {
+    id: "sprint-editorial-hub",
+    route: "/vis/sprints/2026-w21/editorial-hub/",
+    sourceFile: "src/pages/vis/sprints/2026-w21/editorial-hub/index.astro",
+    title: "Sprint lab — Editorial hub",
+    surfaceType: "sprint-lab",
+    status: "lab",
+    currentPlacement: "Under aktiv sprint",
+    suggestedPlacement: "Nå og sprint → Sprint → Editorial hub",
+    recommendation: "behold",
+    rationale: "Hub-visualisering for redaksjonell IA.",
+  },
+  {
+    id: "sprint-frontpage-mandate",
+    route: "/vis/sprints/2026-w21/frontpage-mandate/",
+    sourceFile: "src/pages/vis/sprints/2026-w21/frontpage-mandate/index.astro",
+    title: "Sprint lab — Frontpage mandate",
+    surfaceType: "sprint-lab",
+    status: "lab",
+    currentPlacement: "Under aktiv sprint",
+    suggestedPlacement: "Nå og sprint → Sprint → Frontpage mandate",
+    recommendation: "behold",
+    rationale: "Forsidemandat-lab knyttet til VIS IA-arbeid.",
+  },
+  {
+    id: "sprint-primitives",
+    route: "/vis/sprints/2026-w21/primitives/",
+    sourceFile: "src/pages/vis/sprints/2026-w21/primitives/index.astro",
+    title: "Sprint lab — Primitives (13 + 3 context)",
+    surfaceType: "sprint-lab",
+    status: "lab",
+    currentPlacement: "Under aktiv sprint — surfaces, buttons, cards, m.fl.",
+    suggestedPlacement: "Nå og sprint → Sprint → Primitives",
+    recommendation: "behold",
+    rationale: "MVP Design Lock primitives. Mange undersider — grupper i tre, ikke flat liste.",
+  },
+  {
+    id: "control-center",
+    route: "/vis/system/control-center",
+    sourceFile: "src/pages/vis/system/control-center.astro",
+    title: "Viddel Control Center",
+    surfaceType: "system-doc",
+    status: "reference",
+    currentPlacement: "VIS system — featured inngang",
+    suggestedPlacement: "System → Control Center (sekundær)",
+    recommendation: "behold",
+    rationale: "Agent/prosjektkontekst. Nyttig — men ikke primær for Thomas/Vibeke daglig.",
+  },
+  {
+    id: "ia-principles",
+    route: "/vis/system/ia-principles-v01",
+    sourceFile: "src/pages/vis/system/ia-principles-v01.astro",
+    title: "IA-prinsipper v0.1",
+    surfaceType: "system-doc",
+    status: "canonical",
+    currentPlacement: "VIS system",
+    suggestedPlacement: "System → IA-prinsipper (dokumentasjon)",
+    recommendation: "behold",
+    rationale: "Need-led IA-grunnmur — canonical for produkt-IA, ikke sprint-lab.",
+  },
+  {
+    id: "ia-inventory",
+    route: "/vis/system/ia-inventory-v01",
+    sourceFile: "src/pages/vis/system/ia-inventory-v01.astro",
+    title: "VIS IA Inventory v0.1",
+    surfaceType: "system-doc",
+    status: "active",
+    currentPlacement: "VIS system (ny)",
+    suggestedPlacement: "System → IA inventory (meta — kan skjules i prod-meny senere)",
+    recommendation: "behold",
+    rationale: "Dette dokumentet — kartlegging før tremeny.",
+  },
+  {
+    id: "hub-mandate",
+    route: "/vis/system/hub-mandate-v01",
+    sourceFile: "src/pages/vis/system/hub-mandate-v01.astro",
+    title: "Hub Mandate v0.1",
+    surfaceType: "system-doc",
+    status: "reference",
+    currentPlacement: "VIS system",
+    suggestedPlacement: "System → Hub mandate",
+    recommendation: "behold",
+    rationale: "Canonical hub-mandat — referanse, ikke daglig navigasjon.",
+  },
+  {
+    id: "design-system-v01-overview",
+    route: "/vis/system/design-system-v01",
+    sourceFile: "src/pages/vis/system/design-system-v01.astro",
+    title: "Design System Overview (VIS legacy)",
+    surfaceType: "system-doc",
+    status: "legacy",
+    currentPlacement: "VIS system — merket legacy i system-index",
+    suggestedPlacement: "Historikk / arkiv → Legacy system-docs",
+    recommendation: "arkiver",
+    rationale: "Erstattet av /designsystem/ som canonical. Behold URL, fjern fra primær nav.",
+  },
+  {
+    id: "article-system",
+    route: "/vis/system/article-system",
+    sourceFile: "src/pages/vis/system/article-system.astro",
+    title: "Article system (VIS)",
+    surfaceType: "system-doc",
+    status: "reference",
+    currentPlacement: "VIS system",
+    suggestedPlacement: "System → Article docs (undergruppe)",
+    recommendation: "behold",
+    rationale: "Artikkelkomponent-referanse — støtter redaksjon og designsystem.",
+  },
+  {
+    id: "article-foundations",
+    route: "/vis/system/article/foundations",
+    sourceFile: "src/pages/vis/system/article/foundations.astro",
+    title: "Article foundations",
+    surfaceType: "system-doc",
+    status: "reference",
+    currentPlacement: "VIS system/article/",
+    suggestedPlacement: "System → Article → Foundations",
+    recommendation: "behold",
+    rationale: "Dokumentasjon — grupper article/* under én tre-node.",
+  },
+  {
+    id: "article-components",
+    route: "/vis/system/article/components",
+    sourceFile: "src/pages/vis/system/article/components.astro",
+    title: "Article components",
+    surfaceType: "system-doc",
+    status: "reference",
+    currentPlacement: "VIS system/article/",
+    suggestedPlacement: "System → Article → Components",
+    recommendation: "behold",
+    rationale: "Komponent-preview referanse.",
+  },
+  {
+    id: "article-templates",
+    route: "/vis/system/article/templates",
+    sourceFile: "src/pages/vis/system/article/templates.astro",
+    title: "Article templates",
+    surfaceType: "system-doc",
+    status: "reference",
+    currentPlacement: "VIS system/article/",
+    suggestedPlacement: "System → Article → Templates",
+    recommendation: "behold",
+    rationale: "Template-oppskrift — referanse.",
+  },
+  {
+    id: "article-changelog",
+    route: "/vis/system/article/changelog",
+    sourceFile: "src/pages/vis/system/article/changelog.astro",
+    title: "Article changelog",
+    surfaceType: "system-doc",
+    status: "reference",
+    currentPlacement: "VIS system/article/",
+    suggestedPlacement: "System → Article → Changelog",
+    recommendation: "behold",
+    rationale: "Historikk for artikkel-system — lav frekvens.",
+  },
+  {
+    id: "article-index",
+    route: "/vis/system/article/",
+    sourceFile: "src/pages/vis/system/article/index.astro",
+    title: "Article system index",
+    surfaceType: "system-doc",
+    status: "reference",
+    currentPlacement: "VIS system/article/",
+    suggestedPlacement: "System → Article (gruppe)",
+    recommendation: "slå sammen",
+    rationale: "Kan være tre-node for article-underdokumenter — unngå flat system-liste.",
+  },
+  {
+    id: "vis-system-index",
+    route: "/vis/system/",
+    sourceFile: "src/pages/vis/system/index.astro",
+    title: "Systemreferanse (legacy hub)",
+    surfaceType: "system-doc",
+    status: "legacy",
+    currentPlacement: "VIS /system — manuell link-liste",
+    suggestedPlacement: "Erstattes av tremeny — behold som fallback til overgang",
+    recommendation: "arkiver",
+    rationale: "Flat hub dupliserer det nye treet skal løse. Behold midlertidig.",
+  },
+  {
+    id: "task-bus-live",
+    route: "/vis/system/task-bus-live",
+    sourceFile: "src/pages/vis/system/task-bus-live.astro",
+    title: "Task bus live (pensjonert)",
+    surfaceType: "runtime-tool",
+    status: "legacy",
+    currentPlacement: "VIS system — merket pensjonert",
+    suggestedPlacement: "Historikk / arkiv",
+    recommendation: "arkiver",
+    rationale: "Erstattet av GitHub runtime + roadmap. Vurder sletting etter tremeny.",
+  },
+  {
+    id: "vis-artikkel-placeholder",
+    route: "/vis/artikkel",
+    sourceFile: "src/pages/vis/artikkel.astro",
+    title: "VIS wireframe — Artikkel (placeholder)",
+    surfaceType: "placeholder",
+    status: "historical",
+    currentPlacement: "VIS rot — placeholder",
+    suggestedPlacement: "Historikk / arkiv eller fjern lenker",
+    recommendation: "vurder sletting",
+    rationale: "Tom placeholder — rå wireframes nå via /vis/[slug].",
+  },
+  {
+    id: "vis-hub-placeholder",
+    route: "/vis/hub",
+    sourceFile: "src/pages/vis/hub.astro",
+    title: "VIS wireframe — NAV-Hub (placeholder)",
+    surfaceType: "placeholder",
+    status: "historical",
+    currentPlacement: "VIS rot — placeholder",
+    suggestedPlacement: "Historikk / arkiv eller fjern lenker",
+    recommendation: "vurder sletting",
+    rationale: "Tom placeholder — erstattet av production hubs og sprint-labs.",
+  },
+  {
+    id: "raw-wireframes",
+    route: "/vis/[slug]",
+    sourceFile: "src/pages/vis/[slug].astro + public/vis/raw/*.html",
+    title: "Raw HTML wireframes (10 filer)",
+    surfaceType: "wireframe-render",
+    status: "historical",
+    currentPlacement: "Arkiv/details på /vis/ + direkte slug-URL",
+    suggestedPlacement: "Historikk / arkiv → Raw wireframes",
+    recommendation: "arkiver",
+    rationale: "KlarLyd wireframes, strategi, sprint-arkiv. Kun søkbar referanse — ikke primær nav.",
+  },
+  {
+    id: "raw-klarlyd-forside-a",
+    route: "/vis/KlarLyd_Forside_Variant_A",
+    sourceFile: "public/vis/raw/KlarLyd_Forside_Variant_A.html",
+    title: "KlarLyd – Forside Variant A",
+    surfaceType: "wireframe-raw",
+    status: "historical",
+    currentPlacement: "Historikk / arkiv på /vis/",
+    suggestedPlacement: "Historikk / arkiv",
+    recommendation: "arkiver",
+    rationale: "Tidlig wireframe — produksjon er /no/.",
+  },
+  {
+    id: "raw-klarlyd-forside-b",
+    route: "/vis/KlarLyd_Forside_Variant_B_AI_v01",
+    sourceFile: "public/vis/raw/KlarLyd_Forside_Variant_B_AI_v01.html",
+    title: "KlarLyd – Forside Variant B (AI First)",
+    surfaceType: "wireframe-raw",
+    status: "historical",
+    currentPlacement: "Historikk / arkiv",
+    suggestedPlacement: "Historikk / arkiv",
+    recommendation: "arkiver",
+    rationale: "Historisk AI-first forsidespike.",
+  },
+  {
+    id: "raw-strategi-notion",
+    route: "/vis/KlarLyd_Strategi_Notion_v05",
+    sourceFile: "public/vis/raw/KlarLyd_Strategi_Notion_v05.html",
+    title: "KlarLyd – Strategisk IA v5",
+    surfaceType: "wireframe-raw",
+    status: "historical",
+    currentPlacement: "Historikk / arkiv",
+    suggestedPlacement: "Historikk / arkiv → Strategi",
+    recommendation: "arkiver",
+    rationale: "Strategidok — erstattet av ia-principles-v01 og hub-mandate.",
+  },
+  {
+    id: "raw-sprint-foundation",
+    route: "/vis/KlarLyd_Sprint_01_Foundation_Archive_v09",
+    sourceFile: "public/vis/raw/KlarLyd_Sprint_01_Foundation_Archive_v09.html",
+    title: "Sprint 01 Foundation (arkiv)",
+    surfaceType: "wireframe-raw",
+    status: "historical",
+    currentPlacement: "Historikk / arkiv",
+    suggestedPlacement: "Historikk / arkiv → Lukkede sprintvisninger",
+    recommendation: "arkiver",
+    rationale: "Eksplisitt arkivert sprint — modell for fremtidige closedSprints.",
+  },
+  {
+    id: "raw-live-board",
+    route: "/vis/KlarLyd_Live_Board_Roadmap_v01",
+    sourceFile: "public/vis/raw/KlarLyd_Live_Board_Roadmap_v01.html",
+    title: "KlarLyd Live Board / Roadmap v0.4",
+    surfaceType: "wireframe-raw",
+    status: "legacy",
+    currentPlacement: "Historikk — merket pensjonert i system-index",
+    suggestedPlacement: "Historikk / arkiv",
+    recommendation: "vurder sletting",
+    rationale: "Erstattet av roadmap-timeline-v01. Duplikat formål.",
+  },
+  {
+    id: "mvp-current-state",
+    route: "(data)",
+    sourceFile: "src/data/mvp-current-state.ts",
+    title: "MVP current-state registry",
+    surfaceType: "runtime-data",
+    status: "canonical",
+    currentPlacement: "Data — driver /vis/ MVP nå og sprint",
+    suggestedPlacement: "Nå og sprint (datakilde)",
+    recommendation: "behold",
+    rationale: "Operativ sannhet — ikke egen side, men kritisk for kontrollrom.",
+  },
+  {
+    id: "vis-frontpage-hubs",
+    route: "(data)",
+    sourceFile: "src/data/vis-frontpage-hubs-v01.ts",
+    title: "VIS frontpage hubs registry",
+    surfaceType: "runtime-data",
+    status: "active",
+    currentPlacement: "Data — driver hub-kort på /vis/",
+    suggestedPlacement: "Erstattes gradvis av tremeny-data",
+    recommendation: "slå sammen",
+    rationale: "Hub-definisjon overlapper med fremtidig tre — konsolider i v0.2.",
+  },
+];
+
+export function getVisIaInventoryEntries(): VisIaEntry[] {
+  return visIaInventoryEntries;
+}
+
+export function getVisIaEntriesByStatus(status: VisIaStatus): VisIaEntry[] {
+  return visIaInventoryEntries.filter((e) => e.status === status);
+}
+
+export function getVisIaEntriesByRecommendation(rec: VisIaRecommendation): VisIaEntry[] {
+  return visIaInventoryEntries.filter((e) => e.recommendation === rec);
+}

--- a/src/pages/vis/system/ia-inventory-v01.astro
+++ b/src/pages/vis/system/ia-inventory-v01.astro
@@ -1,59 +1,33 @@
 ---
-/* CONTRACT: VIS IA Inventory v0.2 — mandatpass og kartlegging før tremeny. */
+/* CONTRACT: VIS IA Inventory v0.3 — konsolideringsklarhet før tremeny. */
 import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
-import VisIaTreeBranch from "../../../components/vis/VisIaTreeBranch.astro";
+import VisIaSurfaceCard from "../../../components/vis/VisIaSurfaceCard.astro";
 import {
   getVisIaArchiveCandidates,
   getVisIaDeleteCandidates,
   getVisIaEntriesByTopTask,
-  getVisIaInventoryEntries,
+  getVisIaInventoryEntriesFull,
   getVisIaMergeCandidates,
-  visIaConsolidationNotes,
+  getVisIaThomasReviewEntries,
   visIaInventoryMeta,
-  visIaOverlapClusters,
-  visIaPageContractExample,
-  visIaPageContractProposal,
   visIaTopTaskLabels,
-  visIaTreeProposal,
-  visIaTreeProposalV02,
-  type VisIaEntry,
-  type VisIaStatus,
   type VisIaTopTask,
 } from "../../../data/vis-ia-inventory-v01.ts";
+import {
+  visIaConsolidationMeta,
+  visIaDeepDiveAreas,
+  visIaMetadataStrategy,
+  visIaPageContractV03Example,
+  visIaPageContractV03Fields,
+  visIaTreeProposalV03,
+} from "../../../data/vis-ia-consolidation-v03.ts";
 
 const base = import.meta.env.BASE_URL;
-const entries = getVisIaInventoryEntries();
-
-const statusOrder: VisIaStatus[] = [
-  "active",
-  "canonical",
-  "lab",
-  "reference",
-  "planned",
-  "historical",
-  "legacy",
-  "unknown",
-];
-
-const statusLabels: Record<VisIaStatus, string> = {
-  active: "Active",
-  canonical: "Canonical",
-  planned: "Planned",
-  reference: "Reference",
-  lab: "Lab",
-  historical: "Historical",
-  legacy: "Legacy",
-  unknown: "Unknown",
-};
-
-const recommendationLabels = {
-  behold: "Behold",
-  "slå sammen": "Slå sammen",
-  "flytt under": "Flytt under",
-  arkiver: "Arkiver",
-  "vurder sletting": "Vurder sletting",
-  "trenger avklaring": "Trenger avklaring",
-} as const;
+const entries = getVisIaInventoryEntriesFull();
+const thomasReview = getVisIaThomasReviewEntries();
+const mergeCandidates = getVisIaMergeCandidates();
+const archiveCandidates = getVisIaArchiveCandidates();
+const deleteCandidates = getVisIaDeleteCandidates();
 
 const topTaskOrder: VisIaTopTask[] = [
   "status-nå",
@@ -65,23 +39,18 @@ const topTaskOrder: VisIaTopTask[] = [
   "unngå-forveksling",
 ];
 
-function groupByStatus(items: VisIaEntry[]) {
-  return statusOrder
-    .map((status) => ({
-      status,
-      items: items.filter((e) => e.status === status),
-    }))
-    .filter((g) => g.items.length > 0);
+function entriesForTask(task: VisIaTopTask) {
+  return entries.filter(
+    (e) => e.mandate.primaryTask === task || e.mandate.secondaryTask === task,
+  );
 }
 
-const grouped = groupByStatus(entries);
-const mergeCandidates = getVisIaMergeCandidates();
-const archiveCandidates = getVisIaArchiveCandidates();
-const deleteCandidates = getVisIaDeleteCandidates();
-const needsContract = entries.filter((e) => e.mandate.needsPageContract);
+const preserveValues = [
+  ...new Set(entries.flatMap((e) => e.consolidation.functionalValue)),
+].sort();
 ---
 
-<PrototypeLayout title="VIS IA Inventory v0.2">
+<PrototypeLayout title="VIS IA Inventory v0.3">
   <main class="ia-inv">
     <nav class="ia-inv__crumb">
       <a href={`${base}vis`}>VIS</a>
@@ -92,222 +61,189 @@ const needsContract = entries.filter((e) => e.mandate.needsPageContract);
     </nav>
 
     <header class="ia-inv__hero">
-      <p class="ia-inv__kicker">VIS · IA · {visIaInventoryMeta.mandatePass}</p>
-      <h1>VIS IA Inventory</h1>
+      <p class="ia-inv__kicker">VIS · IA · {visIaConsolidationMeta.passName}</p>
+      <h1>Konsolideringsklarhet før tremeny</h1>
       <p>{visIaInventoryMeta.purpose}</p>
       <p class="ia-inv__meta">
-        Oppdatert {visIaInventoryMeta.updatedAt} · {entries.length} flater · mandatvurdering per flate
+        Oppdatert {visIaInventoryMeta.updatedAt} · {entries.length} flater vurdert
       </p>
     </header>
 
-    <section class="ia-inv__section" aria-labelledby="ia-inv-tasks">
-      <h2 id="ia-inv-tasks">Top tasks VIS skal støtte</h2>
-      <p class="ia-inv__lead">Grunnlag for tremodell v0.2 — behov først, routes etter.</p>
-      <ol class="ia-inv__task-list">
-        {topTaskOrder.map((task) => (
-          <li>
-            <strong>{visIaTopTaskLabels[task]}</strong>
-            <span class="ia-inv__task-count">
-              {getVisIaEntriesByTopTask(task).length} flater
-            </span>
-          </li>
-        ))}
-      </ol>
+    <section class="ia-inv__dashboard" aria-label="QA-oppsummering">
+      <article class="ia-inv__stat ia-inv__stat--highlight">
+        <span class="ia-inv__stat-n">{thomasReview.length}</span>
+        <span class="ia-inv__stat-l">Trenger Thomas</span>
+      </article>
+      <article class="ia-inv__stat">
+        <span class="ia-inv__stat-n">{mergeCandidates.length}</span>
+        <span class="ia-inv__stat-l">Slå sammen (label/nav)</span>
+      </article>
+      <article class="ia-inv__stat">
+        <span class="ia-inv__stat-n">{archiveCandidates.length}</span>
+        <span class="ia-inv__stat-l">Arkiver</span>
+      </article>
+      <article class="ia-inv__stat">
+        <span class="ia-inv__stat-n">{deleteCandidates.length}</span>
+        <span class="ia-inv__stat-l">Vurder sletting</span>
+      </article>
     </section>
 
-    <section class="ia-inv__section" aria-labelledby="ia-inv-tree-v02">
-      <h2 id="ia-inv-tree-v02">Foreslått tremeny v0.2 (need-led)</h2>
-      <p class="ia-inv__lead">Organisert etter top tasks — Thomas QA før implementasjon.</p>
-      <VisIaTreeBranch nodes={visIaTreeProposalV02} base={base} />
-    </section>
+    {
+      thomasReview.length ? (
+        <section class="ia-inv__section ia-inv__section--accent" aria-labelledby="ia-inv-thomas">
+          <h2 id="ia-inv-thomas">Dette må Thomas vurdere</h2>
+          <ul class="ia-inv__review-list">
+            {thomasReview.map((e) => (
+              <li>
+                <a href={`#${e.id}`}>{e.title}</a>
+                <span>{e.consolidation.futurePlacement}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null
+    }
 
-    <section class="ia-inv__section" aria-labelledby="ia-inv-overlap">
-      <h2 id="ia-inv-overlap">Overlap-analyse — dobbel konfekt</h2>
-      <ul class="ia-inv__cards">
+    <section class="ia-inv__section" aria-labelledby="ia-inv-deep">
+      <h2 id="ia-inv-deep">Grundig vurdering — seks konfliktområder</h2>
+      <p class="ia-inv__lead">
+        Vi skiller mellom «ligner på hverandre» og «løser samme behov». Route-overlapp er ikke alltid reelt overlapp.
+      </p>
+      <div class="ia-inv__deep-grid">
         {
-          visIaOverlapClusters.map((cluster) => (
-            <li class="ia-inv__card ia-inv__card--overlap">
-              <h3>{cluster.title}</h3>
-              <p class="ia-inv__card-surfaces">
-                Flater: {cluster.surfaces.join(" · ")}
-              </p>
-              <p class="ia-inv__card-conflict">
-                <strong>Konflikt:</strong> {cluster.conflict}
-              </p>
-              <p class="ia-inv__card-resolution">
-                <strong>Anbefaling:</strong> {cluster.resolution}
-              </p>
-            </li>
+          visIaDeepDiveAreas.map((area) => (
+            <article class="ia-inv__deep">
+              <p class="ia-inv__deep-letter">{area.letter}</p>
+              <h3>{area.title}</h3>
+              <p class="ia-inv__deep-summary">{area.summary}</p>
+              <dl class="ia-inv__deep-dl">
+                {area.clarifications.map((item) => (
+                  <div class="ia-inv__deep-qa">
+                    <dt>{item.question}</dt>
+                    <dd>{item.answer}</dd>
+                  </div>
+                ))}
+              </dl>
+              <div class="ia-inv__deep-cols">
+                <div>
+                  <h4>Må bevares ved sammenslåing</h4>
+                  <ul>
+                    {area.preserveWhenMerging.map((item) => (
+                      <li>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <h4>Skal ikke blandes</h4>
+                  <ul>
+                    {area.doNotMix.map((item) => (
+                      <li>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </article>
           ))
         }
-      </ul>
-    </section>
-
-    <section class="ia-inv__section" aria-labelledby="ia-inv-consolidation">
-      <h2 id="ia-inv-consolidation">Anbefalt konsolidering</h2>
-      <div class="ia-inv__summary-grid ia-inv__summary-grid--3">
-        <article>
-          <h3>Slå sammen ({mergeCandidates.length})</h3>
-          <ul>
-            {mergeCandidates.map((e) => (
-              <li>{e.title}</li>
-            ))}
-          </ul>
-        </article>
-        <article>
-          <h3>Arkiver ({archiveCandidates.length})</h3>
-          <ul>
-            {archiveCandidates.map((e) => (
-              <li>{e.title}</li>
-            ))}
-          </ul>
-        </article>
-        <article>
-          <h3>Vurder sletting ({deleteCandidates.length})</h3>
-          <ul>
-            {deleteCandidates.map((e) => (
-              <li>{e.title}</li>
-            ))}
-          </ul>
-        </article>
       </div>
-      <ul class="ia-inv__cards">
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-preserve">
+      <h2 id="ia-inv-preserve">Funksjonalitet som må bevares</h2>
+      <p class="ia-inv__lead">
+        Før vi slår sammen eller flytter — dette er det vi ikke kan miste.
+      </p>
+      <ul class="ia-inv__preserve-tags">
+        {preserveValues.map((v) => (
+          <li>{v}</li>
+        ))}
+      </ul>
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-tree">
+      <h2 id="ia-inv-tree">Anbefalt tremodell v0.3</h2>
+      <p class="ia-inv__lead">{visIaTreeProposalV03.note}</p>
+      <div class="ia-inv__tree-v03">
         {
-          visIaConsolidationNotes.map((note) => (
-            <li class="ia-inv__card">
-              <h3>{note.title}</h3>
-              <p class="ia-inv__card-rec">{note.recommendation}</p>
-              <p>{note.rationale}</p>
-            </li>
+          visIaTreeProposalV03.sections.map((section) => (
+            <article class="ia-inv__tree-section">
+              <h3>{section.label}</h3>
+              <ul>
+                {section.items.map((item) => (
+                  <li>
+                    {item.href ? (
+                      <a href={`${base}${item.href.replace(/^\//, "")}`}>{item.label}</a>
+                    ) : (
+                      item.label
+                    )}
+                    {item.note ? <span>{item.note}</span> : null}
+                  </li>
+                ))}
+              </ul>
+            </article>
           ))
         }
-      </ul>
+      </div>
     </section>
 
     <section class="ia-inv__section" aria-labelledby="ia-inv-contract">
-      <h2 id="ia-inv-contract">Forslag: page contract / metadata</h2>
-      <p class="ia-inv__lead">
-        Maskinlesbart format slik VIS-header senere kan vise hensikt, status og canonical kilde automatisk.
-        {needsContract.length} flater anbefalt merket.
-      </p>
-      <div class="ia-inv__table-wrap">
-        <table class="ia-inv__table">
-          <thead>
-            <tr>
-              <th>Felt</th>
-              <th>Påkrevd</th>
-              <th>Beskrivelse</th>
-            </tr>
-          </thead>
-          <tbody>
-            {
-              visIaPageContractProposal.map((field) => (
-                <tr>
-                  <td><code>{field.field}</code></td>
-                  <td>{field.required ? "Ja" : "Nei"}</td>
-                  <td>
-                    {field.description}
-                    {field.example ? <span class="ia-inv__file">f.eks. {field.example}</span> : null}
-                  </td>
-                </tr>
-              ))
-            }
-          </tbody>
-        </table>
+      <h2 id="ia-inv-contract">Page contract — for VIS-header senere</h2>
+      <p class="ia-inv__lead">{visIaMetadataStrategy.summary}</p>
+      <div class="ia-inv__strategy-grid">
+        <article>
+          <h3>Per side</h3>
+          <p>{visIaMetadataStrategy.perPage}</p>
+        </article>
+        <article>
+          <h3>Sentral registry</h3>
+          <p>{visIaMetadataStrategy.centralRegistry}</p>
+        </article>
+        <article>
+          <h3>Gjeninnføre header-hensikt</h3>
+          <p>{visIaMetadataStrategy.headerRevival}</p>
+        </article>
       </div>
+      <ul class="ia-inv__contract-fields">
+        {
+          visIaPageContractV03Fields.map((f) => (
+            <li>
+              <code>{f.field}</code>
+              {f.required ? " · påkrevd" : " · valgfri"}
+              <span>{f.description}</span>
+            </li>
+          ))
+        }
+      </ul>
       <details class="ia-inv__details">
-        <summary>Eksempel page contract (JSON/frontmatter)</summary>
-        <pre class="ia-inv__pre">{JSON.stringify(visIaPageContractExample, null, 2)}</pre>
+        <summary>Eksempel page contract</summary>
+        <pre class="ia-inv__pre">{JSON.stringify(visIaPageContractV03Example, null, 2)}</pre>
       </details>
     </section>
 
-    <section class="ia-inv__section" aria-labelledby="ia-inv-mandate">
-      <h2 id="ia-inv-mandate">Mandatvurdering per flate</h2>
-      {
-        grouped.map(({ status, items }) => (
-          <div class="ia-inv__group">
-            <h3>{statusLabels[status]} ({items.length})</h3>
-            <div class="ia-inv__mandate-grid">
-              {items.map((entry) => (
-                <article class="ia-inv__mandate-card">
-                  <header>
-                    <h4>{entry.title}</h4>
-                    <code class="ia-inv__route">{entry.route}</code>
-                  </header>
-                  <dl class="ia-inv__mandate-dl">
-                    <div>
-                      <dt>Behov</dt>
-                      <dd>{entry.mandate.userNeed}</dd>
-                    </div>
-                    <div>
-                      <dt>Primær top task</dt>
-                      <dd>{visIaTopTaskLabels[entry.mandate.primaryTask]}</dd>
-                    </div>
-                    {
-                      entry.mandate.secondaryTask ? (
-                        <div>
-                          <dt>Sekundær top task</dt>
-                          <dd>{visIaTopTaskLabels[entry.mandate.secondaryTask]}</dd>
-                        </div>
-                      ) : null
-                    }
-                    <div>
-                      <dt>Målgruppe</dt>
-                      <dd>{entry.mandate.audience.length ? entry.mandate.audience.join(", ") : "—"}</dd>
-                    </div>
-                    <div>
-                      <dt>Kjerneinnhold</dt>
-                      <dd>{entry.mandate.coreContent}</dd>
-                    </div>
-                    <div>
-                      <dt>Etter bruk</dt>
-                      <dd>{entry.mandate.postUseAction}</dd>
-                    </div>
-                    {
-                      entry.mandate.overlappingSurfaces.length ? (
-                        <div>
-                          <dt>Overlapper med</dt>
-                          <dd>{entry.mandate.overlappingSurfaces.join(" · ")}</dd>
-                        </div>
-                      ) : null
-                    }
-                    <div>
-                      <dt>Hub-plassering</dt>
-                      <dd>{entry.mandate.hubPlacement}</dd>
-                    </div>
-                    <div>
-                      <dt>Foreslått i tre v0.2</dt>
-                      <dd>{entry.suggestedPlacement}</dd>
-                    </div>
-                  </dl>
-                  <footer>
-                    <span class={`ia-inv__pill ia-inv__pill--${entry.recommendation.replace(/\s+/g, "-")}`}>
-                      {recommendationLabels[entry.recommendation]}
-                    </span>
-                    {entry.mandate.needsPageContract ? (
-                      <span class="ia-inv__pill ia-inv__pill--contract">Page contract</span>
-                    ) : null}
-                  </footer>
-                </article>
+    {
+      topTaskOrder.map((task) => {
+        const taskEntries = entriesForTask(task);
+        if (!taskEntries.length) return null;
+        return (
+          <section class="ia-inv__section ia-inv__section--task" aria-labelledby={`ia-task-${task}`}>
+            <h2 id={`ia-task-${task}`}>{visIaTopTaskLabels[task]}</h2>
+            <p class="ia-inv__lead">{taskEntries.length} flater · gruppert etter behov</p>
+            <div class="ia-inv__surface-grid">
+              {taskEntries.map((entry) => (
+                <VisIaSurfaceCard entry={entry} consolidation={entry.consolidation} base={base} />
               ))}
             </div>
-          </div>
-        ))
-      }
-    </section>
-
-    <section class="ia-inv__section" aria-labelledby="ia-inv-tree-v01">
-      <h2 id="ia-inv-tree-v01">Tremeny v0.1 (route-basert) — referanse</h2>
-      <p class="ia-inv__lead">Beholdt for sammenligning med v0.2.</p>
-      <VisIaTreeBranch nodes={visIaTreeProposal} base={base} />
-    </section>
+          </section>
+        );
+      })
+    }
   </main>
 
   <style>
     .ia-inv {
-      max-width: 56rem;
+      max-width: 52rem;
       margin: 0 auto;
-      padding: 1.5rem 1rem 3rem;
+      padding: 1.5rem 1rem 3.5rem;
       color: rgb(17 24 39);
     }
 
@@ -336,14 +272,15 @@ const needsContract = entries.filter((e) => e.mandate.needsPageContract);
 
     .ia-inv__hero h1 {
       margin: 0.35rem 0 0;
-      font-size: clamp(1.5rem, 3vw, 2rem);
+      font-size: clamp(1.45rem, 3vw, 1.9rem);
       font-weight: 650;
       letter-spacing: -0.03em;
+      line-height: 1.2;
     }
 
     .ia-inv__hero p {
       margin: 0.55rem 0 0;
-      max-width: 40rem;
+      max-width: 38rem;
       font-size: 0.92rem;
       line-height: 1.55;
       color: rgb(75 85 99);
@@ -354,259 +291,285 @@ const needsContract = entries.filter((e) => e.mandate.needsPageContract);
       color: rgb(156 163 175) !important;
     }
 
-    .ia-inv__section {
-      margin-top: 2.25rem;
-      padding-top: 1.5rem;
-      border-top: 1px solid rgb(243 244 246);
-    }
-
-    .ia-inv__section h2 {
-      margin: 0;
-      font-size: 1rem;
-      font-weight: 650;
-      letter-spacing: -0.02em;
-    }
-
-    .ia-inv__lead {
-      margin: 0.35rem 0 0.85rem;
-      font-size: 0.84rem;
-      color: rgb(107 114 128);
-    }
-
-    .ia-inv__task-list {
-      margin: 0;
-      padding-left: 1.25rem;
-      font-size: 0.84rem;
-      line-height: 1.6;
-    }
-
-    .ia-inv__task-count {
-      display: block;
-      font-size: 0.72rem;
-      color: rgb(156 163 175);
-      font-weight: 400;
-    }
-
-    .ia-inv__tree {
-      margin: 0;
-      padding-left: 0;
-      list-style: none;
-      font-size: 0.86rem;
-      line-height: 1.5;
-    }
-
-    .ia-inv__tree ul {
-      margin: 0.25rem 0 0.35rem;
-      padding-left: 1.15rem;
-      list-style: none;
-      border-left: 1px solid rgb(229 231 235);
-    }
-
-    .ia-inv__tree-root + .ia-inv__tree-root {
-      margin-top: 0.75rem;
-    }
-
-    .ia-inv__tree-label {
-      font-weight: 600;
-      color: rgb(31 41 55);
-    }
-
-    .ia-inv__tree-label a {
-      color: inherit;
-      text-decoration: underline;
-      text-underline-offset: 2px;
-      text-decoration-color: rgb(209 213 219);
-    }
-
-    .ia-inv__tree-task {
-      display: block;
-      margin-top: 0.1rem;
-      font-size: 0.68rem;
-      font-weight: 600;
-      color: rgb(99 102 241);
-    }
-
-    .ia-inv__tree-note {
-      display: block;
-      margin-top: 0.1rem;
-      font-size: 0.76rem;
-      color: rgb(156 163 175);
-    }
-
-    .ia-inv__cards {
-      margin: 0.85rem 0 0;
-      padding: 0;
-      list-style: none;
+    .ia-inv__dashboard {
       display: grid;
-      gap: 0.75rem;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 0.65rem;
+      margin-top: 1.5rem;
     }
 
-    .ia-inv__card {
-      padding: 0.85rem 0;
-      border-bottom: 1px solid rgb(243 244 246);
-    }
-
-    .ia-inv__card h3 {
-      margin: 0;
-      font-size: 0.9rem;
-      font-weight: 650;
-    }
-
-    .ia-inv__card-rec {
-      margin: 0.25rem 0 0;
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: rgb(55 65 81);
-    }
-
-    .ia-inv__card p:last-child {
-      margin: 0.35rem 0 0;
-      font-size: 0.82rem;
-      line-height: 1.45;
-      color: rgb(107 114 128);
-    }
-
-    .ia-inv__card-surfaces {
-      margin: 0.25rem 0 0 !important;
-      font-size: 0.75rem !important;
-      color: rgb(156 163 175) !important;
-    }
-
-    .ia-inv__card-conflict,
-    .ia-inv__card-resolution {
-      margin: 0.45rem 0 0 !important;
-      font-size: 0.82rem !important;
-      line-height: 1.45;
-    }
-
-    .ia-inv__summary-grid {
-      display: grid;
-      gap: 1rem;
-      margin-top: 0.85rem;
-    }
-
-    .ia-inv__summary-grid h3 {
-      margin: 0 0 0.45rem;
-      font-size: 0.82rem;
-      font-weight: 650;
-      color: rgb(75 85 99);
-    }
-
-    .ia-inv__summary-grid ul {
-      margin: 0;
-      padding-left: 1.1rem;
-      font-size: 0.8rem;
-      color: rgb(107 114 128);
-    }
-
-    .ia-inv__group {
-      margin-top: 1.25rem;
-    }
-
-    .ia-inv__group h3 {
-      margin: 0 0 0.75rem;
-      font-size: 0.78rem;
-      font-weight: 650;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: rgb(107 114 128);
-    }
-
-    .ia-inv__mandate-grid {
-      display: grid;
-      gap: 0.85rem;
-    }
-
-    .ia-inv__mandate-card {
+    .ia-inv__stat {
       padding: 0.85rem 1rem;
       border: 1px solid rgb(243 244 246);
       border-radius: 0.5rem;
       background: rgb(249 250 251);
     }
 
-    .ia-inv__mandate-card h4 {
+    .ia-inv__stat--highlight {
+      border-color: rgb(254 215 170);
+      background: rgb(255 251 245);
+    }
+
+    .ia-inv__stat-n {
+      display: block;
+      font-size: 1.5rem;
+      font-weight: 650;
+      letter-spacing: -0.03em;
+      line-height: 1;
+    }
+
+    .ia-inv__stat-l {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.72rem;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__section {
+      margin-top: 2.5rem;
+      padding-top: 1.75rem;
+      border-top: 1px solid rgb(243 244 246);
+    }
+
+    .ia-inv__section--accent {
+      border-top-color: rgb(254 215 170);
+      background: rgb(255 251 245);
+      margin-left: -1rem;
+      margin-right: -1rem;
+      padding: 1.25rem 1rem 1.5rem;
+      border-radius: 0.5rem;
+      border: 1px solid rgb(254 215 170);
+    }
+
+    .ia-inv__section h2 {
       margin: 0;
-      font-size: 0.88rem;
+      font-size: 1.05rem;
+      font-weight: 650;
+      letter-spacing: -0.02em;
+    }
+
+    .ia-inv__lead {
+      margin: 0.4rem 0 1rem;
+      font-size: 0.84rem;
+      line-height: 1.5;
+      color: rgb(107 114 128);
+      max-width: 40rem;
+    }
+
+    .ia-inv__review-list {
+      margin: 0.75rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .ia-inv__review-list li {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      align-items: baseline;
+      padding: 0.45rem 0;
+      border-bottom: 1px solid rgb(254 235 200);
+      font-size: 0.84rem;
+    }
+
+    .ia-inv__review-list a {
+      font-weight: 600;
+      color: rgb(194 65 12);
+    }
+
+    .ia-inv__review-list span {
+      font-size: 0.72rem;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__deep-grid {
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .ia-inv__deep {
+      padding: 1rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .ia-inv__deep-letter {
+      margin: 0;
+      font-size: 0.65rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      color: rgb(99 102 241);
+    }
+
+    .ia-inv__deep h3 {
+      margin: 0.2rem 0 0;
+      font-size: 0.92rem;
       font-weight: 650;
     }
 
-    .ia-inv__route {
-      display: block;
-      margin-top: 0.2rem;
-      font-size: 0.68rem;
+    .ia-inv__deep-summary {
+      margin: 0.4rem 0 0;
+      font-size: 0.84rem;
+      line-height: 1.5;
+      color: rgb(75 85 99);
+    }
+
+    .ia-inv__deep-dl {
+      margin: 0.75rem 0 0;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .ia-inv__deep-qa dt {
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: rgb(55 65 81);
+    }
+
+    .ia-inv__deep-qa dd {
+      margin: 0.15rem 0 0;
+      font-size: 0.8rem;
+      line-height: 1.45;
       color: rgb(107 114 128);
-      word-break: break-all;
     }
 
-    .ia-inv__mandate-dl {
-      margin: 0.65rem 0 0;
+    .ia-inv__deep-cols {
       display: grid;
-      gap: 0.45rem;
+      gap: 0.75rem;
+      margin-top: 0.85rem;
     }
 
-    .ia-inv__mandate-dl div {
-      display: grid;
-      gap: 0.1rem;
-    }
-
-    .ia-inv__mandate-dl dt {
-      font-size: 0.65rem;
+    .ia-inv__deep-cols h4 {
+      margin: 0 0 0.35rem;
+      font-size: 0.68rem;
       font-weight: 650;
       letter-spacing: 0.05em;
       text-transform: uppercase;
       color: rgb(156 163 175);
     }
 
-    .ia-inv__mandate-dl dd {
+    .ia-inv__deep-cols ul {
       margin: 0;
-      font-size: 0.8rem;
+      padding-left: 1.1rem;
+      font-size: 0.78rem;
+      color: rgb(107 114 128);
       line-height: 1.45;
+    }
+
+    .ia-inv__preserve-tags {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+    }
+
+    .ia-inv__preserve-tags li {
+      font-size: 0.75rem;
+      padding: 0.25rem 0.55rem;
+      border-radius: 999px;
+      background: rgb(236 253 245);
+      color: rgb(6 95 70);
+      border: 1px solid rgb(209 250 229);
+    }
+
+    .ia-inv__tree-v03 {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .ia-inv__tree-section {
+      padding: 0.85rem 1rem;
+      border: 1px solid rgb(243 244 246);
+      border-radius: 0.5rem;
+      background: rgb(249 250 251);
+    }
+
+    .ia-inv__tree-section h3 {
+      margin: 0 0 0.5rem;
+      font-size: 0.82rem;
+      font-weight: 650;
       color: rgb(55 65 81);
     }
 
-    .ia-inv__mandate-card footer {
-      margin-top: 0.65rem;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.35rem;
+    .ia-inv__tree-section ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      font-size: 0.8rem;
     }
 
-    .ia-inv__table-wrap {
-      overflow-x: auto;
-    }
-
-    .ia-inv__table {
-      width: 100%;
-      border-collapse: collapse;
-      font-size: 0.78rem;
-    }
-
-    .ia-inv__table th,
-    .ia-inv__table td {
-      padding: 0.55rem 0.45rem;
-      text-align: left;
-      vertical-align: top;
+    .ia-inv__tree-section li {
+      padding: 0.3rem 0;
       border-bottom: 1px solid rgb(243 244 246);
     }
 
-    .ia-inv__table th {
-      font-size: 0.68rem;
-      font-weight: 650;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: rgb(156 163 175);
+    .ia-inv__tree-section li:last-child {
+      border-bottom: none;
     }
 
-    .ia-inv__file {
+    .ia-inv__tree-section a {
+      font-weight: 600;
+      color: rgb(31 41 55);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      text-decoration-color: rgb(209 213 219);
+    }
+
+    .ia-inv__tree-section span {
       display: block;
-      margin-top: 0.15rem;
-      font-family: ui-monospace, monospace;
-      font-size: 0.65rem;
+      margin-top: 0.1rem;
+      font-size: 0.72rem;
       color: rgb(156 163 175);
     }
 
-    .ia-inv__table code {
-      font-size: 0.7rem;
+    .ia-inv__strategy-grid {
+      display: grid;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .ia-inv__strategy-grid article {
+      padding: 0.75rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .ia-inv__strategy-grid h3 {
+      margin: 0 0 0.3rem;
+      font-size: 0.78rem;
+      font-weight: 650;
+      color: rgb(75 85 99);
+    }
+
+    .ia-inv__strategy-grid p {
+      margin: 0;
+      font-size: 0.8rem;
+      line-height: 1.45;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__contract-fields {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 0.45rem;
+    }
+
+    .ia-inv__contract-fields li {
+      font-size: 0.78rem;
+      color: rgb(75 85 99);
+    }
+
+    .ia-inv__contract-fields code {
+      font-size: 0.72rem;
+      font-weight: 600;
+    }
+
+    .ia-inv__contract-fields span {
+      display: block;
+      margin-top: 0.1rem;
+      color: rgb(156 163 175);
     }
 
     .ia-inv__details {
@@ -624,61 +587,33 @@ const needsContract = entries.filter((e) => e.mandate.needsPageContract);
       overflow-x: auto;
     }
 
-    .ia-inv__pill {
-      display: inline-block;
-      padding: 0.12rem 0.45rem;
-      border-radius: 999px;
-      font-size: 0.68rem;
-      font-weight: 600;
-      border: 1px solid rgb(229 231 235);
-      white-space: nowrap;
+    .ia-inv__section--task {
+      scroll-margin-top: 1rem;
     }
 
-    .ia-inv__pill--behold {
-      border-color: rgb(209 250 229);
-      color: rgb(6 95 70);
-      background: rgb(236 253 245);
-    }
-
-    .ia-inv__pill--slå-sammen,
-    .ia-inv__pill--flytt-under {
-      border-color: rgb(191 219 254);
-      color: rgb(30 64 175);
-      background: rgb(239 246 255);
-    }
-
-    .ia-inv__pill--arkiver {
-      border-color: rgb(254 243 199);
-      color: rgb(146 64 14);
-      background: rgb(255 251 235);
-    }
-
-    .ia-inv__pill--vurder-sletting {
-      border-color: rgb(254 202 202);
-      color: rgb(153 27 27);
-      background: rgb(254 242 242);
-    }
-
-    .ia-inv__pill--contract {
-      border-color: rgb(221 214 254);
-      color: rgb(91 33 182);
-      background: rgb(245 243 255);
+    .ia-inv__surface-grid {
+      display: grid;
+      gap: 0.85rem;
     }
 
     @media (min-width: 768px) {
       .ia-inv {
-        padding: 2rem 1.5rem 3.5rem;
+        padding: 2rem 1.5rem 4rem;
       }
 
-      .ia-inv__summary-grid {
+      .ia-inv__dashboard {
+        grid-template-columns: repeat(4, 1fr);
+      }
+
+      .ia-inv__deep-cols {
         grid-template-columns: 1fr 1fr;
       }
 
-      .ia-inv__summary-grid--3 {
+      .ia-inv__strategy-grid {
         grid-template-columns: 1fr 1fr 1fr;
       }
 
-      .ia-inv__mandate-grid {
+      .ia-inv__tree-v03 {
         grid-template-columns: 1fr 1fr;
       }
     }

--- a/src/pages/vis/system/ia-inventory-v01.astro
+++ b/src/pages/vis/system/ia-inventory-v01.astro
@@ -1,0 +1,479 @@
+---
+/* CONTRACT: VIS IA Inventory v0.1 — intern analyseflate for kartlegging før tremeny. */
+import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import {
+  getVisIaEntriesByRecommendation,
+  getVisIaEntriesByStatus,
+  getVisIaInventoryEntries,
+  visIaConsolidationNotes,
+  visIaInventoryMeta,
+  visIaTreeProposal,
+  type VisIaEntry,
+  type VisIaStatus,
+} from "../../../data/vis-ia-inventory-v01.ts";
+
+const base = import.meta.env.BASE_URL;
+const entries = getVisIaInventoryEntries();
+
+const statusOrder: VisIaStatus[] = [
+  "active",
+  "canonical",
+  "lab",
+  "reference",
+  "planned",
+  "historical",
+  "legacy",
+  "unknown",
+];
+
+const statusLabels: Record<VisIaStatus, string> = {
+  active: "Active",
+  canonical: "Canonical",
+  planned: "Planned",
+  reference: "Reference",
+  lab: "Lab",
+  historical: "Historical",
+  legacy: "Legacy",
+  unknown: "Unknown",
+};
+
+const recommendationLabels = {
+  behold: "Behold",
+  "slå sammen": "Slå sammen",
+  flytt: "Flytt",
+  arkiver: "Arkiver",
+  "vurder sletting": "Vurder sletting",
+} as const;
+
+function groupByStatus(items: VisIaEntry[]) {
+  return statusOrder
+    .map((status) => ({
+      status,
+      items: items.filter((e) => e.status === status),
+    }))
+    .filter((g) => g.items.length > 0);
+}
+
+const grouped = groupByStatus(entries);
+const archiveCandidates = getVisIaEntriesByRecommendation("arkiver");
+const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
+---
+
+<PrototypeLayout title="VIS IA Inventory v0.1">
+  <main class="ia-inv">
+    <nav class="ia-inv__crumb">
+      <a href={`${base}vis`}>VIS</a>
+      <span aria-hidden="true">/</span>
+      <a href={`${base}vis/system`}>System</a>
+      <span aria-hidden="true">/</span>
+      <span>IA Inventory</span>
+    </nav>
+
+    <header class="ia-inv__hero">
+      <p class="ia-inv__kicker">VIS · IA · analyse {visIaInventoryMeta.version}</p>
+      <h1>VIS IA Inventory</h1>
+      <p>{visIaInventoryMeta.purpose}</p>
+      <p class="ia-inv__meta">Oppdatert {visIaInventoryMeta.updatedAt} · {entries.length} flater kartlagt</p>
+    </header>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-tree">
+      <h2 id="ia-inv-tree">Foreslått tremeny v0.1</h2>
+      <p class="ia-inv__lead">Thomas QA — før implementasjon av lokal navigasjon.</p>
+      <ul class="ia-inv__tree">
+        {
+          visIaTreeProposal.map((root) => (
+            <li class="ia-inv__tree-root">
+              <span class="ia-inv__tree-label">
+                {root.href ? <a href={`${base}${root.href.replace(/^\//, "")}`}>{root.label}</a> : root.label}
+              </span>
+              {root.note ? <span class="ia-inv__tree-note">{root.note}</span> : null}
+              {
+                root.children ? (
+                  <ul>
+                    {root.children.map((child) => (
+                      <li>
+                        <span class="ia-inv__tree-label">
+                          {child.href ? (
+                            <a href={`${base}${child.href.replace(/^\//, "")}`}>{child.label}</a>
+                          ) : (
+                            child.label
+                          )}
+                        </span>
+                        {child.note ? <span class="ia-inv__tree-note">{child.note}</span> : null}
+                        {
+                          child.children ? (
+                            <ul>
+                              {child.children.map((leaf) => (
+                                <li>
+                                  <span class="ia-inv__tree-label">
+                                    {leaf.href ? (
+                                      <a href={`${base}${leaf.href.replace(/^\//, "")}`}>{leaf.label}</a>
+                                    ) : (
+                                      leaf.label
+                                    )}
+                                  </span>
+                                  {leaf.note ? <span class="ia-inv__tree-note">{leaf.note}</span> : null}
+                                </li>
+                              ))}
+                            </ul>
+                          ) : null
+                        }
+                      </li>
+                    ))}
+                  </ul>
+                ) : null
+              }
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-consolidation">
+      <h2 id="ia-inv-consolidation">Konsolidering — viktige vurderinger</h2>
+      <ul class="ia-inv__cards">
+        {
+          visIaConsolidationNotes.map((note) => (
+            <li class="ia-inv__card">
+              <h3>{note.title}</h3>
+              <p class="ia-inv__card-rec">{note.recommendation}</p>
+              <p>{note.rationale}</p>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-archive">
+      <h2 id="ia-inv-archive">Arkiv / sletting senere</h2>
+      <div class="ia-inv__summary-grid">
+        <article>
+          <h3>Anbefalt arkivering ({archiveCandidates.length})</h3>
+          <ul>
+            {archiveCandidates.map((e) => (
+              <li>{e.title}</li>
+            ))}
+          </ul>
+        </article>
+        <article>
+          <h3>Vurder sletting ({deleteCandidates.length})</h3>
+          <ul>
+            {deleteCandidates.map((e) => (
+              <li>{e.title}</li>
+            ))}
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-full">
+      <h2 id="ia-inv-full">Fullt inventar</h2>
+      {
+        grouped.map(({ status, items }) => (
+          <div class="ia-inv__group">
+            <h3>{statusLabels[status]} ({items.length})</h3>
+            <div class="ia-inv__table-wrap">
+              <table class="ia-inv__table">
+                <thead>
+                  <tr>
+                    <th>Flate</th>
+                    <th>Route</th>
+                    <th>Foreslått</th>
+                    <th>Anbefaling</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((entry) => (
+                    <tr>
+                      <td>
+                        <strong>{entry.title}</strong>
+                        <span class="ia-inv__rationale">{entry.rationale}</span>
+                      </td>
+                      <td>
+                        <code>{entry.route}</code>
+                        {entry.sourceFile ? <span class="ia-inv__file">{entry.sourceFile}</span> : null}
+                      </td>
+                      <td>{entry.suggestedPlacement}</td>
+                      <td>
+                        <span class={`ia-inv__pill ia-inv__pill--${entry.recommendation.replace(/\s+/g, "-")}`}>
+                          {recommendationLabels[entry.recommendation]}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ))
+      }
+    </section>
+  </main>
+
+  <style>
+    .ia-inv {
+      max-width: 56rem;
+      margin: 0 auto;
+      padding: 1.5rem 1rem 3rem;
+      color: rgb(17 24 39);
+    }
+
+    .ia-inv__crumb {
+      display: flex;
+      gap: 0.4rem;
+      align-items: center;
+      font-size: 0.72rem;
+      color: rgb(107 114 128);
+      margin-bottom: 1rem;
+    }
+
+    .ia-inv__crumb a {
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .ia-inv__kicker {
+      margin: 0;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__hero h1 {
+      margin: 0.35rem 0 0;
+      font-size: clamp(1.5rem, 3vw, 2rem);
+      font-weight: 650;
+      letter-spacing: -0.03em;
+    }
+
+    .ia-inv__hero p {
+      margin: 0.55rem 0 0;
+      max-width: 40rem;
+      font-size: 0.92rem;
+      line-height: 1.55;
+      color: rgb(75 85 99);
+    }
+
+    .ia-inv__meta {
+      font-size: 0.78rem !important;
+      color: rgb(156 163 175) !important;
+    }
+
+    .ia-inv__section {
+      margin-top: 2.25rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid rgb(243 244 246);
+    }
+
+    .ia-inv__section h2 {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 650;
+      letter-spacing: -0.02em;
+    }
+
+    .ia-inv__lead {
+      margin: 0.35rem 0 0.85rem;
+      font-size: 0.84rem;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__tree {
+      margin: 0;
+      padding-left: 0;
+      list-style: none;
+      font-size: 0.86rem;
+      line-height: 1.5;
+    }
+
+    .ia-inv__tree ul {
+      margin: 0.25rem 0 0.35rem;
+      padding-left: 1.15rem;
+      list-style: none;
+      border-left: 1px solid rgb(229 231 235);
+    }
+
+    .ia-inv__tree-root + .ia-inv__tree-root {
+      margin-top: 0.5rem;
+    }
+
+    .ia-inv__tree-label {
+      font-weight: 600;
+      color: rgb(31 41 55);
+    }
+
+    .ia-inv__tree-label a {
+      color: inherit;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      text-decoration-color: rgb(209 213 219);
+    }
+
+    .ia-inv__tree-note {
+      display: block;
+      margin-top: 0.1rem;
+      font-size: 0.76rem;
+      color: rgb(156 163 175);
+    }
+
+    .ia-inv__cards {
+      margin: 0.85rem 0 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .ia-inv__card {
+      padding: 0.85rem 0;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .ia-inv__card h3 {
+      margin: 0;
+      font-size: 0.9rem;
+      font-weight: 650;
+    }
+
+    .ia-inv__card-rec {
+      margin: 0.25rem 0 0;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: rgb(55 65 81);
+    }
+
+    .ia-inv__card p:last-child {
+      margin: 0.35rem 0 0;
+      font-size: 0.82rem;
+      line-height: 1.45;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__summary-grid {
+      display: grid;
+      gap: 1rem;
+      margin-top: 0.85rem;
+    }
+
+    .ia-inv__summary-grid h3 {
+      margin: 0 0 0.45rem;
+      font-size: 0.82rem;
+      font-weight: 650;
+      color: rgb(75 85 99);
+    }
+
+    .ia-inv__summary-grid ul {
+      margin: 0;
+      padding-left: 1.1rem;
+      font-size: 0.8rem;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__group {
+      margin-top: 1.25rem;
+    }
+
+    .ia-inv__group h3 {
+      margin: 0 0 0.5rem;
+      font-size: 0.78rem;
+      font-weight: 650;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__table-wrap {
+      overflow-x: auto;
+    }
+
+    .ia-inv__table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.78rem;
+    }
+
+    .ia-inv__table th,
+    .ia-inv__table td {
+      padding: 0.55rem 0.45rem;
+      text-align: left;
+      vertical-align: top;
+      border-bottom: 1px solid rgb(243 244 246);
+    }
+
+    .ia-inv__table th {
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .ia-inv__rationale {
+      display: block;
+      margin-top: 0.2rem;
+      font-weight: 400;
+      color: rgb(156 163 175);
+      line-height: 1.4;
+    }
+
+    .ia-inv__file {
+      display: block;
+      margin-top: 0.15rem;
+      font-family: ui-monospace, monospace;
+      font-size: 0.65rem;
+      color: rgb(156 163 175);
+    }
+
+    .ia-inv__table code {
+      font-size: 0.7rem;
+      word-break: break-all;
+    }
+
+    .ia-inv__pill {
+      display: inline-block;
+      padding: 0.12rem 0.45rem;
+      border-radius: 999px;
+      font-size: 0.68rem;
+      font-weight: 600;
+      border: 1px solid rgb(229 231 235);
+      white-space: nowrap;
+    }
+
+    .ia-inv__pill--behold {
+      border-color: rgb(209 250 229);
+      color: rgb(6 95 70);
+      background: rgb(236 253 245);
+    }
+
+    .ia-inv__pill--slå-sammen,
+    .ia-inv__pill--flytt {
+      border-color: rgb(191 219 254);
+      color: rgb(30 64 175);
+      background: rgb(239 246 255);
+    }
+
+    .ia-inv__pill--arkiver {
+      border-color: rgb(254 243 199);
+      color: rgb(146 64 14);
+      background: rgb(255 251 235);
+    }
+
+    .ia-inv__pill--vurder-sletting {
+      border-color: rgb(254 202 202);
+      color: rgb(153 27 27);
+      background: rgb(254 242 242);
+    }
+
+    @media (min-width: 768px) {
+      .ia-inv {
+        padding: 2rem 1.5rem 3.5rem;
+      }
+
+      .ia-inv__summary-grid {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+  </style>
+</PrototypeLayout>

--- a/src/pages/vis/system/ia-inventory-v01.astro
+++ b/src/pages/vis/system/ia-inventory-v01.astro
@@ -1,15 +1,24 @@
 ---
-/* CONTRACT: VIS IA Inventory v0.1 — intern analyseflate for kartlegging før tremeny. */
+/* CONTRACT: VIS IA Inventory v0.2 — mandatpass og kartlegging før tremeny. */
 import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import VisIaTreeBranch from "../../../components/vis/VisIaTreeBranch.astro";
 import {
-  getVisIaEntriesByRecommendation,
-  getVisIaEntriesByStatus,
+  getVisIaArchiveCandidates,
+  getVisIaDeleteCandidates,
+  getVisIaEntriesByTopTask,
   getVisIaInventoryEntries,
+  getVisIaMergeCandidates,
   visIaConsolidationNotes,
   visIaInventoryMeta,
+  visIaOverlapClusters,
+  visIaPageContractExample,
+  visIaPageContractProposal,
+  visIaTopTaskLabels,
   visIaTreeProposal,
+  visIaTreeProposalV02,
   type VisIaEntry,
   type VisIaStatus,
+  type VisIaTopTask,
 } from "../../../data/vis-ia-inventory-v01.ts";
 
 const base = import.meta.env.BASE_URL;
@@ -40,10 +49,21 @@ const statusLabels: Record<VisIaStatus, string> = {
 const recommendationLabels = {
   behold: "Behold",
   "slå sammen": "Slå sammen",
-  flytt: "Flytt",
+  "flytt under": "Flytt under",
   arkiver: "Arkiver",
   "vurder sletting": "Vurder sletting",
+  "trenger avklaring": "Trenger avklaring",
 } as const;
+
+const topTaskOrder: VisIaTopTask[] = [
+  "status-nå",
+  "jobber-med",
+  "finn-flate",
+  "beslutninger-qa",
+  "forstå-system",
+  "historikk",
+  "unngå-forveksling",
+];
 
 function groupByStatus(items: VisIaEntry[]) {
   return statusOrder
@@ -55,11 +75,13 @@ function groupByStatus(items: VisIaEntry[]) {
 }
 
 const grouped = groupByStatus(entries);
-const archiveCandidates = getVisIaEntriesByRecommendation("arkiver");
-const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
+const mergeCandidates = getVisIaMergeCandidates();
+const archiveCandidates = getVisIaArchiveCandidates();
+const deleteCandidates = getVisIaDeleteCandidates();
+const needsContract = entries.filter((e) => e.mandate.needsPageContract);
 ---
 
-<PrototypeLayout title="VIS IA Inventory v0.1">
+<PrototypeLayout title="VIS IA Inventory v0.2">
   <main class="ia-inv">
     <nav class="ia-inv__crumb">
       <a href={`${base}vis`}>VIS</a>
@@ -70,59 +92,51 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
     </nav>
 
     <header class="ia-inv__hero">
-      <p class="ia-inv__kicker">VIS · IA · analyse {visIaInventoryMeta.version}</p>
+      <p class="ia-inv__kicker">VIS · IA · {visIaInventoryMeta.mandatePass}</p>
       <h1>VIS IA Inventory</h1>
       <p>{visIaInventoryMeta.purpose}</p>
-      <p class="ia-inv__meta">Oppdatert {visIaInventoryMeta.updatedAt} · {entries.length} flater kartlagt</p>
+      <p class="ia-inv__meta">
+        Oppdatert {visIaInventoryMeta.updatedAt} · {entries.length} flater · mandatvurdering per flate
+      </p>
     </header>
 
-    <section class="ia-inv__section" aria-labelledby="ia-inv-tree">
-      <h2 id="ia-inv-tree">Foreslått tremeny v0.1</h2>
-      <p class="ia-inv__lead">Thomas QA — før implementasjon av lokal navigasjon.</p>
-      <ul class="ia-inv__tree">
+    <section class="ia-inv__section" aria-labelledby="ia-inv-tasks">
+      <h2 id="ia-inv-tasks">Top tasks VIS skal støtte</h2>
+      <p class="ia-inv__lead">Grunnlag for tremodell v0.2 — behov først, routes etter.</p>
+      <ol class="ia-inv__task-list">
+        {topTaskOrder.map((task) => (
+          <li>
+            <strong>{visIaTopTaskLabels[task]}</strong>
+            <span class="ia-inv__task-count">
+              {getVisIaEntriesByTopTask(task).length} flater
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-tree-v02">
+      <h2 id="ia-inv-tree-v02">Foreslått tremeny v0.2 (need-led)</h2>
+      <p class="ia-inv__lead">Organisert etter top tasks — Thomas QA før implementasjon.</p>
+      <VisIaTreeBranch nodes={visIaTreeProposalV02} base={base} />
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-overlap">
+      <h2 id="ia-inv-overlap">Overlap-analyse — dobbel konfekt</h2>
+      <ul class="ia-inv__cards">
         {
-          visIaTreeProposal.map((root) => (
-            <li class="ia-inv__tree-root">
-              <span class="ia-inv__tree-label">
-                {root.href ? <a href={`${base}${root.href.replace(/^\//, "")}`}>{root.label}</a> : root.label}
-              </span>
-              {root.note ? <span class="ia-inv__tree-note">{root.note}</span> : null}
-              {
-                root.children ? (
-                  <ul>
-                    {root.children.map((child) => (
-                      <li>
-                        <span class="ia-inv__tree-label">
-                          {child.href ? (
-                            <a href={`${base}${child.href.replace(/^\//, "")}`}>{child.label}</a>
-                          ) : (
-                            child.label
-                          )}
-                        </span>
-                        {child.note ? <span class="ia-inv__tree-note">{child.note}</span> : null}
-                        {
-                          child.children ? (
-                            <ul>
-                              {child.children.map((leaf) => (
-                                <li>
-                                  <span class="ia-inv__tree-label">
-                                    {leaf.href ? (
-                                      <a href={`${base}${leaf.href.replace(/^\//, "")}`}>{leaf.label}</a>
-                                    ) : (
-                                      leaf.label
-                                    )}
-                                  </span>
-                                  {leaf.note ? <span class="ia-inv__tree-note">{leaf.note}</span> : null}
-                                </li>
-                              ))}
-                            </ul>
-                          ) : null
-                        }
-                      </li>
-                    ))}
-                  </ul>
-                ) : null
-              }
+          visIaOverlapClusters.map((cluster) => (
+            <li class="ia-inv__card ia-inv__card--overlap">
+              <h3>{cluster.title}</h3>
+              <p class="ia-inv__card-surfaces">
+                Flater: {cluster.surfaces.join(" · ")}
+              </p>
+              <p class="ia-inv__card-conflict">
+                <strong>Konflikt:</strong> {cluster.conflict}
+              </p>
+              <p class="ia-inv__card-resolution">
+                <strong>Anbefaling:</strong> {cluster.resolution}
+              </p>
             </li>
           ))
         }
@@ -130,25 +144,18 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
     </section>
 
     <section class="ia-inv__section" aria-labelledby="ia-inv-consolidation">
-      <h2 id="ia-inv-consolidation">Konsolidering — viktige vurderinger</h2>
-      <ul class="ia-inv__cards">
-        {
-          visIaConsolidationNotes.map((note) => (
-            <li class="ia-inv__card">
-              <h3>{note.title}</h3>
-              <p class="ia-inv__card-rec">{note.recommendation}</p>
-              <p>{note.rationale}</p>
-            </li>
-          ))
-        }
-      </ul>
-    </section>
-
-    <section class="ia-inv__section" aria-labelledby="ia-inv-archive">
-      <h2 id="ia-inv-archive">Arkiv / sletting senere</h2>
-      <div class="ia-inv__summary-grid">
+      <h2 id="ia-inv-consolidation">Anbefalt konsolidering</h2>
+      <div class="ia-inv__summary-grid ia-inv__summary-grid--3">
         <article>
-          <h3>Anbefalt arkivering ({archiveCandidates.length})</h3>
+          <h3>Slå sammen ({mergeCandidates.length})</h3>
+          <ul>
+            {mergeCandidates.map((e) => (
+              <li>{e.title}</li>
+            ))}
+          </ul>
+        </article>
+        <article>
+          <h3>Arkiver ({archiveCandidates.length})</h3>
           <ul>
             {archiveCandidates.map((e) => (
               <li>{e.title}</li>
@@ -164,49 +171,135 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
           </ul>
         </article>
       </div>
+      <ul class="ia-inv__cards">
+        {
+          visIaConsolidationNotes.map((note) => (
+            <li class="ia-inv__card">
+              <h3>{note.title}</h3>
+              <p class="ia-inv__card-rec">{note.recommendation}</p>
+              <p>{note.rationale}</p>
+            </li>
+          ))
+        }
+      </ul>
     </section>
 
-    <section class="ia-inv__section" aria-labelledby="ia-inv-full">
-      <h2 id="ia-inv-full">Fullt inventar</h2>
+    <section class="ia-inv__section" aria-labelledby="ia-inv-contract">
+      <h2 id="ia-inv-contract">Forslag: page contract / metadata</h2>
+      <p class="ia-inv__lead">
+        Maskinlesbart format slik VIS-header senere kan vise hensikt, status og canonical kilde automatisk.
+        {needsContract.length} flater anbefalt merket.
+      </p>
+      <div class="ia-inv__table-wrap">
+        <table class="ia-inv__table">
+          <thead>
+            <tr>
+              <th>Felt</th>
+              <th>Påkrevd</th>
+              <th>Beskrivelse</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              visIaPageContractProposal.map((field) => (
+                <tr>
+                  <td><code>{field.field}</code></td>
+                  <td>{field.required ? "Ja" : "Nei"}</td>
+                  <td>
+                    {field.description}
+                    {field.example ? <span class="ia-inv__file">f.eks. {field.example}</span> : null}
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+      <details class="ia-inv__details">
+        <summary>Eksempel page contract (JSON/frontmatter)</summary>
+        <pre class="ia-inv__pre">{JSON.stringify(visIaPageContractExample, null, 2)}</pre>
+      </details>
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-mandate">
+      <h2 id="ia-inv-mandate">Mandatvurdering per flate</h2>
       {
         grouped.map(({ status, items }) => (
           <div class="ia-inv__group">
             <h3>{statusLabels[status]} ({items.length})</h3>
-            <div class="ia-inv__table-wrap">
-              <table class="ia-inv__table">
-                <thead>
-                  <tr>
-                    <th>Flate</th>
-                    <th>Route</th>
-                    <th>Foreslått</th>
-                    <th>Anbefaling</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {items.map((entry) => (
-                    <tr>
-                      <td>
-                        <strong>{entry.title}</strong>
-                        <span class="ia-inv__rationale">{entry.rationale}</span>
-                      </td>
-                      <td>
-                        <code>{entry.route}</code>
-                        {entry.sourceFile ? <span class="ia-inv__file">{entry.sourceFile}</span> : null}
-                      </td>
-                      <td>{entry.suggestedPlacement}</td>
-                      <td>
-                        <span class={`ia-inv__pill ia-inv__pill--${entry.recommendation.replace(/\s+/g, "-")}`}>
-                          {recommendationLabels[entry.recommendation]}
-                        </span>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+            <div class="ia-inv__mandate-grid">
+              {items.map((entry) => (
+                <article class="ia-inv__mandate-card">
+                  <header>
+                    <h4>{entry.title}</h4>
+                    <code class="ia-inv__route">{entry.route}</code>
+                  </header>
+                  <dl class="ia-inv__mandate-dl">
+                    <div>
+                      <dt>Behov</dt>
+                      <dd>{entry.mandate.userNeed}</dd>
+                    </div>
+                    <div>
+                      <dt>Primær top task</dt>
+                      <dd>{visIaTopTaskLabels[entry.mandate.primaryTask]}</dd>
+                    </div>
+                    {
+                      entry.mandate.secondaryTask ? (
+                        <div>
+                          <dt>Sekundær top task</dt>
+                          <dd>{visIaTopTaskLabels[entry.mandate.secondaryTask]}</dd>
+                        </div>
+                      ) : null
+                    }
+                    <div>
+                      <dt>Målgruppe</dt>
+                      <dd>{entry.mandate.audience.length ? entry.mandate.audience.join(", ") : "—"}</dd>
+                    </div>
+                    <div>
+                      <dt>Kjerneinnhold</dt>
+                      <dd>{entry.mandate.coreContent}</dd>
+                    </div>
+                    <div>
+                      <dt>Etter bruk</dt>
+                      <dd>{entry.mandate.postUseAction}</dd>
+                    </div>
+                    {
+                      entry.mandate.overlappingSurfaces.length ? (
+                        <div>
+                          <dt>Overlapper med</dt>
+                          <dd>{entry.mandate.overlappingSurfaces.join(" · ")}</dd>
+                        </div>
+                      ) : null
+                    }
+                    <div>
+                      <dt>Hub-plassering</dt>
+                      <dd>{entry.mandate.hubPlacement}</dd>
+                    </div>
+                    <div>
+                      <dt>Foreslått i tre v0.2</dt>
+                      <dd>{entry.suggestedPlacement}</dd>
+                    </div>
+                  </dl>
+                  <footer>
+                    <span class={`ia-inv__pill ia-inv__pill--${entry.recommendation.replace(/\s+/g, "-")}`}>
+                      {recommendationLabels[entry.recommendation]}
+                    </span>
+                    {entry.mandate.needsPageContract ? (
+                      <span class="ia-inv__pill ia-inv__pill--contract">Page contract</span>
+                    ) : null}
+                  </footer>
+                </article>
+              ))}
             </div>
           </div>
         ))
       }
+    </section>
+
+    <section class="ia-inv__section" aria-labelledby="ia-inv-tree-v01">
+      <h2 id="ia-inv-tree-v01">Tremeny v0.1 (route-basert) — referanse</h2>
+      <p class="ia-inv__lead">Beholdt for sammenligning med v0.2.</p>
+      <VisIaTreeBranch nodes={visIaTreeProposal} base={base} />
     </section>
   </main>
 
@@ -280,6 +373,20 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
       color: rgb(107 114 128);
     }
 
+    .ia-inv__task-list {
+      margin: 0;
+      padding-left: 1.25rem;
+      font-size: 0.84rem;
+      line-height: 1.6;
+    }
+
+    .ia-inv__task-count {
+      display: block;
+      font-size: 0.72rem;
+      color: rgb(156 163 175);
+      font-weight: 400;
+    }
+
     .ia-inv__tree {
       margin: 0;
       padding-left: 0;
@@ -296,7 +403,7 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
     }
 
     .ia-inv__tree-root + .ia-inv__tree-root {
-      margin-top: 0.5rem;
+      margin-top: 0.75rem;
     }
 
     .ia-inv__tree-label {
@@ -309,6 +416,14 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
       text-decoration: underline;
       text-underline-offset: 2px;
       text-decoration-color: rgb(209 213 219);
+    }
+
+    .ia-inv__tree-task {
+      display: block;
+      margin-top: 0.1rem;
+      font-size: 0.68rem;
+      font-weight: 600;
+      color: rgb(99 102 241);
     }
 
     .ia-inv__tree-note {
@@ -351,6 +466,19 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
       color: rgb(107 114 128);
     }
 
+    .ia-inv__card-surfaces {
+      margin: 0.25rem 0 0 !important;
+      font-size: 0.75rem !important;
+      color: rgb(156 163 175) !important;
+    }
+
+    .ia-inv__card-conflict,
+    .ia-inv__card-resolution {
+      margin: 0.45rem 0 0 !important;
+      font-size: 0.82rem !important;
+      line-height: 1.45;
+    }
+
     .ia-inv__summary-grid {
       display: grid;
       gap: 1rem;
@@ -376,12 +504,71 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
     }
 
     .ia-inv__group h3 {
-      margin: 0 0 0.5rem;
+      margin: 0 0 0.75rem;
       font-size: 0.78rem;
       font-weight: 650;
       letter-spacing: 0.06em;
       text-transform: uppercase;
       color: rgb(107 114 128);
+    }
+
+    .ia-inv__mandate-grid {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .ia-inv__mandate-card {
+      padding: 0.85rem 1rem;
+      border: 1px solid rgb(243 244 246);
+      border-radius: 0.5rem;
+      background: rgb(249 250 251);
+    }
+
+    .ia-inv__mandate-card h4 {
+      margin: 0;
+      font-size: 0.88rem;
+      font-weight: 650;
+    }
+
+    .ia-inv__route {
+      display: block;
+      margin-top: 0.2rem;
+      font-size: 0.68rem;
+      color: rgb(107 114 128);
+      word-break: break-all;
+    }
+
+    .ia-inv__mandate-dl {
+      margin: 0.65rem 0 0;
+      display: grid;
+      gap: 0.45rem;
+    }
+
+    .ia-inv__mandate-dl div {
+      display: grid;
+      gap: 0.1rem;
+    }
+
+    .ia-inv__mandate-dl dt {
+      font-size: 0.65rem;
+      font-weight: 650;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: rgb(156 163 175);
+    }
+
+    .ia-inv__mandate-dl dd {
+      margin: 0;
+      font-size: 0.8rem;
+      line-height: 1.45;
+      color: rgb(55 65 81);
+    }
+
+    .ia-inv__mandate-card footer {
+      margin-top: 0.65rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
     }
 
     .ia-inv__table-wrap {
@@ -410,14 +597,6 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
       color: rgb(156 163 175);
     }
 
-    .ia-inv__rationale {
-      display: block;
-      margin-top: 0.2rem;
-      font-weight: 400;
-      color: rgb(156 163 175);
-      line-height: 1.4;
-    }
-
     .ia-inv__file {
       display: block;
       margin-top: 0.15rem;
@@ -428,7 +607,21 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
 
     .ia-inv__table code {
       font-size: 0.7rem;
-      word-break: break-all;
+    }
+
+    .ia-inv__details {
+      margin-top: 0.85rem;
+      font-size: 0.82rem;
+    }
+
+    .ia-inv__pre {
+      margin: 0.5rem 0 0;
+      padding: 0.75rem;
+      font-size: 0.72rem;
+      background: rgb(17 24 39);
+      color: rgb(229 231 235);
+      border-radius: 0.35rem;
+      overflow-x: auto;
     }
 
     .ia-inv__pill {
@@ -448,7 +641,7 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
     }
 
     .ia-inv__pill--slå-sammen,
-    .ia-inv__pill--flytt {
+    .ia-inv__pill--flytt-under {
       border-color: rgb(191 219 254);
       color: rgb(30 64 175);
       background: rgb(239 246 255);
@@ -466,12 +659,26 @@ const deleteCandidates = getVisIaEntriesByRecommendation("vurder sletting");
       background: rgb(254 242 242);
     }
 
+    .ia-inv__pill--contract {
+      border-color: rgb(221 214 254);
+      color: rgb(91 33 182);
+      background: rgb(245 243 255);
+    }
+
     @media (min-width: 768px) {
       .ia-inv {
         padding: 2rem 1.5rem 3.5rem;
       }
 
       .ia-inv__summary-grid {
+        grid-template-columns: 1fr 1fr;
+      }
+
+      .ia-inv__summary-grid--3 {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
+
+      .ia-inv__mandate-grid {
         grid-template-columns: 1fr 1fr;
       }
     }

--- a/src/pages/vis/system/ia-inventory-v01.astro
+++ b/src/pages/vis/system/ia-inventory-v01.astro
@@ -3,7 +3,6 @@
 import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
 import VisIaSurfaceCard from "../../../components/vis/VisIaSurfaceCard.astro";
 import {
-  getVisIaArchiveCandidates,
   getVisIaDeleteCandidates,
   getVisIaEntriesByTopTask,
   getVisIaInventoryEntriesFull,

--- a/src/pages/vis/system/ia-inventory-v01.astro
+++ b/src/pages/vis/system/ia-inventory-v01.astro
@@ -15,8 +15,10 @@ import {
 } from "../../../data/vis-ia-inventory-v01.ts";
 import {
   visIaConsolidationMeta,
+  visIaClosedDecisions,
   visIaDeepDiveAreas,
   visIaMetadataStrategy,
+  visIaNextImplementation,
   visIaPageContractV03Example,
   visIaPageContractV03Fields,
   visIaTreeProposalV03,
@@ -26,7 +28,6 @@ const base = import.meta.env.BASE_URL;
 const entries = getVisIaInventoryEntriesFull();
 const thomasReview = getVisIaThomasReviewEntries();
 const mergeCandidates = getVisIaMergeCandidates();
-const archiveCandidates = getVisIaArchiveCandidates();
 const deleteCandidates = getVisIaDeleteCandidates();
 
 const topTaskOrder: VisIaTopTask[] = [
@@ -50,7 +51,7 @@ const preserveValues = [
 ].sort();
 ---
 
-<PrototypeLayout title="VIS IA Inventory v0.3">
+<PrototypeLayout title="VIS IA Inventory v0.3.1">
   <main class="ia-inv">
     <nav class="ia-inv__crumb">
       <a href={`${base}vis`}>VIS</a>
@@ -70,22 +71,36 @@ const preserveValues = [
     </header>
 
     <section class="ia-inv__dashboard" aria-label="QA-oppsummering">
-      <article class="ia-inv__stat ia-inv__stat--highlight">
+      <article class="ia-inv__stat ia-inv__stat--ok">
+        <span class="ia-inv__stat-n">{visIaClosedDecisions.length}</span>
+        <span class="ia-inv__stat-l">Avklaringer lukket</span>
+      </article>
+      <article class="ia-inv__stat">
         <span class="ia-inv__stat-n">{thomasReview.length}</span>
-        <span class="ia-inv__stat-l">Trenger Thomas</span>
+        <span class="ia-inv__stat-l">Åpne for Thomas</span>
       </article>
       <article class="ia-inv__stat">
         <span class="ia-inv__stat-n">{mergeCandidates.length}</span>
-        <span class="ia-inv__stat-l">Slå sammen (label/nav)</span>
-      </article>
-      <article class="ia-inv__stat">
-        <span class="ia-inv__stat-n">{archiveCandidates.length}</span>
-        <span class="ia-inv__stat-l">Arkiver</span>
+        <span class="ia-inv__stat-l">Data/nav-konsolidering</span>
       </article>
       <article class="ia-inv__stat">
         <span class="ia-inv__stat-n">{deleteCandidates.length}</span>
-        <span class="ia-inv__stat-l">Vurder sletting</span>
+        <span class="ia-inv__stat-l">Vurder sletting senere</span>
       </article>
+    </section>
+
+    <section class="ia-inv__section ia-inv__section--decisions" aria-labelledby="ia-inv-decisions">
+      <h2 id="ia-inv-decisions">Avklarte beslutninger (v0.3.1)</h2>
+      <p class="ia-inv__lead">Innarbeidet som anbefalinger — ikke lenger åpne spørsmål.</p>
+      <ul class="ia-inv__decisions">
+        {visIaClosedDecisions.map((d) => (
+          <li>
+            <h3>{d.topic}</h3>
+            <p class="ia-inv__decision">{d.decision}</p>
+            <p class="ia-inv__decision-why">{d.rationale}</p>
+          </li>
+        ))}
+      </ul>
     </section>
 
     {
@@ -161,8 +176,15 @@ const preserveValues = [
     </section>
 
     <section class="ia-inv__section" aria-labelledby="ia-inv-tree">
-      <h2 id="ia-inv-tree">Anbefalt tremodell v0.3</h2>
+      <h2 id="ia-inv-tree">Anbefalt tremodell v0.3.1</h2>
       <p class="ia-inv__lead">{visIaTreeProposalV03.note}</p>
+      {
+        visIaTreeProposalV03.excludedFromTree?.length ? (
+          <p class="ia-inv__exclude">
+            Ikke i tre: {visIaTreeProposalV03.excludedFromTree.join(", ")}
+          </p>
+        ) : null
+      }
       <div class="ia-inv__tree-v03">
         {
           visIaTreeProposalV03.sections.map((section) => (
@@ -187,7 +209,13 @@ const preserveValues = [
     </section>
 
     <section class="ia-inv__section" aria-labelledby="ia-inv-contract">
-      <h2 id="ia-inv-contract">Page contract — for VIS-header senere</h2>
+      <h2 id="ia-inv-contract">Page contract — del av {visIaNextImplementation.name}</h2>
+      <p class="ia-inv__lead">{visIaNextImplementation.summary}</p>
+      <ul class="ia-inv__next-includes">
+        {visIaNextImplementation.includes.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
       <p class="ia-inv__lead">{visIaMetadataStrategy.summary}</p>
       <div class="ia-inv__strategy-grid">
         <article>
@@ -214,6 +242,9 @@ const preserveValues = [
           ))
         }
       </ul>
+      <p class="ia-inv__header-goals">
+        VIS-header skal vise: {visIaNextImplementation.headerGoals.join(" · ")}
+      </p>
       <details class="ia-inv__details">
         <summary>Eksempel page contract</summary>
         <pre class="ia-inv__pre">{JSON.stringify(visIaPageContractV03Example, null, 2)}</pre>
@@ -303,6 +334,72 @@ const preserveValues = [
       border: 1px solid rgb(243 244 246);
       border-radius: 0.5rem;
       background: rgb(249 250 251);
+    }
+
+    .ia-inv__stat--ok {
+      border-color: rgb(167 243 208);
+      background: rgb(236 253 245);
+    }
+
+    .ia-inv__section--decisions {
+      background: rgb(249 250 251);
+      margin-left: -1rem;
+      margin-right: -1rem;
+      padding: 1.25rem 1rem 1.5rem;
+      border-radius: 0.5rem;
+      border: 1px solid rgb(229 231 235);
+    }
+
+    .ia-inv__decisions {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .ia-inv__decisions h3 {
+      margin: 0;
+      font-size: 0.88rem;
+      font-weight: 650;
+    }
+
+    .ia-inv__decision {
+      margin: 0.3rem 0 0;
+      font-size: 0.82rem;
+      line-height: 1.45;
+      color: rgb(55 65 81);
+      font-weight: 500;
+    }
+
+    .ia-inv__decision-why {
+      margin: 0.25rem 0 0;
+      font-size: 0.78rem;
+      color: rgb(107 114 128);
+    }
+
+    .ia-inv__exclude {
+      margin: 0 0 0.85rem;
+      font-size: 0.78rem;
+      color: rgb(153 27 27);
+      background: rgb(254 242 242);
+      padding: 0.45rem 0.65rem;
+      border-radius: 0.35rem;
+    }
+
+    .ia-inv__next-includes {
+      margin: 0 0 1rem;
+      padding-left: 1.15rem;
+      font-size: 0.8rem;
+      color: rgb(75 85 99);
+      line-height: 1.45;
+    }
+
+    .ia-inv__header-goals {
+      margin: 0.85rem 0 0;
+      font-size: 0.78rem;
+      color: rgb(107 114 128);
+      font-style: italic;
     }
 
     .ia-inv__stat--highlight {

--- a/src/pages/vis/system/index.astro
+++ b/src/pages/vis/system/index.astro
@@ -58,6 +58,11 @@ const base = import.meta.env.BASE_URL;
           <b>IA-prinsipper v0.1</b>
           <p>Need-led IA, segmenter vs. navigasjon, artikkelmandat og eksempel.</p>
         </a>
+        <a href={`${base}vis/system/ia-inventory-v01`}>
+          <span>IA · inventory</span>
+          <b>VIS IA Inventory v0.1</b>
+          <p>Kartlegging av VIS-flater og foreslått tremeny — QA før lokal navigasjon.</p>
+        </a>
         <a href={`${base}vis/system/hub-mandate-v01`}>
           <span>hub · mandat</span>
           <b>Hub Mandate v0.1</b>


### PR DESCRIPTION
## Summary
- Kartlegger 37 VIS-relaterte flater med status, plassering og anbefaling
- Foreslår tremeny v0.1 (kontrollrom → nå/sprint, system, design, assets, arkiv)
- Lesbar analyseflate: `/vis/system/ia-inventory-v01/`
- Ingen routes slettet eller flyttet

## Test plan
- [ ] Åpne `/vis/system/ia-inventory-v01/` — lesbar tremodell og inventartabell
- [ ] `/vis/` uendret (ingen frontpage-endring)
- [ ] `/no/chat/`, `/backstage/`, `/designsystem/` uendret
- [ ] `npm run build` grønn

Made with [Cursor](https://cursor.com)