### PR TITLE
VIS Tree Navigation v0.1 (#192)

### DIFF
--- a/src/components/vis/VisNavSidebar.astro
+++ b/src/components/vis/VisNavSidebar.astro
@@ -1,0 +1,180 @@
+---
+/* CONTRACT: Venstrestilt VIS tremeny v0.1 — orientering, ikke dominans. */
+import {
+  getVisNavSections,
+  isNavItemActive,
+  isSectionActive,
+  resolveItemHref,
+  resolveNavItemLabel,
+} from "../../lib/vis-navigation.ts";
+
+interface Props {
+  pathname: string;
+  baseUrl: string;
+  /** When true, sidebar is visible (mobile drawer open). */
+  mobileOpen?: boolean;
+}
+
+const { pathname, baseUrl } = Astro.props;
+const sections = getVisNavSections();
+---
+
+<aside
+  id="vis-tree-nav"
+  class="vis-tree-nav hidden w-[min(100%,16.5rem)] shrink-0 border-r border-gray-200/90 bg-gray-50/50 md:block md:w-56 lg:w-60"
+  aria-label="VIS-meny"
+>
+  <nav class="sticky top-10 max-h-[calc(100dvh-2.5rem)] overflow-y-auto px-3 py-4 sm:px-4">
+    {
+      sections.map((section) => {
+        const sectionActive = isSectionActive(section, pathname, baseUrl);
+        return (
+          <details class="vis-tree-nav__section group mb-4 last:mb-0" open={sectionActive}>
+            <summary class="vis-tree-nav__summary cursor-pointer list-none py-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-500 marker:content-none [&::-webkit-details-marker]:hidden">
+              <span class="flex items-center justify-between gap-2">
+                {section.label}
+                <span class="text-[10px] text-gray-400 transition group-open:rotate-180" aria-hidden="true">
+                  ▾
+                </span>
+              </span>
+            </summary>
+            <ul class="mt-1 space-y-0.5 pb-1 pl-0.5">
+              {section.items.map((item) => {
+                const active = isNavItemActive(item, pathname, baseUrl);
+                const href = resolveItemHref(item, baseUrl);
+                const label = resolveNavItemLabel(item);
+                if (item.navOnly || !href) {
+                  return (
+                    <li>
+                      <span class="block rounded-md px-2.5 py-1.5 text-sm text-gray-400">{label}</span>
+                    </li>
+                  );
+                }
+                return (
+                  <li>
+                    <a
+                      href={href}
+                      class:list={[
+                        "block rounded-md px-2.5 py-1.5 text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/40",
+                        active
+                          ? "bg-purple-100/70 font-medium text-purple-950"
+                          : "text-gray-700 hover:bg-gray-100/80 hover:text-gray-900",
+                      ]}
+                      aria-current={active ? "page" : undefined}
+                    >
+                      {label}
+                      {
+                        item.secondaryLabel ? (
+                          <span class="mt-0.5 block text-[11px] font-normal text-gray-500">{item.secondaryLabel}</span>
+                        ) : null
+                      }
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </details>
+        );
+      })
+    }
+  </nav>
+</aside>
+
+<!-- Mobile drawer clone -->
+<aside
+  id="vis-tree-nav-mobile"
+  class="vis-tree-nav-mobile fixed inset-y-0 left-0 z-[9998] hidden w-[min(18rem,88vw)] border-r border-gray-200 bg-gray-50 shadow-xl md:hidden"
+  aria-label="VIS-meny"
+  aria-hidden="true"
+>
+  <div class="flex h-10 items-center justify-between border-b border-gray-200 bg-gray-900 px-3">
+    <span class="text-xs font-bold uppercase tracking-widest text-purple-400">VIS-meny</span>
+    <button
+      type="button"
+      id="vis-tree-nav-mobile-close"
+      class="rounded px-2 py-1 text-xs text-gray-300 hover:bg-gray-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500"
+    >
+      Lukk
+    </button>
+  </div>
+  <nav class="max-h-[calc(100dvh-2.5rem)] overflow-y-auto px-3 py-4">
+    {
+      sections.map((section) => {
+        const sectionActive = isSectionActive(section, pathname, baseUrl);
+        return (
+          <details class="group mb-4 last:mb-0" open={sectionActive}>
+            <summary class="cursor-pointer list-none py-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-500 marker:content-none [&::-webkit-details-marker]:hidden">
+              {section.label}
+            </summary>
+            <ul class="mt-1 space-y-0.5">
+              {section.items.map((item) => {
+                const active = isNavItemActive(item, pathname, baseUrl);
+                const href = resolveItemHref(item, baseUrl);
+                const label = resolveNavItemLabel(item);
+                if (item.navOnly || !href) {
+                  return (
+                    <li>
+                      <span class="block rounded-md px-2.5 py-1.5 text-sm text-gray-400">{label}</span>
+                    </li>
+                  );
+                }
+                return (
+                  <li>
+                    <a
+                      href={href}
+                      class:list={[
+                        "block rounded-md px-2.5 py-1.5 text-sm",
+                        active ? "bg-purple-100/70 font-medium text-purple-950" : "text-gray-700 hover:bg-gray-100",
+                      ]}
+                      aria-current={active ? "page" : undefined}
+                    >
+                      {label}
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </details>
+        );
+      })
+    }
+  </nav>
+</aside>
+
+<div
+  id="vis-tree-nav-backdrop"
+  class="fixed inset-0 z-[9997] hidden bg-black/30 md:hidden"
+  aria-hidden="true"
+/>
+
+<script is:inline>
+  (function () {
+    var openBtn = document.getElementById("vis-tree-nav-toggle");
+    var closeBtn = document.getElementById("vis-tree-nav-mobile-close");
+    var drawer = document.getElementById("vis-tree-nav-mobile");
+    var backdrop = document.getElementById("vis-tree-nav-backdrop");
+    function openDrawer() {
+      if (!drawer || !backdrop) return;
+      drawer.classList.remove("hidden");
+      drawer.setAttribute("aria-hidden", "false");
+      backdrop.classList.remove("hidden");
+      if (openBtn) openBtn.setAttribute("aria-expanded", "true");
+      document.body.style.overflow = "hidden";
+    }
+    function closeDrawer() {
+      if (!drawer || !backdrop) return;
+      drawer.classList.add("hidden");
+      drawer.setAttribute("aria-hidden", "true");
+      backdrop.classList.add("hidden");
+      if (openBtn) openBtn.setAttribute("aria-expanded", "false");
+      document.body.style.overflow = "";
+      if (openBtn) openBtn.focus();
+    }
+    if (openBtn) openBtn.addEventListener("click", openDrawer);
+    if (closeBtn) closeBtn.addEventListener("click", closeDrawer);
+    if (backdrop) backdrop.addEventListener("click", closeDrawer);
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") closeDrawer();
+    });
+  })();
+</script>

--- a/src/components/vis/VisPageIntro.astro
+++ b/src/components/vis/VisPageIntro.astro
@@ -1,0 +1,26 @@
+---
+/* CONTRACT: Kort sidehensikt fra page contract — menneskelig språk, ikke metadata-dump. */
+import type { VisPageContract } from "../../data/vis-navigation-v01.ts";
+import { visStatusLabels } from "../../lib/vis-navigation.ts";
+
+interface Props {
+  contract: VisPageContract;
+}
+
+const { contract } = Astro.props;
+const statusLabel = visStatusLabels[contract.status];
+---
+
+<div class="vis-page-intro border-b border-gray-200/80 bg-gray-50/60 px-4 py-4 sm:px-6 sm:py-5">
+  <div class="mx-auto max-w-4xl">
+    <p class="text-[11px] font-medium uppercase tracking-wide text-gray-500">{statusLabel}</p>
+    <p class="mt-1 text-base leading-relaxed text-gray-800 sm:text-[1.05rem]">{contract.purpose}</p>
+    {
+      contract.nextAction ? (
+        <p class="mt-2 text-sm text-gray-600">
+          <span class="font-medium text-gray-700">Neste:</span> {contract.nextAction}
+        </p>
+      ) : null
+    }
+  </div>
+</div>

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -26,6 +26,11 @@ export const quickAnswers = [
     question: "Hva gjør vi når noe ikke virker?",
     answer: "Start med hva brukeren ser, sjekk env-vars i Vercel, Upstash og CES — se feilsøkingsseksjonen under.",
   },
+  {
+    question: "Hvor orienterer vi oss i VIS?",
+    answer:
+      "VIS kontrollrom (/vis/) og venstremenyen på interne flater — rolig orientering om hvor du er og hva siden er til for. Backstage er fortsatt canonical systemreferanse.",
+  },
 ] as const;
 
 export type SystemMapLayer = {

--- a/src/data/vis-frontpage-hubs-v01.ts
+++ b/src/data/vis-frontpage-hubs-v01.ts
@@ -1,115 +1,16 @@
-/* CONTRACT: VIS frontpage hub definitions v0.1 — mandate, links and active/planned status for /vis/ IA. */
+/* CONTRACT: VIS frontpage hub definitions v0.1 — delegates to vis-navigation-v01 (single source). */
 
-import { mvpCurrentState } from "./mvp-current-state.ts";
+export type { VisHubAvailability, VisHubTier, VisFrontpageHub } from "./vis-navigation-v01.ts";
 
-export type VisHubAvailability = "active" | "planned" | "historikk";
+export {
+  visFrontpageMandate,
+  visPrimaryNextWorkIds,
+  visSourceOfTruthNotes,
+} from "./vis-navigation-v01.ts";
 
-export type VisHubTier = "primary" | "secondary";
+import { getVisHubEntriesFromNav } from "../lib/vis-navigation.ts";
 
-export type VisFrontpageHub = {
-  id: string;
-  title: string;
-  mandate: string;
-  href?: string;
-  availability: VisHubAvailability;
-  tier: VisHubTier;
-  issue?: string;
-};
-
-/** Main hubs on VIS frontpage — hub & spoke model, not backlog. */
-export function getVisFrontpageHubs(baseUrl: string): VisFrontpageHub[] {
-  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
-  const sprint = mvpCurrentState.currentSprint;
-  const sprintActive = sprint.status === "active";
-
-  const staticHubs: VisFrontpageHub[] = [
-    {
-      id: "designsystem",
-      title: "Designsystem",
-      mandate: "UI-mønstre, komponenter og applied surfaces.",
-      href: `${base}designsystem/`,
-      availability: "active",
-      tier: "primary",
-    },
-    {
-      id: "backstage",
-      title: "Backstage",
-      mandate: "AI, API, guards, env-vars og production.",
-      href: `${base}backstage/`,
-      availability: "active",
-      tier: "primary",
-    },
-    {
-      id: "gitbuss",
-      title: "Gitbuss",
-      mandate: "GitHub issues, arbeidsspor og Return Tickets.",
-      href: `${base}vis/system/github-runtime-status`,
-      availability: "active",
-      tier: "primary",
-    },
-    {
-      id: "roadmap",
-      title: "Roadmap",
-      mandate: "Retning og kommende faser — ikke alle småoppgaver.",
-      href: `${base}vis/system/roadmap-timeline-v01`,
-      availability: "active",
-      tier: "primary",
-    },
-    {
-      id: "dam",
-      title: "DAM / bildebank",
-      mandate: "Visuelle assets og bildebruk for MVP.",
-      href: `${base}vis/assets/editorial`,
-      availability: "active",
-      tier: "secondary",
-    },
-    {
-      id: "review",
-      title: "Review",
-      mandate: "QA, sammenligning og godkjenning.",
-      href: `${base}vis/review/`,
-      availability: "active",
-      tier: "secondary",
-    },
-  ];
-
-  const sprintHub: VisFrontpageHub = {
-    id: "sprint",
-    title: sprintActive ? `Sprint ${sprint.label}` : "Sprint / historikk",
-    mandate: sprintActive
-      ? "Operativ sprintflate — labs, guardrails og beslutningsgrunnlag."
-      : "Hvordan vi kom hit — ikke gjeldende sannhet.",
-    href: `${base}${sprint.route.replace(/^\//, "")}`,
-    availability: sprintActive ? "active" : "historikk",
-    tier: sprintActive ? "primary" : "secondary",
-    issue: sprint.issue,
-  };
-
-  if (sprintActive) {
-    const primaryHubs = staticHubs.filter((h) => h.tier === "primary");
-    const secondaryHubs = staticHubs.filter((h) => h.tier === "secondary");
-    return [...primaryHubs, sprintHub, ...secondaryHubs];
-  }
-
-  return [...staticHubs, sprintHub];
+/** Main hubs on VIS frontpage — derived from navigation registry. */
+export function getVisFrontpageHubs(baseUrl: string) {
+  return getVisHubEntriesFromNav(baseUrl);
 }
-
-export const visFrontpageMandate = {
-  title: "VIS kontrollrom",
-  lead: "Rask oversikt over hva som er sant nå, neste steg og hvor du går videre. Ikke backlog.",
-} as const;
-
-export const visPrimaryNextWorkIds = [
-  "internal-ai-test-qa",
-  "ai-usage-monitoring",
-] as const;
-
-export const visSourceOfTruthNotes = [
-  { label: "src/data/mvp-current-state.ts", role: "Gjeldende MVP-status" },
-  { label: "/designsystem/", role: "Gjeldende UI/mønstre" },
-  { label: "/backstage/", role: "System/API/guard/env — canonical referanse" },
-  { label: "GitHub issues/projects", role: "Oppgavebuss" },
-  { label: "Roadmap", role: "Retning / faser" },
-  { label: "DAM / bildebank", role: "Assetoversikt" },
-  { label: "Sprint-sider", role: "Aktiv sprint (currentSprint) · lukkede i arkiv" },
-] as const;

--- a/src/data/vis-navigation-v01.ts
+++ b/src/data/vis-navigation-v01.ts
@@ -1,0 +1,394 @@
+/* CONTRACT: VIS Tree Navigation v0.1 — felles datakilde for tremeny, hub-kort og page contract. */
+
+import { mvpCurrentState } from "./mvp-current-state.ts";
+
+export type VisHubAvailability = "active" | "planned" | "historikk";
+
+export type VisHubTier = "primary" | "secondary";
+
+export type VisFrontpageHub = {
+  id: string;
+  title: string;
+  mandate: string;
+  href?: string;
+  availability: VisHubAvailability;
+  tier: VisHubTier;
+  issue?: string;
+};
+
+export type VisPageStatus =
+  | "active"
+  | "canonical"
+  | "lab"
+  | "reference"
+  | "historical"
+  | "legacy";
+
+export type VisPageContract = {
+  id: string;
+  title: string;
+  type: string;
+  status: VisPageStatus;
+  purpose: string;
+  primaryTask: string;
+  audience: string[];
+  relatedArea?: string[];
+  canonicalSource?: string;
+  lastReviewed: string;
+  ownerRole: string;
+  nextAction?: string;
+};
+
+export type VisNavItem = {
+  id: string;
+  label: string;
+  href?: string;
+  secondaryLabel?: string;
+  pageContractId?: string;
+  hubTier?: "primary" | "secondary";
+  navOnly?: boolean;
+};
+
+export type VisNavSection = {
+  id: string;
+  label: string;
+  items: VisNavItem[];
+};
+
+const sprintRoute = mvpCurrentState.currentSprint.route.replace(/\/$/, "");
+
+export const visPageContracts: Record<string, VisPageContract> = {
+  "vis-kontrollrom": {
+    id: "vis-kontrollrom",
+    title: "VIS kontrollrom",
+    type: "kontrollrom",
+    status: "active",
+    purpose: "Rask oversikt over hva som er sant nå, og hvor du går videre. Ikke backlog.",
+    primaryTask: "status-nå",
+    audience: ["Thomas", "Vibeke"],
+    relatedArea: ["runtime-feed", "gitbuss"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+    nextAction: "Les «Akkurat nå» og velg arbeidsflate i menyen.",
+  },
+  "runtime-feed": {
+    id: "runtime-feed",
+    title: "Runtime feed",
+    type: "runtime-data",
+    status: "active",
+    purpose: "Kort «Akkurat nå» på forsiden — hva skjer og hva er neste beslutning.",
+    primaryTask: "status-nå",
+    audience: ["Thomas", "Vibeke"],
+    canonicalSource: "src/data/vis-runtime-feed.ts",
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+  },
+  "sprint-active": {
+    id: "sprint-active",
+    title: "Sprint 2026-W21",
+    type: "sprint-lab",
+    status: "active",
+    purpose: "Designarbeid og beslutninger denne sprinten.",
+    primaryTask: "jobber-med",
+    audience: ["Thomas", "Vibeke"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+    nextAction: "Åpne relevant lab og ta beslutning i Review.",
+  },
+  "sprint-lab-default": {
+    id: "sprint-lab-default",
+    title: "Sprint lab",
+    type: "sprint-lab",
+    status: "lab",
+    purpose: "Beslutningsgrunnlag for design i aktiv sprint.",
+    primaryTask: "beslutninger-qa",
+    audience: ["Thomas", "Vibeke"],
+    canonicalSource: "/designsystem/",
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+    nextAction: "Godkjenn i Review — deretter oppdater designsystem.",
+  },
+  designsystem: {
+    id: "designsystem",
+    title: "Designsystem",
+    type: "canonical-external",
+    status: "canonical",
+    purpose: "Canonical UI-mønstre, tokens og komponenter for produksjon.",
+    primaryTask: "forstå-system",
+    audience: ["Thomas", "Vibeke", "Cursor"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+    nextAction: "Slå opp mønster før implementasjon eller QA.",
+  },
+  backstage: {
+    id: "backstage",
+    title: "Backstage",
+    type: "canonical-external",
+    status: "canonical",
+    purpose: "Systemforklaring for AI, API og arbeidsregler — autoritativ referanse.",
+    primaryTask: "forstå-system",
+    audience: ["Thomas", "Vibeke", "Cursor"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+    nextAction: "Les operating rules ved systemendringer.",
+  },
+  gitbuss: {
+    id: "gitbuss",
+    title: "Gitbuss",
+    type: "runtime-tool",
+    status: "active",
+    purpose: "Operativ GitHub-oversikt — issues og PR-er uten å åpne GitHub.",
+    primaryTask: "jobber-med",
+    audience: ["Thomas", "Cursor"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+    nextAction: "Prioriter arbeid — koble til sprint eller roadmap ved behov.",
+  },
+  roadmap: {
+    id: "roadmap",
+    title: "Roadmap",
+    type: "runtime-tool",
+    status: "active",
+    purpose: "Retning og faser over tid — ikke daglig task-backlog.",
+    primaryTask: "forstå-system",
+    audience: ["Thomas", "Vibeke"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+  },
+  "redaksjonelle-bilder": {
+    id: "redaksjonelle-bilder",
+    title: "Redaksjonelle bilder",
+    type: "assets",
+    status: "active",
+    purpose: "Finne og velge bilder til artikler og innhold.",
+    primaryTask: "finn-flate",
+    audience: ["Thomas", "Vibeke"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Vibeke",
+    nextAction: "Velg bilde til innhold i Storyblok/redaksjon.",
+  },
+  review: {
+    id: "review",
+    title: "Review",
+    type: "review",
+    status: "active",
+    purpose: "QA og godkjenne design og sprint-labs før de blir canonical.",
+    primaryTask: "beslutninger-qa",
+    audience: ["Thomas", "Vibeke"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+    nextAction: "Gå gjennom review-lenker og godkjenn eller send tilbake.",
+  },
+  "agentdrift-runbook": {
+    id: "agentdrift-runbook",
+    title: "Agentdrift / runbook",
+    type: "system-doc",
+    status: "reference",
+    purpose: "Agent-runbook og filpeker — operativ hjelp for Cursor og agenter.",
+    primaryTask: "forstå-system",
+    audience: ["Cursor", "@rigger"],
+    canonicalSource: "/backstage/",
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+    nextAction: "Start agent-oppgave med riktig kontekst.",
+  },
+  "ia-inventory": {
+    id: "ia-inventory",
+    title: "IA inventory",
+    type: "system-doc",
+    status: "reference",
+    purpose: "Dyp referanse for VIS IA — mandat, overlapp og konsolidering. Ikke daglig UI-mønster.",
+    primaryTask: "forstå-system",
+    audience: ["Thomas"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+  },
+  "raw-wireframes": {
+    id: "raw-wireframes",
+    title: "Raw wireframes",
+    type: "wireframe",
+    status: "historical",
+    purpose: "Historiske HTML-wireframes — begrunnelse, ikke gjeldende produkt.",
+    primaryTask: "historikk",
+    audience: ["Thomas", "Vibeke"],
+    canonicalSource: "/no/",
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+  },
+  "legacy-docs": {
+    id: "legacy-docs",
+    title: "Legacy system-docs",
+    type: "system-doc",
+    status: "legacy",
+    purpose: "Utdaterte systemdokumenter — sjekk canonical erstatning.",
+    primaryTask: "historikk",
+    audience: ["Thomas"],
+    lastReviewed: "2026-06-01",
+    ownerRole: "Thomas",
+  },
+};
+
+export const visNavSections: VisNavSection[] = [
+  {
+    id: "now",
+    label: "Nå",
+    items: [
+      {
+        id: "kontrollrom",
+        label: "VIS kontrollrom",
+        href: "/vis",
+        pageContractId: "vis-kontrollrom",
+        hubTier: "primary",
+      },
+      {
+        id: "runtime-feed",
+        label: "Runtime feed",
+        navOnly: true,
+        pageContractId: "runtime-feed",
+      },
+      {
+        id: "sprint-active",
+        label: "Sprint 2026-W21",
+        href: sprintRoute,
+        pageContractId: "sprint-active",
+        hubTier: "primary",
+      },
+    ],
+  },
+  {
+    id: "workspaces",
+    label: "Arbeidsflater",
+    items: [
+      {
+        id: "designsystem",
+        label: "Designsystem",
+        href: "/designsystem",
+        pageContractId: "designsystem",
+        hubTier: "primary",
+      },
+      {
+        id: "backstage",
+        label: "Backstage",
+        href: "/backstage",
+        pageContractId: "backstage",
+        hubTier: "primary",
+      },
+      {
+        id: "gitbuss",
+        label: "Gitbuss",
+        href: "/vis/system/github-runtime-status",
+        pageContractId: "gitbuss",
+        hubTier: "primary",
+      },
+      {
+        id: "roadmap",
+        label: "Roadmap",
+        href: "/vis/system/roadmap-timeline-v01",
+        pageContractId: "roadmap",
+        hubTier: "primary",
+      },
+      {
+        id: "redaksjonelle-bilder",
+        label: "Redaksjonelle bilder",
+        href: "/vis/assets/editorial",
+        secondaryLabel: "DAM / bildebank",
+        pageContractId: "redaksjonelle-bilder",
+        hubTier: "secondary",
+      },
+      {
+        id: "review",
+        label: "Review",
+        href: "/vis/review",
+        pageContractId: "review",
+        hubTier: "secondary",
+      },
+    ],
+  },
+  {
+    id: "understand",
+    label: "Forstå system og innhold",
+    items: [
+      {
+        id: "agentdrift",
+        label: "Agentdrift / runbook",
+        href: "/vis/system/control-center",
+        pageContractId: "agentdrift-runbook",
+      },
+      {
+        id: "ia-inventory",
+        label: "IA inventory",
+        href: "/vis/system/ia-inventory-v01",
+        pageContractId: "ia-inventory",
+      },
+    ],
+  },
+  {
+    id: "history",
+    label: "Historikk",
+    items: [
+      {
+        id: "raw-wireframes",
+        label: "Raw wireframes",
+        href: "/vis",
+        pageContractId: "raw-wireframes",
+      },
+      {
+        id: "legacy-design-v01",
+        label: "Legacy design v01",
+        href: "/vis/system/design-system-v01",
+        pageContractId: "legacy-docs",
+      },
+      {
+        id: "task-bus-live",
+        label: "Task bus live",
+        href: "/vis/system/task-bus-live",
+        pageContractId: "legacy-docs",
+      },
+      {
+        id: "sprint-archive",
+        label: "Eldre sprintflater",
+        href: "/vis/KlarLyd_Sprint_01_Foundation_Archive_v09",
+        pageContractId: "raw-wireframes",
+      },
+      {
+        id: "placeholder-artikkel",
+        label: "Placeholder: artikkel",
+        href: "/vis/artikkel",
+        pageContractId: "legacy-docs",
+      },
+      {
+        id: "placeholder-hub",
+        label: "Placeholder: hub",
+        href: "/vis/hub",
+        pageContractId: "legacy-docs",
+      },
+    ],
+  },
+];
+
+export const visNavigationMeta = {
+  version: "v0.1",
+  updatedAt: "2026-06-01",
+  dataSource: "src/data/vis-navigation-v01.ts",
+} as const;
+
+export const visFrontpageMandate = {
+  title: "VIS kontrollrom",
+  lead: "Rask oversikt over hva som er sant nå, neste steg og hvor du går videre. Ikke backlog.",
+} as const;
+
+export const visPrimaryNextWorkIds = [
+  "vis-tree-navigation-v01",
+  "internal-ai-test-qa",
+] as const;
+
+export const visSourceOfTruthNotes = [
+  { label: "src/data/mvp-current-state.ts", role: "Gjeldende MVP-status" },
+  { label: "/designsystem/", role: "Gjeldende UI/mønstre" },
+  { label: "/backstage/", role: "System/API/guard — canonical referanse" },
+  { label: "GitHub issues/projects", role: "Oppgavebuss" },
+  { label: "Roadmap", role: "Retning / faser" },
+  { label: "Redaksjonelle bilder", role: "Assetoversikt" },
+  { label: "Sprint-sider", role: "Aktiv sprint · lukkede i arkiv" },
+  { label: "src/data/vis-navigation-v01.ts", role: "Tremeny og page contract" },
+] as const;

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -41,45 +41,49 @@ export type VisRuntimeFeed = {
 
 /** Manually updated after important Return Tickets — not synced from GitHub. */
 export const visRuntimeFeed = {
-  updatedAt: "2026-05-31",
+  updatedAt: "2026-06-01",
   activeNow: [
     {
-      id: "ai-usage-monitoring-v01",
+      id: "vis-tree-navigation-v01",
       headline:
-        "Vi vurderer hvordan Viddel skal måle bruk av AI-chatten før vi deler den med flere.",
-      workTitle: "#188 AI usage monitoring v0.1",
-      area: "Data, monitoring og innsikt",
+        "Vi bygger en enkel venstremeny på interne VIS-flater, så det er lettere å se hvor man er og hva siden er til for.",
+      workTitle: "#192 VIS Tree Navigation v0.1",
+      area: "VIS IA og intern navigasjon",
       why:
-        "Vi trenger å se om chatten virker, om den feiler, og hvilke innganger som faktisk blir brukt — uten å lagre spørsmål eller svar.",
-      status: "Vurdering ferdig. Neste steg er å velge løsning.",
+        "Thomas og Vibeke trenger orientering uten ny backlog-UI — felles tremeny, page contract og rolig sidebar.",
+      status: "v0.1 implementert. QA på desktop og mobil (~390px) gjenstår.",
       possibleSolution:
-        "Smal hybrid: teknisk drift i Vercel, Upstash og CES + få trygge produkt-events i PostHog EU.",
-      nextDecision:
-        "Skal vi godkjenne hybrid-retningen, eller starte enklere med bare driftstellerne?",
-      issue: "#188",
-      issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
+        "Felles datakilde (vis-navigation-v01), VisInternalLayout, sidebar på nøkkelsider.",
+      nextDecision: "Godkjenn tremeny og page contract som daglig mønster på flere VIS-flater.",
+      issue: "#192",
+      issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/192",
       progressSteps: [
-        { id: "assessment", label: "Vurdering ferdig", state: "done" },
-        { id: "decision", label: "Beslutning", state: "current" },
-        { id: "implementation", label: "Implementasjon", state: "upcoming" },
+        { id: "data", label: "Felles datakilde", state: "done" },
+        { id: "sidebar", label: "Sidebar + layout", state: "done" },
+        { id: "qa", label: "QA og utrulling", state: "current" },
       ],
     },
   ],
   recentlyCompletedSummary:
-    "Backstage v0.1, VIS frontpage v0.1 og Spør Viddel live i production.",
-  lastReturnTicketSummary: "#188 assessment er levert. Ingen kode endret ennå.",
+    "VIS IA Inventory v0.3.1 (#191), Backstage v0.1 og VIS frontpage v0.1 i production.",
+  lastReturnTicketSummary: "#192 v0.1 — tremeny, page contract og layout på nøkkelsider.",
   links: {
     primary: [
       {
-        label: "Issue #188",
-        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
+        label: "Issue #192",
+        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/192",
         kind: "issue",
       },
     ],
     secondary: [
       {
-        label: "Assessment-kommentar",
-        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188#issuecomment-4585993994",
+        label: "IA inventory (referanse)",
+        href: "/vis/system/ia-inventory-v01/",
+        kind: "page",
+      },
+      {
+        label: "Issue #188 (parkert)",
+        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
         kind: "issue",
       },
     ],

--- a/src/layouts/VisInternalLayout.astro
+++ b/src/layouts/VisInternalLayout.astro
@@ -1,0 +1,57 @@
+---
+/* CONTRACT: VIS intern layout v0.1 — PrototypeLayout + venstremeny + valgfri page contract intro. */
+import PrototypeLayout from "./PrototypeLayout.astro";
+import VisNavSidebar from "../components/vis/VisNavSidebar.astro";
+import VisPageIntro from "../components/vis/VisPageIntro.astro";
+import { resolvePageContract } from "../lib/vis-navigation.ts";
+
+interface Props {
+  title: string;
+  /** Override auto-detected page contract id. */
+  pageContractId?: string;
+  /** Show compact page intro from contract (default: true when contract resolves). */
+  showPageIntro?: boolean;
+  /** Enable VIS tree navigation (default: true). */
+  visNav?: boolean;
+}
+
+const { title, pageContractId, showPageIntro, visNav = true } = Astro.props;
+
+const base = import.meta.env.BASE_URL;
+const pathname = Astro.url.pathname;
+const contract = resolvePageContract(pathname, base, pageContractId);
+const shouldShowIntro = showPageIntro ?? !!contract;
+---
+
+<PrototypeLayout title={title}>
+  {
+    visNav ? (
+      <div class="vis-internal-shell flex min-h-[calc(100dvh-2.5rem)] flex-col md:flex-row">
+        <div class="flex shrink-0 items-center border-b border-gray-200 bg-gray-50/80 px-3 py-2 md:hidden">
+          <button
+            type="button"
+            id="vis-tree-nav-toggle"
+            class="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/40"
+            aria-expanded="false"
+            aria-controls="vis-tree-nav-mobile"
+          >
+            VIS-meny
+            <span class="text-xs text-gray-400" aria-hidden="true">
+              ▾
+            </span>
+          </button>
+        </div>
+        <VisNavSidebar pathname={pathname} baseUrl={base} />
+        <div class="vis-internal-main min-w-0 flex-1">
+          {shouldShowIntro && contract ? <VisPageIntro contract={contract} /> : null}
+          <slot />
+        </div>
+      </div>
+    ) : (
+      <>
+        {shouldShowIntro && contract ? <VisPageIntro contract={contract} /> : null}
+        <slot />
+      </>
+    )
+  }
+</PrototypeLayout>

--- a/src/lib/vis-navigation.ts
+++ b/src/lib/vis-navigation.ts
@@ -1,0 +1,160 @@
+/* CONTRACT: Helpers for VIS Tree Navigation v0.1 — path matching, contracts, active state. */
+
+import { mvpCurrentState } from "../data/mvp-current-state.ts";
+import {
+  visNavSections,
+  visPageContracts,
+  type VisNavItem,
+  type VisNavSection,
+  type VisPageContract,
+} from "../data/vis-navigation-v01.ts";
+
+export function normalizeVisPath(pathname: string, baseUrl = "/"): string {
+  let p = pathname;
+  const base = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  if (base && base !== "/" && p.startsWith(base)) {
+    p = p.slice(base.length) || "/";
+  }
+  if (!p.startsWith("/")) p = `/${p}`;
+  if (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1);
+  return p;
+}
+
+export function navHrefToPath(href: string): string {
+  const p = href.startsWith("/") ? href : `/${href}`;
+  return p.length > 1 && p.endsWith("/") ? p.slice(0, -1) : p;
+}
+
+export type VisNavMatch = {
+  item: VisNavItem;
+  section: VisNavSection;
+  exact: boolean;
+};
+
+export function findNavMatch(pathname: string, baseUrl = "/"): VisNavMatch | null {
+  const path = normalizeVisPath(pathname, baseUrl);
+  let best: VisNavMatch | null = null;
+
+  for (const section of visNavSections) {
+    for (const item of section.items) {
+      if (!item.href) continue;
+      const itemPath = navHrefToPath(item.href);
+      const exact = path === itemPath;
+      const prefix = path.startsWith(`${itemPath}/`);
+      if (!exact && !prefix) continue;
+      if (!best || (exact && !best.exact) || itemPath.length > navHrefToPath(best.item.href!)) {
+        best = { item, section, exact };
+      }
+    }
+  }
+  return best;
+}
+
+export function resolvePageContract(pathname: string, baseUrl = "/", explicitId?: string): VisPageContract | undefined {
+  if (explicitId && visPageContracts[explicitId]) {
+    return visPageContracts[explicitId];
+  }
+  const path = normalizeVisPath(pathname, baseUrl);
+  const match = findNavMatch(pathname, baseUrl);
+  if (match?.item.pageContractId && visPageContracts[match.item.pageContractId]) {
+    return visPageContracts[match.item.pageContractId];
+  }
+  if (path.startsWith("/vis/sprints/")) {
+    return visPageContracts["sprint-lab-default"];
+  }
+  if (path.startsWith("/vis/") && path !== "/vis") {
+    const slug = path.replace(/^\/vis\//, "");
+    if (slug && !slug.includes("/") && visPageContracts[`wireframe-${slug}`]) {
+      return visPageContracts[`wireframe-${slug}`];
+    }
+  }
+  return undefined;
+}
+
+export function isNavItemActive(item: VisNavItem, pathname: string, baseUrl = "/"): boolean {
+  const match = findNavMatch(pathname, baseUrl);
+  if (!match || !item.href) return false;
+  return match.item.id === item.id;
+}
+
+export function isSectionActive(section: VisNavSection, pathname: string, baseUrl = "/"): boolean {
+  return section.items.some((item) => isNavItemActive(item, pathname, baseUrl));
+}
+
+export function getVisNavSections(): VisNavSection[] {
+  return visNavSections;
+}
+
+export function getSprintNavLabel(): string {
+  const sprint = mvpCurrentState.currentSprint;
+  return sprint.status === "active" ? `Sprint ${sprint.label}` : `Sprint ${sprint.label} (arkiv)`;
+}
+
+export function resolveNavItemLabel(item: VisNavItem): string {
+  if (item.id === "sprint-active") return getSprintNavLabel();
+  return item.label;
+}
+
+export function resolveItemHref(item: VisNavItem, baseUrl: string): string | undefined {
+  if (!item.href) return undefined;
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const clean = item.href.replace(/^\//, "");
+  return `${base}${clean}`;
+}
+
+/** Build frontpage hub list from navigation registry — single source. */
+export function getVisHubEntriesFromNav(baseUrl: string) {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const hubs: {
+    id: string;
+    title: string;
+    mandate: string;
+    href?: string;
+    availability: "active" | "planned" | "historikk";
+    tier: "primary" | "secondary";
+    issue?: string;
+  }[] = [];
+
+  for (const section of visNavSections) {
+    for (const item of section.items) {
+      if (!item.hubTier || !item.href) continue;
+      const contract = item.pageContractId ? visPageContracts[item.pageContractId] : undefined;
+      hubs.push({
+        id: item.id,
+        title: resolveNavItemLabel(item),
+        mandate: contract?.purpose ?? item.secondaryLabel ?? "",
+        href: `${base}${item.href.replace(/^\//, "")}`,
+        availability: contract?.status === "historical" || contract?.status === "legacy" ? "historikk" : "active",
+        tier: item.hubTier,
+      });
+    }
+  }
+
+  const sprint = mvpCurrentState.currentSprint;
+  const sprintActive = sprint.status === "active";
+  const sprintHub = {
+    id: "sprint",
+    title: sprintActive ? `Sprint ${sprint.label}` : "Sprint / historikk",
+    mandate: sprintActive
+      ? "Operativ sprintflate — labs og beslutningsgrunnlag."
+      : "Hvordan vi kom hit — ikke gjeldende sannhet.",
+    href: `${base}${sprint.route.replace(/^\//, "")}`,
+    availability: (sprintActive ? "active" : "historikk") as "active" | "historikk",
+    tier: (sprintActive ? "primary" : "secondary") as "primary" | "secondary",
+    issue: sprint.issue,
+  };
+
+  const primary = hubs.filter((h) => h.tier === "primary" && h.id !== "sprint-active");
+  const secondary = hubs.filter((h) => h.tier === "secondary");
+  if (sprintActive) return [...primary, sprintHub, ...secondary];
+  return [...hubs.filter((h) => h.tier === "primary"), ...secondary, sprintHub];
+}
+
+export const visStatusLabels: Record<VisPageContract["status"], string> = {
+  active: "Aktiv",
+  canonical: "Canonical",
+  lab: "Lab",
+  reference: "Referanse",
+  historical: "Historikk",
+  legacy: "Legacy",
+};

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Backstage v0.1 — pedagogisk intern referanse; forståelse først, teknikk nederst (#184). */
-import PrototypeLayout from "../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../layouts/VisInternalLayout.astro";
 import {
   backstageMeta,
   beforeExternalSharing,
@@ -40,7 +40,7 @@ const layerTone: Record<string, string> = {
 };
 ---
 
-<PrototypeLayout title="Backstage — Viddel">
+<VisInternalLayout title="Backstage — Viddel" showPageIntro={false}>
   <main class="bs">
     <nav class="bs__crumb" aria-label="Du er her">
       <a href={`${base}vis/`}>VIS</a>
@@ -1335,4 +1335,4 @@ const layerTone: Record<string, string> = {
       text-underline-offset: 2px;
     }
   </style>
-</PrototypeLayout>
+</VisInternalLayout>

--- a/src/pages/designsystem/index.astro
+++ b/src/pages/designsystem/index.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: Canonical MVP design system v0.1 — visual HITL catalog for patterns, primitives, applied surfaces. */
-import PrototypeLayout from "../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../layouts/VisInternalLayout.astro";
 import PatternPreview from "../../components/designsystem/PatternPreview.astro";
 import "../../styles/global.css";
 import "../../styles/r1-dialog-article.css";
@@ -40,7 +40,7 @@ const primitiveSwatchClass: Record<string, string> = {
 };
 ---
 
-<PrototypeLayout title="Designsystem — Viddel MVP">
+<VisInternalLayout title="Designsystem — Viddel MVP" showPageIntro={false}>
   <main class="ds-catalog" data-design-system-catalog>
     <nav class="ds-catalog__breadcrumb" aria-label="Du er her">
       <a href={`${base}vis`}>VIS</a>
@@ -217,4 +217,4 @@ const primitiveSwatchClass: Record<string, string> = {
       </details>
     </footer>
   </main>
-</PrototypeLayout>
+</VisInternalLayout>

--- a/src/pages/vis/assets/editorial.astro
+++ b/src/pages/vis/assets/editorial.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: VIS-only asset browser for Editorial Image Library v0.2 candidates. */
-import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../../layouts/VisInternalLayout.astro";
 import {
   editorialImageLibrary,
   type EditorialImageGroup,
@@ -49,7 +49,7 @@ const pathForImage = (entry: EditorialImageLibraryEntry) =>
   entry.webPath.startsWith("/") ? entry.webPath : `/${entry.webPath}`;
 ---
 
-<PrototypeLayout title="Editorial Image Library">
+<VisInternalLayout title="Editorial Image Library" pageContractId="redaksjonelle-bilder">
   <main class="asset-page">
     <nav class="asset-breadcrumb" aria-label="Du er her">
       <a href={`${base}vis`}>VIS</a>
@@ -132,7 +132,7 @@ const pathForImage = (entry: EditorialImageLibraryEntry) =>
       ))}
     </div>
   </main>
-</PrototypeLayout>
+</VisInternalLayout>
 
 <style>
   .asset-page {

--- a/src/pages/vis/index.astro
+++ b/src/pages/vis/index.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: VIS frontpage v0.1 — kontrollrom med visuell prioritet; MVP from registry, hubs from vis-frontpage-hubs-v01. */
-import PrototypeLayout from "../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../layouts/VisInternalLayout.astro";
 import { groupedVisEntries, visTypeLabelNo, wireframeIndexEntries } from "../../lib/vis-wireframes";
 import { getVisFrontpageEntries, getCurrentSprintVisEntry, mvpCurrentState } from "../../data/mvp-current-state.ts";
 import { getClosedSprintArchiveLinks } from "../../lib/vis-sprint-guard.ts";
@@ -42,7 +42,7 @@ const primaryLinks = runtimeFeed.links.primary;
 const secondaryLinks = runtimeFeed.links.secondary ?? [];
 ---
 
-<PrototypeLayout title="VIS kontrollrom">
+<VisInternalLayout title="VIS kontrollrom" showPageIntro={false}>
   <main class="vis-room">
     <header class="vis-room__header">
       <p class="vis-room__kicker">Intern · VIS</p>
@@ -1014,4 +1014,4 @@ const secondaryLinks = runtimeFeed.links.secondary ?? [];
       }
     }
   </style>
-</PrototypeLayout>
+</VisInternalLayout>

--- a/src/pages/vis/review/index.astro
+++ b/src/pages/vis/review/index.astro
@@ -2,7 +2,7 @@
 /* CONTRACT: Stakeholder-safe VIS review entry (#131B / #131C).
    Renders from review registry — curated links only, no archive/KlarLyd/agent runtime.
 */
-import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../../layouts/VisInternalLayout.astro";
 import "../../../styles/global.css";
 import {
   activeBySprint,
@@ -30,7 +30,7 @@ function statusClass(status: ReviewRegistryItem["status"]): string {
 }
 ---
 
-<PrototypeLayout title="Viddel Review">
+<VisInternalLayout title="Viddel Review" pageContractId="review">
   <main class="vreview" data-vis-review-page>
     <header class="vreview__hero">
       <p class="vreview__kicker">VIS · #131C · Review registry</p>
@@ -393,4 +393,4 @@ function statusClass(status: ReviewRegistryItem["status"]): string {
       text-underline-offset: 2px;
     }
   </style>
-</PrototypeLayout>
+</VisInternalLayout>

--- a/src/pages/vis/sprints/2026-w21/index.astro
+++ b/src/pages/vis/sprints/2026-w21/index.astro
@@ -17,7 +17,7 @@
    #131B: Stakeholder review entry at /vis/review/.
    Parent sprint: #120 MVP Design Lock v0.1.
 */
-import PrototypeLayout from "../../../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../../../layouts/VisInternalLayout.astro";
 import "../../../../styles/global.css";
 
 const base = import.meta.env.BASE_URL;
@@ -76,7 +76,7 @@ const typographyLabDirections = [
 ];
 ---
 
-<PrototypeLayout title="Sprint Preview — 2026-W21">
+<VisInternalLayout title="Sprint Preview — 2026-W21" showPageIntro={false} pageContractId="sprint-active">
   <main class="sprint-preview" data-sprint-preview>
     <nav class="sprint-preview__breadcrumb" aria-label="Du er her">
       <a href={`${base}vis`}>VIS</a>
@@ -1151,4 +1151,4 @@ const typographyLabDirections = [
       }
     }
   </style>
-</PrototypeLayout>
+</VisInternalLayout>

--- a/src/pages/vis/system/control-center.astro
+++ b/src/pages/vis/system/control-center.astro
@@ -2,7 +2,7 @@
 /* CONTRACT: VIS Control Center — human-readable front door for Viddel canonical project knowledge. */
 import fs from "node:fs";
 import path from "node:path";
-import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../../layouts/VisInternalLayout.astro";
 
 const base = import.meta.env.BASE_URL;
 const mdPath = path.join(process.cwd(), "docs", "project", "VIDDEL_PROJECT_CONTROL_CENTER_v0_1.md");
@@ -89,7 +89,7 @@ const activeTracks = [
 ];
 ---
 
-<PrototypeLayout title="Viddel Control Center">
+<VisInternalLayout title="Viddel Control Center" pageContractId="agentdrift-runbook">
   <main class="control-page">
     <nav class="control-breadcrumb">
       <a href={`${base}vis`}>VIS</a>
@@ -477,4 +477,4 @@ const activeTracks = [
       }
     }
   </style>
-</PrototypeLayout>
+</VisInternalLayout>

--- a/src/pages/vis/system/github-runtime-status.astro
+++ b/src/pages/vis/system/github-runtime-status.astro
@@ -2,7 +2,7 @@
 /* CONTRACT: VIS runtime-feed — viser generert GitHub-status (public/vis/runtime/00_GITHUB_RUNTIME_STATUS.md) for @navigator; kuratert /vis forblir separat. */
 import fs from "node:fs";
 import path from "node:path";
-import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../../layouts/VisInternalLayout.astro";
 
 const base = import.meta.env.BASE_URL;
 const mdPath = path.join(process.cwd(), "public", "vis", "runtime", "00_GITHUB_RUNTIME_STATUS.md");
@@ -23,7 +23,7 @@ function escapeHtml(s: string): string {
 const safe = escapeHtml(raw);
 ---
 
-<PrototypeLayout title="GitHub runtime status">
+<VisInternalLayout title="GitHub runtime status" pageContractId="gitbuss">
   <main class="px-4 py-6 sm:px-6 sm:py-8">
     <nav class="text-xs text-gray-500">
       <a href={`${base}vis/system`} class="underline underline-offset-2">System</a>
@@ -57,4 +57,4 @@ const safe = escapeHtml(raw);
       >
     </p>
   </main>
-</PrototypeLayout>
+</VisInternalLayout>

--- a/src/pages/vis/system/ia-inventory-v01.astro
+++ b/src/pages/vis/system/ia-inventory-v01.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: VIS IA Inventory v0.3 — konsolideringsklarhet før tremeny. */
-import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../../layouts/VisInternalLayout.astro";
 import VisIaSurfaceCard from "../../../components/vis/VisIaSurfaceCard.astro";
 import {
   getVisIaDeleteCandidates,
@@ -50,7 +50,7 @@ const preserveValues = [
 ].sort();
 ---
 
-<PrototypeLayout title="VIS IA Inventory v0.3.1">
+<VisInternalLayout title="VIS IA Inventory v0.3.1" pageContractId="ia-inventory">
   <main class="ia-inv">
     <nav class="ia-inv__crumb">
       <a href={`${base}vis`}>VIS</a>
@@ -714,4 +714,4 @@ const preserveValues = [
       }
     }
   </style>
-</PrototypeLayout>
+</VisInternalLayout>

--- a/src/pages/vis/system/roadmap-timeline-v01.astro
+++ b/src/pages/vis/system/roadmap-timeline-v01.astro
@@ -1,6 +1,6 @@
 ---
 /* CONTRACT: VIS read model v0.1 — initiatives from GitHub KL-META, grouped by repo lane manifest (no Gantt, no task expansion). */
-import PrototypeLayout from "../../../layouts/PrototypeLayout.astro";
+import VisInternalLayout from "../../../layouts/VisInternalLayout.astro";
 import laneManifest from "../../../../docs/project/roadmap_timeline_lanes.v0.1.json";
 
 const base = import.meta.env.BASE_URL;
@@ -9,7 +9,7 @@ const repo = "vox-web";
 const roadmapClientProps = JSON.stringify({ laneManifest, owner, repo });
 ---
 
-<PrototypeLayout title="Roadmap timeline v0.4.1">
+<VisInternalLayout title="Roadmap timeline v0.4.1" pageContractId="roadmap">
   <main class="px-4 py-6 sm:px-6 sm:py-8">
     <header class="rounded-md border border-gray-300 bg-white px-4 py-4 sm:px-5">
       <p class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Live dashboard</p>
@@ -78,7 +78,7 @@ const roadmapClientProps = JSON.stringify({ laneManifest, owner, repo });
       Se også <a href={`${base}vis/system`} class="underline underline-offset-2">/vis/system</a>.
     </p>
   </main>
-</PrototypeLayout>
+</VisInternalLayout>
 
 <!-- Props for client module: define:vars + import in the same Astro script breaks prod bundling; JSON bootstrap keeps one bundled module. -->
 <script type="application/json" id="vis-roadmap-props" set:html={roadmapClientProps} />


### PR DESCRIPTION
## Summary
- Felles datakilde `vis-navigation-v01.ts` for tremeny, page contract og hub-kort
- Venstrestilt sidebar (`VisNavSidebar`) + `VisInternalLayout` på nøkkelinterne VIS-flater
- Page intro med kort sidehensikt på system-/verktøysider
- Hub-registry delegerer til navigasjonsdata (Redaksjonelle bilder som hovedlabel)

## Test plan
- [ ] Desktop: sidebar + aktiv state på `/vis/`, `/backstage/`, `/designsystem/`
- [ ] Mobil ~390px: «VIS-meny» drawer på `/vis/` og `/backstage/`
- [ ] Page intro på IA inventory og control-center — kort, ikke metadata-dump
- [ ] `/vis/` runtime feed og «Spør Viddel — live» fortsatt tydelig
- [ ] Backstage runbooks og gå-hit-lenker fungerer
- [ ] Designsystem pattern-katalog lesbar ved siden av meny
- [ ] `/no/chat/` uendret
- [ ] `npm run build` grønn

Closes #192 (etter visuell QA og merge).


Made with [Cursor](https://cursor.com)