### PR TITLE
AI usage monitoring Hybrid v0.1 (#188)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,8 @@ GOOGLE_SERVICE_ACCOUNT_JSON=
 # Create at https://console.upstash.com/ — REST API URL + token.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+
+# PostHog EU (#188) — optional public keys for client-side product events only.
+# No session replay, no user profiles, no message content.
+PUBLIC_POSTHOG_KEY=
+PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com

--- a/src/components/analytics/ViddelAnalytics.astro
+++ b/src/components/analytics/ViddelAnalytics.astro
@@ -1,0 +1,107 @@
+---
+/* CONTRACT: Minimal PostHog EU init + safe client tracking wrapper (v0.1). */
+import {
+  VIDDEL_ANALYTICS_EVENTS,
+  VIDDEL_ANALYTICS_PROPERTIES,
+} from "../../lib/viddel-analytics-events.ts";
+
+const posthogKey = (import.meta.env.PUBLIC_POSTHOG_KEY ?? "").trim();
+const posthogHost = (import.meta.env.PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com").trim();
+const enabled = Boolean(posthogKey);
+const environment = import.meta.env.PROD
+  ? (import.meta.env.VERCEL_ENV ?? "production")
+  : "development";
+
+const allowedEvents = VIDDEL_ANALYTICS_EVENTS;
+const allowedProperties = VIDDEL_ANALYTICS_PROPERTIES;
+---
+
+{
+  enabled ? (
+    <script
+      define:vars={{ posthogKey, posthogHost, environment, allowedEvents, allowedProperties }}
+      is:inline
+    >
+      (function () {
+        var loaded = false;
+        var queue = [];
+
+        function hashSeed(label) {
+          var hash = 0;
+          for (var i = 0; i < label.length; i += 1) {
+            hash = (hash << 5) - hash + label.charCodeAt(i);
+            hash |= 0;
+          }
+          return "s" + Math.abs(hash).toString(36).slice(0, 10);
+        }
+
+        function articleSlugFromPath() {
+          var match = window.location.pathname.match(/\/no\/artikkel\/([^/]+)/);
+          return match ? match[1] : undefined;
+        }
+
+        function pickAllowed(props) {
+          var out = { environment: environment, route: window.location.pathname };
+          if (!props || typeof props !== "object") return out;
+          allowedProperties.forEach(function (key) {
+            if (props[key] !== undefined && props[key] !== null && props[key] !== "") {
+              out[key] = props[key];
+            }
+          });
+          return out;
+        }
+
+        window.viddelTrack = function (eventName, props) {
+          if (allowedEvents.indexOf(eventName) === -1) return;
+          var payload = pickAllowed(props);
+          if (!loaded || !window.posthog || typeof window.posthog.capture !== "function") {
+            queue.push([eventName, payload]);
+            return;
+          }
+          window.posthog.capture(eventName, payload);
+        };
+
+        window.viddelSeedId = hashSeed;
+
+        var script = document.createElement("script");
+        script.src = posthogHost.replace(/\/$/, "") + "/static/array.js";
+        script.async = true;
+        script.onload = function () {
+          if (!window.posthog || typeof window.posthog.init !== "function") return;
+          window.posthog.init(posthogKey, {
+            api_host: posthogHost,
+            autocapture: false,
+            capture_pageview: false,
+            disable_session_recording: true,
+            persistence: "memory",
+            person_profiles: "never",
+          });
+          loaded = true;
+          queue.forEach(function (item) {
+            window.posthog.capture(item[0], item[1]);
+          });
+          queue = [];
+        };
+        document.head.appendChild(script);
+
+        document.addEventListener(
+          "click",
+          function (event) {
+            var target = event.target;
+            if (!target || typeof target.closest !== "function") return;
+            var el = target.closest("[data-viddel-track]");
+            if (!el) return;
+            var trackEvent = el.getAttribute("data-viddel-track");
+            if (!trackEvent) return;
+            var entrySurface = el.getAttribute("data-viddel-entry-surface") || undefined;
+            var seedLabel = el.getAttribute("data-viddel-seed-label") || "";
+            var props = { entry_surface: entrySurface, article_slug: articleSlugFromPath() };
+            if (seedLabel) props.seed_id = hashSeed(seedLabel);
+            window.viddelTrack(trackEvent, props);
+          },
+          true,
+        );
+      })();
+    </script>
+  ) : null
+}

--- a/src/components/article/ArticleInlineChatShell.astro
+++ b/src/components/article/ArticleInlineChatShell.astro
@@ -62,6 +62,9 @@ const inspectLabelClass =
                 mode === "progressive" && "inline-chat-shell__seed-row",
               ]}
               data-inline-chat-seed={item.question}
+              data-viddel-track="article_ai_seed_clicked"
+              data-viddel-entry-surface="article_inline_shell"
+              data-viddel-seed-label={item.question}
             >
               <span class={mode === "progressive" ? "inline-chat-shell__seed-question" : undefined}>{item.question}</span>
             </button>

--- a/src/components/article/PromptGroup.astro
+++ b/src/components/article/PromptGroup.astro
@@ -45,7 +45,13 @@ const inspectLabelClass =
     {
       items.map((item) => (
         <li class="prompt-group__item prompt_group__item" data-component="PromptGroupItem">
-          <a href={buildChatShellHref(item.question, seedFrom)} class="prompt-group__link prompt_group__link">
+          <a
+            href={buildChatShellHref(item.question, seedFrom)}
+            class="prompt-group__link prompt_group__link"
+            data-viddel-track="article_ai_seed_clicked"
+            data-viddel-entry-surface="article_prompt"
+            data-viddel-seed-label={item.question}
+          >
             <span class="prompt-group__question prompt_group__question">{item.question}</span>
             <span class="prompt-group__hint" aria-hidden="true">
               <svg class="prompt-group__hint-icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -64,7 +70,13 @@ const inspectLabelClass =
     }
   </ul>
 
-  <a href={freeChatHref} class="prompt-group__cta" data-component="PromptGroupCta">
+  <a
+    href={freeChatHref}
+    class="prompt-group__cta"
+    data-component="PromptGroupCta"
+    data-viddel-track="ai_entry_clicked"
+    data-viddel-entry-surface="article_prompt_cta"
+  >
     <span class={inspectLabelClass} data-component-label>PromptGroupCta</span>
     {ctaLabel}
   </a>

--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -99,6 +99,8 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
     </nav>
     <a
       href={chatHref}
+      data-viddel-track="ai_entry_clicked"
+      data-viddel-entry-surface="header_nav"
       class={`hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
         chatActive
           ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -10,7 +10,7 @@ export const backstageMeta = {
 export const statusPanel = [
   { label: "Spør Viddel", value: "Live i production", tone: "live" as const },
   { label: "Guard", value: "Aktiv", tone: "ok" as const },
-  { label: "Ekstern deling", value: "Venter på usage monitoring", tone: "wait" as const },
+  { label: "Monitoring", value: "Hybrid v0.1 — intern test", tone: "ok" as const },
 ] as const;
 
 export const quickAnswers = [
@@ -30,6 +30,11 @@ export const quickAnswers = [
     question: "Hvor orienterer vi oss i VIS?",
     answer:
       "VIS kontrollrom (/vis/) og venstremenyen på interne flater — rolig orientering om hvor du er og hva siden er til for. Backstage er fortsatt canonical systemreferanse.",
+  },
+  {
+    question: "Hva måles når noen bruker AI-chatten?",
+    answer:
+      "Vi teller forespørsler og utfall (suksess, feil, rate limit) uten å lagre spørsmål eller svar. PostHog EU får få produkt-events — hvilken side, inngang og feilkode — aldri innhold.",
   },
 ] as const;
 
@@ -615,14 +620,70 @@ export const productionChecklist = [
 ] as const;
 
 export const beforeExternalSharing = [
-  "AI usage monitoring v0.1 først.",
+  "Hybrid monitoring v0.1 er aktiv — intern test med Thomas og Vibeke før ekstern deling.",
+  "Sjekk Upstash driftstall og PostHog EU for mønstre — ikke innhold.",
   "Access/login senere via «Mine sider» i globalmenyen — ikke kodefelt inne i chatten.",
   "Ekstern pilot krever egen beslutning.",
 ] as const;
 
+export const monitoringExplainer = {
+  title: "AI usage monitoring v0.1",
+  lead: "Trygghet før ekstern deling — smalt, trinnvis og uten innholdslogging.",
+  layers: [
+    {
+      id: "drift",
+      label: "Drift (Vercel + Upstash)",
+      human:
+        "Server-side tellere på /api/chat: forespørsel, suksess, feil, rate limit, for lang melding, guard utilgjengelig og manglende konfigurasjon. Vercel Runtime Logs viser strukturerte [chat-drift]-linjer.",
+      where: "Upstash Redis (dagsnøkler) + Vercel → Deployments → Runtime Logs",
+    },
+    {
+      id: "product",
+      label: "Produktinnsikt (PostHog EU)",
+      human:
+        "Få anonyme events: chat åpnet, inngang klikket, seed valgt, spørsmål sendt, svar OK/feil. Kun route, inngangsflate, artikkel-slug, seed-id og feilkode — aldri spørsmål eller svar.",
+      where: "PostHog EU-prosjekt (session replay av, ingen brukerprofiler)",
+    },
+    {
+      id: "ces",
+      label: "CES (AI-motor)",
+      human: "Operativ kjøring av AI — ikke produktanalytics. CES logger ikke i vårt lag.",
+      where: "Google CES / Vertex — se cesExplainer",
+    },
+  ],
+} as const;
+
+export const monitoringLogged = [
+  "Antall /api/chat-forespørsler per dag",
+  "Utfall: suksess, feil, rate_limited, message_too_long, guard_unavailable, configuration_missing",
+  "PostHog: chat_opened, ai_entry_clicked, article_ai_seed_clicked, chat_question_sent, chat_answer_success/error",
+  "Feilkoder (error_code) — aldri meldingstekst",
+  "Route, entry_surface, article_slug, seed_id (hash — ikke spørsmålstekst)",
+] as const;
+
+export const monitoringNotLogged = [
+  "Full spørsmålstekst",
+  "Full svartekst",
+  "Navn, e-post eller helseopplysninger",
+  "Session replay fra chat-input",
+  "Brukerprofiler eller persistent identitet",
+  "Høreapparatmodell som fritekst",
+] as const;
+
+export const monitoringEvents = [
+  { id: "chat_opened", layer: "PostHog", note: "Standalone /no/chat/ lastet" },
+  { id: "ai_entry_clicked", layer: "PostHog", note: "CTA til chat fra nav, hjelp m.m." },
+  { id: "article_ai_seed_clicked", layer: "PostHog", note: "Seed-spørsmål fra artikkel" },
+  { id: "chat_question_sent", layer: "PostHog", note: "Spørsmål sendt (seed/freeform — uten tekst)" },
+  { id: "chat_answer_success", layer: "PostHog", note: "Svar mottatt OK" },
+  { id: "chat_answer_error", layer: "PostHog", note: "Feil ved svar" },
+  { id: "chat_rate_limited", layer: "PostHog", note: "Rate limit truffet" },
+  { id: "chat_message_too_long", layer: "PostHog", note: "Melding for lang" },
+] as const;
+
 export type EnvVarEntry = {
   name: string;
-  group: "upstash" | "ces" | "auth";
+  group: "upstash" | "ces" | "auth" | "posthog";
   controls: string;
 };
 
@@ -635,6 +696,8 @@ export const envVars: EnvVarEntry[] = [
   { name: "CES_APP_VERSION_ID", group: "ces", controls: "App-versjon." },
   { name: "CES_DEPLOYMENT_ID", group: "ces", controls: "Aktiv deployment." },
   { name: "GOOGLE_SERVICE_ACCOUNT_JSON", group: "auth", controls: "Google auth — kun server-side." },
+  { name: "PUBLIC_POSTHOG_KEY", group: "posthog", controls: "PostHog prosjektnøkkel (public, EU)." },
+  { name: "PUBLIC_POSTHOG_HOST", group: "posthog", controls: "PostHog API-host — default https://eu.i.posthog.com" },
 ];
 
 export const envVarNotes = [
@@ -646,6 +709,9 @@ export const envVarNotes = [
 export const sourceFiles = [
   "src/pages/api/chat.ts",
   "src/lib/chat-api-guard.ts",
+  "src/lib/chat-usage-metrics.ts",
+  "src/lib/viddel-analytics-events.ts",
+  "src/components/analytics/ViddelAnalytics.astro",
   "src/lib/ces-env.ts",
   "src/lib/ces-run-session.ts",
 ] as const;

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -77,7 +77,7 @@ export const mvpCurrentState = {
   } satisfies CurrentSprint,
   closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
-    "CES production live på /no/chat/ — intern test med Thomas og Vibeke. Upstash guard aktiv (#180). Backstage v0.1 live (#184) med build-time guard. Neste: AI usage monitoring v0.1 før ekstern deling.",
+    "Hybrid AI monitoring v0.1 (#188) implementeres — drift via Upstash/Vercel og smale PostHog EU-events. Intern test Thomas/Vibeke før ekstern deling.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -111,7 +111,7 @@ export const mvpCurrentState = {
       label: "Spør Viddel",
       route: "/no/chat/",
       status: "Applied",
-      note: "Production UI live. CES prod env aktiv — live AI-svar i production. Public AI guard v0.1 (#180). Intern test Thomas/Vibeke. Backstage v0.1 (#184) live. Ekstern deling venter monitoring.",
+      note: "Production UI live. CES prod env aktiv. Upstash guard + Hybrid monitoring v0.1 (#188). Intern test Thomas/Vibeke.",
       visFrontpage: true,
       kind: "public",
       frontpageDescription: "Standalone headless AI — live i production (intern test). Guard aktiv.",
@@ -168,7 +168,7 @@ export const mvpCurrentState = {
     {
       id: "ai-usage-monitoring",
       label: "AI usage monitoring v0.1",
-      detail: "Påkrevd før ekstern deling — overvåkning av bruk, kost og misbruk.",
+      detail: "Hybrid v0.1 implementert — Upstash drift + PostHog EU. Intern test og verifisering før ekstern deling.",
     },
     {
       id: "backstage-v01",

--- a/src/data/vis-navigation-v01.ts
+++ b/src/data/vis-navigation-v01.ts
@@ -378,7 +378,7 @@ export const visFrontpageMandate = {
 } as const;
 
 export const visPrimaryNextWorkIds = [
-  "vis-tree-navigation-v01",
+  "ai-usage-monitoring",
   "internal-ai-test-qa",
 ] as const;
 

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -44,47 +44,47 @@ export const visRuntimeFeed = {
   updatedAt: "2026-06-01",
   activeNow: [
     {
-      id: "vis-tree-navigation-v01",
+      id: "ai-usage-monitoring-v01",
       headline:
-        "Vi bygger en enkel venstremeny på interne VIS-flater, så det er lettere å se hvor man er og hva siden er til for.",
-      workTitle: "#192 VIS Tree Navigation v0.1",
-      area: "VIS IA og intern navigasjon",
+        "Vi legger inn smal og trygg overvåkning av AI-chatten — driftstall og få produkt-events — før vi deler den med flere.",
+      workTitle: "#188 AI usage monitoring v0.1",
+      area: "Data, monitoring og trygg intern test",
       why:
-        "Thomas og Vibeke trenger orientering uten ny backlog-UI — felles tremeny, page contract og rolig sidebar.",
-      status: "v0.1 implementert. QA på desktop og mobil (~390px) gjenstår.",
+        "Thomas og Vibeke trenger å se om chatten virker og om den misbrukes — uten å lagre spørsmål eller svar.",
+      status: "Hybrid v0.1 implementert. Intern test og verifisering gjenstår.",
       possibleSolution:
-        "Felles datakilde (vis-navigation-v01), VisInternalLayout, sidebar på nøkkelsider.",
-      nextDecision: "Godkjenn tremeny og page contract som daglig mønster på flere VIS-flater.",
-      issue: "#192",
-      issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/192",
+        "Upstash/Vercel for drift, PostHog EU for få anonyme produkt-events.",
+      nextDecision: "Godkjenn tall og mønstre etter intern test — deretter vurdere ekstern deling.",
+      issue: "#188",
+      issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
       progressSteps: [
-        { id: "data", label: "Felles datakilde", state: "done" },
-        { id: "sidebar", label: "Sidebar + layout", state: "done" },
-        { id: "qa", label: "QA og utrulling", state: "current" },
+        { id: "drift", label: "Driftssignaler", state: "done" },
+        { id: "posthog", label: "PostHog EU", state: "done" },
+        { id: "verify", label: "Intern test", state: "current" },
       ],
     },
   ],
   recentlyCompletedSummary:
-    "VIS IA Inventory v0.3.1 (#191), Backstage v0.1 og VIS frontpage v0.1 i production.",
-  lastReturnTicketSummary: "#192 v0.1 — tremeny, page contract og layout på nøkkelsider.",
+    "VIS Tree Navigation v0.1 (#192), IA Inventory v0.3.1 (#191) og Backstage v0.1 i production.",
+  lastReturnTicketSummary: "#188 Hybrid v0.1 — drift + PostHog implementert.",
   links: {
     primary: [
       {
-        label: "Issue #192",
-        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/192",
+        label: "Issue #188",
+        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
         kind: "issue",
+      },
+      {
+        label: "Backstage monitoring",
+        href: "/backstage/",
+        kind: "page",
       },
     ],
     secondary: [
       {
-        label: "IA inventory (referanse)",
-        href: "/vis/system/ia-inventory-v01/",
+        label: "Spør Viddel (test)",
+        href: "/no/chat/",
         kind: "page",
-      },
-      {
-        label: "Issue #188 (parkert)",
-        href: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
-        kind: "issue",
       },
     ],
   },

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -46,27 +46,27 @@ export const visRuntimeFeed = {
     {
       id: "ai-usage-monitoring-v01",
       headline:
-        "Vi legger inn smal og trygg overvåkning av AI-chatten — driftstall og få produkt-events — før vi deler den med flere.",
-      workTitle: "#188 AI usage monitoring v0.1",
-      area: "Data, monitoring og trygg intern test",
+        "Vi legger inn trygg måling av AI-chatten før vi deler Viddel med flere.",
+      workTitle: "AI usage monitoring v0.1 (#188)",
+      area: "Data, monitoring og innsikt",
       why:
-        "Thomas og Vibeke trenger å se om chatten virker og om den misbrukes — uten å lagre spørsmål eller svar.",
-      status: "Hybrid v0.1 implementert. Intern test og verifisering gjenstår.",
-      possibleSolution:
-        "Upstash/Vercel for drift, PostHog EU for få anonyme produkt-events.",
-      nextDecision: "Godkjenn tall og mønstre etter intern test — deretter vurdere ekstern deling.",
+        "Vi må se om chatten virker, om den feiler, og hvilke innganger som brukes — uten å lagre spørsmål eller svar.",
+      status: "Implementert i PR #194. Venter privacy/logging QA før merge.",
+      possibleSolution: "Drift via Upstash nå. PostHog EU aktiveres senere med egen Vercel-nøkkel.",
+      nextDecision: "Merge driftsspor først. PostHog aktiveres senere med egen Vercel-nøkkel.",
       issue: "#188",
       issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
       progressSteps: [
-        { id: "drift", label: "Driftssignaler", state: "done" },
-        { id: "posthog", label: "PostHog EU", state: "done" },
-        { id: "verify", label: "Intern test", state: "current" },
+        { id: "implement", label: "Implementert", state: "done" },
+        { id: "qa", label: "Privacy/logging QA", state: "current" },
+        { id: "merge", label: "Merge", state: "upcoming" },
       ],
     },
   ],
   recentlyCompletedSummary:
     "VIS Tree Navigation v0.1 (#192), IA Inventory v0.3.1 (#191) og Backstage v0.1 i production.",
-  lastReturnTicketSummary: "#188 Hybrid v0.1 — drift + PostHog implementert.",
+  lastReturnTicketSummary:
+    "Privacy/logging QA er gjort i kode. Live Vercel logs og Upstash teller må fortsatt verifiseres.",
   links: {
     primary: [
       {
@@ -75,15 +75,15 @@ export const visRuntimeFeed = {
         kind: "issue",
       },
       {
-        label: "Backstage monitoring",
-        href: "/backstage/",
-        kind: "page",
+        label: "PR #194",
+        href: "https://github.com/THUNDERPLUNDER/vox-web/pull/194",
+        kind: "issue",
       },
     ],
     secondary: [
       {
-        label: "Spør Viddel (test)",
-        href: "/no/chat/",
+        label: "Backstage monitoring",
+        href: "/backstage/",
         kind: "page",
       },
     ],

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import Header from "../components/nav/Header.astro";
 import MobileMenuSheet from "../components/nav/MobileMenuSheet.astro";
 import InspectDrawerArmScript from "../components/dev/InspectDrawerArmScript.astro";
 import InspectToolsDrawer from "../components/dev/InspectToolsDrawer.astro";
+import ViddelAnalytics from "../components/analytics/ViddelAnalytics.astro";
 
 const {
   title = "Viddel",
@@ -332,6 +333,7 @@ const isStandaloneChat = shellVariant === "standalone-chat";
       ) : null
     }
     {showHeaderDevtoolsToggle ? <InspectToolsDrawer /> : null}
+    <ViddelAnalytics />
     {
       showHeaderDevtoolsToggle ? (
       <script is:inline>

--- a/src/lib/chat-usage-metrics.ts
+++ b/src/lib/chat-usage-metrics.ts
@@ -1,0 +1,68 @@
+/* CONTRACT: Server-side drift signals for /api/chat — Upstash counters + structured logs, no content. */
+
+import { Redis } from "@upstash/redis";
+import { isUpstashConfigured } from "./chat-api-guard.ts";
+
+export type ChatDriftSignal =
+  | "request"
+  | "success"
+  | "error"
+  | "rate_limited"
+  | "message_too_long"
+  | "guard_unavailable"
+  | "configuration_missing";
+
+let redisClient: Redis | null | undefined;
+
+function getMetricsRedis(): Redis | null {
+  if (redisClient !== undefined) return redisClient;
+  if (!isUpstashConfigured()) {
+    redisClient = null;
+    return null;
+  }
+  redisClient = Redis.fromEnv();
+  return redisClient;
+}
+
+function dayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function mapApiErrorToDriftSignal(error: string): ChatDriftSignal {
+  switch (error) {
+    case "message_too_long":
+      return "message_too_long";
+    case "rate_limited":
+      return "rate_limited";
+    case "guard_unavailable":
+      return "guard_unavailable";
+    case "configuration_missing":
+      return "configuration_missing";
+    default:
+      return "error";
+  }
+}
+
+/** Fire-and-forget — never throws, never logs message/session/IP. */
+export function recordChatDriftSignal(signal: ChatDriftSignal, meta?: { error_code?: string }): void {
+  console.info("[chat-drift]", {
+    signal,
+    error_code: meta?.error_code ?? null,
+  });
+
+  const redis = getMetricsRedis();
+  if (!redis) return;
+
+  const key = `viddel:chat:drift:${signal}:${dayKey()}`;
+  void redis
+    .incr(key)
+    .then(() => redis.expire(key, 60 * 60 * 24 * 45))
+    .catch(() => {
+      console.error("[chat-drift] metrics_incr_failed", { signal });
+    });
+}
+
+/** Test helper — reset cached redis client between tests. */
+export function resetChatMetricsRedisForTests(): void {
+  redisClient = undefined;
+}

--- a/src/lib/viddel-analytics-events.ts
+++ b/src/lib/viddel-analytics-events.ts
@@ -1,0 +1,36 @@
+/* CONTRACT: Whitelist for PostHog v0.1 — event names and safe properties only. */
+
+export const VIDDEL_ANALYTICS_EVENTS = [
+  "chat_opened",
+  "ai_entry_clicked",
+  "article_ai_seed_clicked",
+  "chat_question_sent",
+  "chat_answer_success",
+  "chat_answer_error",
+  "chat_rate_limited",
+  "chat_message_too_long",
+] as const;
+
+export type ViddelAnalyticsEvent = (typeof VIDDEL_ANALYTICS_EVENTS)[number];
+
+export const VIDDEL_ANALYTICS_PROPERTIES = [
+  "route",
+  "entry_surface",
+  "article_slug",
+  "seed_id",
+  "error_code",
+  "environment",
+  "input_type",
+] as const;
+
+export type ViddelAnalyticsProperty = (typeof VIDDEL_ANALYTICS_PROPERTIES)[number];
+
+/** Stable id from seed text — never returns the question itself. */
+export function seedIdFromLabel(label: string): string {
+  let hash = 0;
+  for (let i = 0; i < label.length; i += 1) {
+    hash = (hash << 5) - hash + label.charCodeAt(i);
+    hash |= 0;
+  }
+  return `s${Math.abs(hash).toString(36).slice(0, 10)}`;
+}

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -6,6 +6,11 @@ import {
   checkChatOrigin,
   checkChatRateLimit,
 } from "../../lib/chat-api-guard";
+import {
+  mapApiErrorToDriftSignal,
+  recordChatDriftSignal,
+  type ChatDriftSignal,
+} from "../../lib/chat-usage-metrics";
 import { resolveCesEnv } from "../../lib/ces-env";
 import { CesRunSessionError, runCesSession } from "../../lib/ces-run-session";
 
@@ -25,14 +30,28 @@ function jsonResponse(body: Record<string, unknown>, status: number): Response {
   });
 }
 
+function respond(
+  body: Record<string, unknown>,
+  status: number,
+  signal?: ChatDriftSignal,
+  errorCode?: string,
+): Response {
+  if (signal) {
+    recordChatDriftSignal(signal, errorCode ? { error_code: errorCode } : undefined);
+  }
+  return jsonResponse(body, status);
+}
+
 export const POST: APIRoute = async ({ request }) => {
   let body: ChatRequestBody;
   try {
     body = (await request.json()) as ChatRequestBody;
   } catch {
-    return jsonResponse(
+    return respond(
       { error: "invalid_json", message: CHAT_GUARD_MESSAGES.invalidRequest },
       400,
+      "error",
+      "invalid_json",
     );
   }
 
@@ -40,46 +59,66 @@ export const POST: APIRoute = async ({ request }) => {
   const sessionId = typeof body.sessionId === "string" ? body.sessionId.trim() : "";
 
   if (!message) {
-    return jsonResponse({ error: "invalid_message", message: "Skriv et spørsmål før du sender." }, 400);
+    return respond(
+      { error: "invalid_message", message: "Skriv et spørsmål før du sender." },
+      400,
+      "error",
+      "invalid_message",
+    );
   }
 
   if (message.length > CHAT_MAX_MESSAGE_LENGTH) {
-    return jsonResponse(
+    return respond(
       { error: "message_too_long", message: CHAT_GUARD_MESSAGES.messageTooLong },
       400,
+      "message_too_long",
+      "message_too_long",
     );
   }
 
   if (!sessionId || !SESSION_ID_PATTERN.test(sessionId)) {
-    return jsonResponse(
+    return respond(
       { error: "invalid_session", message: CHAT_GUARD_MESSAGES.invalidRequest },
       400,
+      "error",
+      "invalid_session",
     );
   }
 
   const originCheck = checkChatOrigin(request);
   if (!originCheck.ok) {
-    return jsonResponse({ error: "forbidden_origin", message: originCheck.message }, 403);
+    return respond(
+      { error: "forbidden_origin", message: originCheck.message },
+      403,
+      "error",
+      "forbidden_origin",
+    );
   }
 
   const rateLimit = await checkChatRateLimit(request);
   if (!rateLimit.ok) {
-    return jsonResponse({ error: rateLimit.error, message: rateLimit.message }, rateLimit.status);
+    const signal = mapApiErrorToDriftSignal(rateLimit.error);
+    return respond({ error: rateLimit.error, message: rateLimit.message }, rateLimit.status, signal, rateLimit.error);
   }
+
+  recordChatDriftSignal("request");
 
   const env = resolveCesEnv();
   if (!env.ok) {
-    return jsonResponse(
+    return respond(
       {
         error: "configuration_missing",
         message: "Viddel er ikke tilgjengelig akkurat nå.",
       },
       503,
+      "configuration_missing",
+      "configuration_missing",
     );
   }
 
   try {
     const result = await runCesSession(env.config, { message, sessionId });
+    recordChatDriftSignal("success");
     return jsonResponse(
       {
         text: result.text,
@@ -95,6 +134,7 @@ export const POST: APIRoute = async ({ request }) => {
         status: error.status,
         sessionIdLength: sessionId.length,
       });
+      recordChatDriftSignal("error", { error_code: error.code });
       return jsonResponse(
         {
           error: error.code,
@@ -108,6 +148,6 @@ export const POST: APIRoute = async ({ request }) => {
     }
 
     console.error("[api/chat] unexpected_error");
-    return jsonResponse({ error: "internal_error", message: CHAT_GUARD_MESSAGES.invalidRequest }, 500);
+    return respond({ error: "internal_error", message: CHAT_GUARD_MESSAGES.invalidRequest }, 500, "error", "internal_error");
   }
 };

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -20,14 +20,19 @@ import {
   services,
   serviceMapFlow,
   firstCheckRules,
+  monitoringExplainer,
+  monitoringEvents,
+  monitoringLogged,
+  monitoringNotLogged,
 } from "../../data/backstage-v01.ts";
 
 const base = import.meta.env.BASE_URL;
 
 const envGroups = [
-  { id: "upstash", label: "Upstash (teller)" },
+  { id: "upstash", label: "Upstash (teller + drift)" },
   { id: "ces", label: "CES (AI-motor)" },
   { id: "auth", label: "Google auth" },
+  { id: "posthog", label: "PostHog EU (produktinnsikt)" },
 ] as const;
 
 const layerTone: Record<string, string> = {
@@ -335,6 +340,53 @@ const layerTone: Record<string, string> = {
           </li>
         ))}
       </ul>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-monitoring">
+      <h2 id="bs-monitoring" class="bs__section-title">{monitoringExplainer.title}</h2>
+      <p class="bs__section-lead">{monitoringExplainer.lead}</p>
+      <div class="bs-monitoring-layers">
+        {monitoringExplainer.layers.map((layer) => (
+          <article class="bs-monitoring-layer">
+            <h3 class="bs-monitoring-layer__title">{layer.label}</h3>
+            <p class="bs-monitoring-layer__human">{layer.human}</p>
+            <p class="bs-monitoring-layer__where">
+              <span class="bs-monitoring-layer__where-label">Sjekk her:</span> {layer.where}
+            </p>
+          </article>
+        ))}
+      </div>
+      <div class="bs-monitoring-grid">
+        <div>
+          <h3 class="bs-monitoring-subtitle">Logges</h3>
+          <ul class="bs-note-list">
+            {monitoringLogged.map((item) => (
+              <li>{item}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 class="bs-monitoring-subtitle">Logges ikke</h3>
+          <ul class="bs-note-list">
+            {monitoringNotLogged.map((item) => (
+              <li>{item}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      <details class="bs-tech bs-tech--inline">
+        <summary>v0.1 PostHog-events</summary>
+        <ul class="bs-tech__env">
+          {monitoringEvents.map((event) => (
+            <li>
+              <code>{event.id}</code>
+              <span>
+                {event.layer} — {event.note}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </details>
     </section>
 
     <section class="bs__section" aria-labelledby="bs-checklist">
@@ -1233,6 +1285,73 @@ const layerTone: Record<string, string> = {
 
     .bs-note-list li + li {
       margin-top: 0.4rem;
+    }
+
+    .bs-monitoring-layers {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+
+    @media (min-width: 768px) {
+      .bs-monitoring-layers {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    .bs-monitoring-layer {
+      padding: 0.85rem 1rem;
+      border-radius: 0.5rem;
+      background: rgb(249 250 251);
+      border: 1px solid rgb(243 244 246);
+    }
+
+    .bs-monitoring-layer__title {
+      margin: 0;
+      font-size: 0.82rem;
+      font-weight: 650;
+      color: rgb(55 65 81);
+    }
+
+    .bs-monitoring-layer__human {
+      margin: 0.45rem 0 0;
+      font-size: 0.88rem;
+      line-height: 1.55;
+      color: rgb(75 85 99);
+    }
+
+    .bs-monitoring-layer__where {
+      margin: 0.55rem 0 0;
+      font-size: 0.78rem;
+      line-height: 1.45;
+      color: rgb(107 114 128);
+    }
+
+    .bs-monitoring-layer__where-label {
+      font-weight: 600;
+    }
+
+    .bs-monitoring-grid {
+      display: grid;
+      gap: 1.25rem;
+      margin-top: 1.25rem;
+    }
+
+    @media (min-width: 640px) {
+      .bs-monitoring-grid {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+
+    .bs-monitoring-subtitle {
+      margin: 0;
+      font-size: 0.82rem;
+      font-weight: 650;
+      color: rgb(55 65 81);
+    }
+
+    .bs-tech--inline {
+      margin-top: 1rem;
     }
 
     .bs-tech {

--- a/src/pages/no/chat.astro
+++ b/src/pages/no/chat.astro
@@ -174,6 +174,11 @@ const aiHeadingId = "viddel-standalone-chat-ai";
       const SESSION_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-_]{4,62}$/;
       const params = new URLSearchParams(window.location.search);
       const seedFromUrl = (params.get("seed") || params.get("q") || "").trim();
+      const entrySurface = (params.get("from") || "standalone").trim() || "standalone";
+
+      if (typeof window.viddelTrack === "function") {
+        window.viddelTrack("chat_opened", { entry_surface: entrySurface });
+      }
 
       let isSending = false;
       let hasConversation = false;
@@ -292,6 +297,20 @@ const aiHeadingId = "viddel-standalone-chat-ai";
         input.disabled = true;
         setLoading(true);
 
+        const inputType = exampleButtons.length && Array.from(exampleButtons).some((btn) => btn.getAttribute("data-viddel-chat-example") === message)
+          ? "seed"
+          : seedFromUrl && message === seedFromUrl
+            ? "seed"
+            : "freeform";
+
+        if (typeof window.viddelTrack === "function") {
+          const trackProps = { entry_surface: entrySurface, input_type: inputType };
+          if (inputType === "seed" && typeof window.viddelSeedId === "function") {
+            trackProps.seed_id = window.viddelSeedId(message);
+          }
+          window.viddelTrack("chat_question_sent", trackProps);
+        }
+
         try {
           const response = await fetch("/api/chat", {
             method: "POST",
@@ -304,18 +323,37 @@ const aiHeadingId = "viddel-standalone-chat-ai";
 
           const payload = await response.json().catch(() => ({}));
           if (!response.ok) {
+            const errorCode = typeof payload?.error === "string" ? payload.error : "unknown";
+            if (typeof window.viddelTrack === "function") {
+              if (errorCode === "rate_limited") {
+                window.viddelTrack("chat_rate_limited", { entry_surface: entrySurface, error_code: errorCode });
+              } else if (errorCode === "message_too_long") {
+                window.viddelTrack("chat_message_too_long", { entry_surface: entrySurface, error_code: errorCode });
+              } else {
+                window.viddelTrack("chat_answer_error", { entry_surface: entrySurface, error_code: errorCode });
+              }
+            }
             showError(friendlyError(payload));
             return;
           }
 
           const text = typeof payload.text === "string" ? payload.text.trim() : "";
           if (!text) {
+            if (typeof window.viddelTrack === "function") {
+              window.viddelTrack("chat_answer_error", { entry_surface: entrySurface, error_code: "empty_response" });
+            }
             showError("Vi fikk ikke tak i svaret akkurat nå. Prøv igjen.");
             return;
           }
 
+          if (typeof window.viddelTrack === "function") {
+            window.viddelTrack("chat_answer_success", { entry_surface: entrySurface });
+          }
           appendAssistantMessage(text);
         } catch (_) {
+          if (typeof window.viddelTrack === "function") {
+            window.viddelTrack("chat_answer_error", { entry_surface: entrySurface, error_code: "network_error" });
+          }
           showError("Nettverksfeil. Sjekk tilkoblingen og prøv igjen.");
         } finally {
           isSending = false;


### PR DESCRIPTION
## Summary
- **Trinn A:** Server-side drift signals on `/api/chat` via Upstash + Vercel logs (no content logging)
- **Trinn B:** Minimal PostHog EU client events (optional via `PUBLIC_POSTHOG_KEY`)
- Backstage monitoring section + VIS/current-state/runtime feed updates

## Test plan
- [ ] `/no/chat/` works unchanged
- [ ] `/api/chat` guard order preserved
- [ ] Vercel logs show `[chat-drift]` lines without message text
- [ ] Upstash keys `viddel:chat:drift:*` increment on test requests
- [ ] PostHog events fire when key configured (EU, no replay)
- [ ] Backstage monitoring section readable
- [ ] `npm run build` green


Made with [Cursor](https://cursor.com)