### PR TITLE
Hotfix: chat error state + upstream retry

### DIFF
--- a/src/lib/chat-usage-metrics.ts
+++ b/src/lib/chat-usage-metrics.ts
@@ -45,21 +45,25 @@ export function mapApiErrorToDriftSignal(error: string): ChatDriftSignal {
 
 /** Fire-and-forget — never throws, never logs message/session/IP. */
 export function recordChatDriftSignal(signal: ChatDriftSignal, meta?: { error_code?: string }): void {
-  console.info("[chat-drift]", {
-    signal,
-    error_code: meta?.error_code ?? null,
-  });
-
-  const redis = getMetricsRedis();
-  if (!redis) return;
-
-  const key = `viddel:chat:drift:${signal}:${dayKey()}`;
-  void redis
-    .incr(key)
-    .then(() => redis.expire(key, 60 * 60 * 24 * 45))
-    .catch(() => {
-      console.error("[chat-drift] metrics_incr_failed", { signal });
+  try {
+    console.info("[chat-drift]", {
+      signal,
+      error_code: meta?.error_code ?? null,
     });
+
+    const redis = getMetricsRedis();
+    if (!redis) return;
+
+    const key = `viddel:chat:drift:${signal}:${dayKey()}`;
+    void redis
+      .incr(key)
+      .then(() => redis.expire(key, 60 * 60 * 24 * 45))
+      .catch(() => {
+        console.error("[chat-drift] metrics_incr_failed", { signal });
+      });
+  } catch {
+    console.error("[chat-drift] metrics_record_failed", { signal });
+  }
 }
 
 /** Test helper — reset cached redis client between tests. */

--- a/src/pages/no/chat.astro
+++ b/src/pages/no/chat.astro
@@ -311,7 +311,9 @@ const aiHeadingId = "viddel-standalone-chat-ai";
           window.viddelTrack("chat_question_sent", trackProps);
         }
 
-        try {
+        const retryableErrors = new Set(["upstream", "empty_response"]);
+
+        const requestChat = async () => {
           const response = await fetch("/api/chat", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -320,17 +322,29 @@ const aiHeadingId = "viddel-standalone-chat-ai";
               sessionId: ensureSessionId(),
             }),
           });
-
           const payload = await response.json().catch(() => ({}));
+          return { response, payload };
+        };
+
+        try {
+          let { response, payload } = await requestChat();
+          let errorCode = typeof payload?.error === "string" ? payload.error : "";
+
+          if (!response.ok && retryableErrors.has(errorCode)) {
+            await new Promise((resolve) => window.setTimeout(resolve, 600));
+            ({ response, payload } = await requestChat());
+            errorCode = typeof payload?.error === "string" ? payload.error : "";
+          }
+
           if (!response.ok) {
-            const errorCode = typeof payload?.error === "string" ? payload.error : "unknown";
+            const trackedCode = errorCode || "unknown";
             if (typeof window.viddelTrack === "function") {
-              if (errorCode === "rate_limited") {
-                window.viddelTrack("chat_rate_limited", { entry_surface: entrySurface, error_code: errorCode });
-              } else if (errorCode === "message_too_long") {
-                window.viddelTrack("chat_message_too_long", { entry_surface: entrySurface, error_code: errorCode });
+              if (trackedCode === "rate_limited") {
+                window.viddelTrack("chat_rate_limited", { entry_surface: entrySurface, error_code: trackedCode });
+              } else if (trackedCode === "message_too_long") {
+                window.viddelTrack("chat_message_too_long", { entry_surface: entrySurface, error_code: trackedCode });
               } else {
-                window.viddelTrack("chat_answer_error", { entry_surface: entrySurface, error_code: errorCode });
+                window.viddelTrack("chat_answer_error", { entry_surface: entrySurface, error_code: trackedCode });
               }
             }
             showError(friendlyError(payload));
@@ -346,6 +360,7 @@ const aiHeadingId = "viddel-standalone-chat-ai";
             return;
           }
 
+          clearError();
           if (typeof window.viddelTrack === "function") {
             window.viddelTrack("chat_answer_success", { entry_surface: entrySurface });
           }


### PR DESCRIPTION
## Summary
- Fjerner «klebrig» feilmelding ved å tømme error state rett før vellykket svar vises
- Én automatisk retry (600 ms) ved `upstream` og `empty_response` fra `/api/chat`
- Fail-soft wrapper på metrics (`recordChatDriftSignal`) — skal ikke påvirke chat-respons

## Bakgrunn
Etter merge av #194 viste produksjon intermittente feil på `/no/chat/` («Vi fikk ikke tak i svaret akkurat nå»). Repro mot prod-API viste 502 `upstream` fra CES — ikke metrics. Metrics er sync/fire-and-forget og kan ikke kaste inn i respons-path.

## Test plan
- [ ] Seed-spørsmål på `/no/chat/` → svar OK
- [ ] Fritekst (Thomas-spørsmålet) → svar eller retry uten klebrig feilbanner etter suksess
- [ ] Simuler/transient upstream → én retry før feil vises
- [ ] Vercel logs: `[chat-drift]` med `upstream` vs `success` — ingen prompt/answer i logger
- [ ] `npm run build` ✅

## Scope
Ingen PostHog-aktivering, ingen rate limit/CES/guard-endringer, ingen UI-redesign utover error/retry.

Made with [Cursor](https://cursor.com)