### PR TITLE
Chat reliability hardening v0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# local reliability probe output (metadata only; no content)
+tmp/chat-reliability/

--- a/docs/project/AI_CHAT_RELIABILITY_ASSESSMENT_v0_1.md
+++ b/docs/project/AI_CHAT_RELIABILITY_ASSESSMENT_v0_1.md
@@ -1,0 +1,200 @@
+# AI Chat Reliability Assessment v0.1
+
+Status: **Complete (analysis)**  
+Date: 2026-06-01  
+Related: [#188](https://github.com/THUNDERPLUNDER/vox-web/issues/188), [#195](https://github.com/THUNDERPLUNDER/vox-web/pull/195)  
+Script: `scripts/chat-reliability-assessment.mjs`
+
+---
+
+## Executive summary
+
+Intermittent chat-feil skyldes **primært CES upstream-feil**, ikke metrics (#194) og ikke Vercel-proxy timeout i de observerte tilfellene.
+
+| Hypotese | Konklusjon |
+|----------|------------|
+| CES upstream | **Sannsynlig hovedårsak** — raske 502 `<1s`, retry hjelper sjelden |
+| Region/endpoint mismatch | **Ingen indikasjon** — headless bruker `eu` + dokumentert API access deployment |
+| Vercel function/proxy | **Usannsynlig som rotårsak** — feil er raske; ingen timeout-mønster (8–20s+) |
+| Vår API/UI-håndtering | **Delvis** — mapper alle CES-feil til HTTP 502; mangler upstream HTTP-status i logger |
+| Rate limit (#180) | **Sekundær** — bulk-test fra én IP treffer 10/10 min burst; ikke brukerens hovedproblem |
+
+**#195 er nok for intern test** (retry + clearError), men **ikke nok for ekstern pilot** hvis CES upstream fortsatt ~20–80% feil.
+
+**Anbefalt reliability-strategi (kort):** CES reliability envelope (timeout, circuit breaker, bedre upstream-status logging) + repo-basert driftcheck — **ikke** plattformbytte ennå.
+
+---
+
+## Sjekk 1 — CES region og endpoint
+
+### Konfigurasjon (fra kode + `.env.example` + beslutningsdok)
+
+| Variabel | Dokumentert verdi | Kilde |
+|----------|-------------------|--------|
+| `CES_PROJECT_ID` | `hearing-aid-mvp` | `.env.example`, DECISION_125M-B |
+| `CES_LOCATION` | `eu` | `.env.example` |
+| `CES_APP_ID` | `1741e68d-0528-4625-8b83-99a0dbb5298f` | `.env.example` |
+| `CES_APP_VERSION_ID` | `91cc4831-f020-4bb1-a17c-650859401cb1` | `.env.example` |
+| `CES_DEPLOYMENT_ID` | `edb2938a-a2bf-4555-b4c9-d54963531db4` | `.env.example` (API access) |
+
+### Faktisk endpoint (fra `ces-run-session.ts`)
+
+```
+POST https://ces.googleapis.com/v1beta/projects/{projectId}/locations/{location}/apps/{appId}/sessions/{sessionId}:runSession
+```
+
+Eksempel (headless prod):
+
+```
+https://ces.googleapis.com/v1beta/projects/hearing-aid-mvp/locations/eu/apps/1741e68d-0528-4625-8b83-99a0dbb5298f/sessions/{sessionId}:runSession
+```
+
+### Service account scopes
+
+`ces-auth.ts` bruker scope `https://www.googleapis.com/auth/cloud-platform` — tilstrekkelig for CES API med SA JSON.
+
+### Mulig mismatch? (viktig å skille kanaler)
+
+| Kanal | Deployment ID | Merknad |
+|-------|---------------|---------|
+| **Headless `/api/chat`** | `edb2938a-…` | API access channel — korrekt for `runSession` |
+| **CES-widget (`BaseLayout`)** | `dc1619d0-…` | Messenger channel — **annen** deployment, samme app/region |
+
+Widget-stien bruker **project number** (`1088102295663`) i hardkodet `deploymentName`; headless bruker **project ID** (`hearing-aid-mvp`). Dette er normalt i GCP (ID vs nummer), ikke nødvendigvis feil.
+
+**Konklusjon region:** `eu` er konsistent. Ingen tegn til feil `global` vs `eu`. Regionvalg kan påvirke latency, men observerte feil er **raske avslag**, ikke trege timeouts.
+
+**Agent har ikke lest Vercel Production env direkte** — verdiene over er fra repo-dokumentasjon. Avvik i Vercel ville være operativ risiko, ikke observert i kode.
+
+---
+
+## Sjekk 2 — Vercel / runtime
+
+| Tema | Funn |
+|------|------|
+| Function region | **Ikke satt** i `vercel.json` / `astro.config.mjs` → Vercel default (typisk nærmeste region til klient, ikke eksplisitt EU-pinning) |
+| `maxDuration` | **Ikke satt** → platform default (ofte 10–60s avhengig av plan) |
+| CES fetch timeout | **Ingen** — `fetch()` uten `AbortController` i `ces-run-session.ts` |
+| AbortController | **Nei** |
+| Opprinnelse av HTTP 502 | **Vår kode** mapper `!response.ok` fra CES til `CesRunSessionError(..., "upstream", 502)` — klient ser nesten alltid **502**, uavhengig av CES HTTP-status (429/503/500) |
+| Diagnostisk tap | `error.message` inneholder `ces_upstream_{status}`, men **logges ikke** — `[api/chat] ces_run_session_failed` logger `code`, `status` (alltid 502), `sessionIdLength` |
+| Guardrekkefølge | Uendret: validate → origin → rate limit → metrics request → CES → success/error metrics |
+
+**Latency-mønster:** Upstream-feil kommer typisk **<1s** (CES avslår raskt). Suksess ~2–8s. Dette peker **mot CES**, ikke Vercel function timeout.
+
+---
+
+## Sjekk 3 — Controlled test (production)
+
+Kjørt med `scripts/chat-reliability-assessment.mjs` mot `https://vox.raddum.no` — **ingen prompt/svar i output**.
+
+### Serie A — 20 kall, 600 ms mellomrom, client-retry simulert
+
+| Metrikk | Verdi |
+|---------|-------|
+| Totalt | 20 |
+| Suksess | 1 (5%) |
+| Upstream 502 | 4 (før rate limit dominerte) |
+| empty_response | 0 |
+| Retry forsøkt | 5 |
+| Retry hjalp | **0** |
+| Latency suksess | 3–8s |
+| Latency upstream-feil | <1s |
+
+**Request 1–5 (før IP rate limit):**
+
+| # | Type | Resultat | Retry |
+|---|------|----------|-------|
+| 1 | seed | ✅ success | — |
+| 2 | freeform | ❌ upstream | ja, hjalp ikke |
+| 3 | freeform | ❌ upstream | ja, hjalp ikke |
+| 4 | seed | ❌ upstream | ja, hjalp ikke |
+| 5 | freeform | ❌ upstream | ja, hjalp ikke |
+
+**Request 6–20:** `rate_limited` (429) — forventet etter bulk-test fra én IP mot 10/10 min burst guard (#180). **Ikke** CES upstream.
+
+Raw metadata: `tmp/chat-reliability/assessment-v01-prod.json` (gitignored tmp — kjør script på nytt for repro).
+
+### Serie B — enkeltverifisering
+
+Etter Serie A: enkelt `POST /api/chat` → **HTTP 200**, ~2s (bekrefter at tjenesten fortsatt kan svare).
+
+### Konklusjon test
+
+- **Success rate (ren upstream-vindu):** ~20% (1/5 før rate limit)
+- **Upstream 502:** konsistent, rask
+- **Retry (#195):** 0/4 recovery i denne serien
+- **Rate limit:** må tas med i fremtidige testserier (bruk `--delay-ms=65000` eller færre kall)
+
+---
+
+## Sjekk 4 — Direkte vs proxy
+
+| Test | Status |
+|------|--------|
+| Via `/api/chat` | ✅ Kjørt (Serie A/B) |
+| Direkte CES fra agent | ❌ **Ikke kjørt** — ingen `CES_*` / SA i lokal `.env` |
+
+**Anbefaling:** Kjør lokalt med Vercel env eller Cloud Shell:
+
+```bash
+# Etter env er satt (aldri commit):
+node scripts/chat-reliability-assessment.mjs --count=10 --direct --delay-ms=12000 --session-per-request
+```
+
+Sammenlign `row.direct.cesHttpStatus` vs `row.httpStatus`. Hvis 502 kun via proxy → undersøk proxy; hvis begge → CES.
+
+---
+
+## Sjekk 5 — Enklere driftverifisering (forslag, ikke implementert)
+
+### Problem
+
+Thomas skal ikke manuelt grave i Vercel Runtime Logs og Upstash Console som hovedflyt.
+
+### Anbefalt måte
+
+| Lag | Forslag |
+|-----|---------|
+| **Repo-script** | `npm run chat:reliability` → wrapper rundt `scripts/chat-reliability-assessment.mjs` — metadata JSON + stdout summary |
+| **Backstage runbook** | Seksjon «Chat driftcheck» med 3 trinn: kjør script → les success rate → eskalér hvis `<80%` |
+| **Intern diagnostics-route** (senere) | `GET /api/ops/chat-drift` bak backstage-guard — returnerer Upstash tellere + siste time (ingen innhold) |
+| **Return Ticket-format** | Tydelige badges: `verified-by-code` / `verified-by-browser` / `requires-console` |
+
+### Return Ticket-verifikasjonsnivåer (forslag)
+
+```
+verified-by-code       → build + unit + script grønn
+verified-by-production → browser/API smoke uten console
+requires-console       → kun når agent mangler credentials (CES direkte, Vercel log export)
+```
+
+---
+
+## Alternativarkitektur (vurdering, ikke implementert)
+
+| # | Alternativ | Når | Risiko |
+|---|------------|-----|--------|
+| 1 | **CES + reliability envelope** | **Anbefalt nå** — timeout, retry/backoff, circuit breaker, log upstream HTTP status | Lav |
+| 2 | **CES + statisk fallback for seed** | Kjente seed-spørsmål ved upstream — bedre UX, ikke rotfix | Medium (vedlikehold) |
+| 3 | **Direkte Vertex AI / Gemini** | Hvis CES ikke stabiliseres etter GCP-eskalering | Høy (mandat) |
+| 4 | **Vercel AI Gateway + fallback** | Multi-modell senere | Medium |
+| 5 | **OpenAI/RAG** | Senere fase | Høy |
+
+---
+
+## Anbefalinger (prioritert)
+
+1. **Eskalér CES upstream** til GCP/CES med tidspunkt + feilrate (metadata fra script) — ikke prompt/svar.
+2. **Logg `upstreamHttpStatus`** i `ces_run_session_failed` (liten kodeendring, neste PR).
+3. **Legg til fetch timeout** (f.eks. 25s AbortController) — skille timeout vs rask CES-feil.
+4. **Pin Vercel function region** til EU hvis mulig (latency).
+5. **Adopter repo-script** som standard driftcheck — Thomas kjører én kommando, leser summary.
+6. **Hold PostHog av** til reliability er akseptabel.
+7. **Utsett ekstern pilot** til success rate stabil >80% over 20+ spaced kall.
+
+---
+
+## #188 status
+
+**Landet teknisk, verification remaining** — console-verifisering erstattes av script-basert driftcheck som hovedflyt.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "kl:tasks": "node scripts/kl-task-layer.mjs",
     "vis:github:runtime-status": "node scripts/generate-github-runtime-status.mjs",
     "vis:github:snapshot": "node scripts/vis-github-live-snapshot.mjs",
-    "chat:reliability": "node scripts/chat-reliability-assessment.mjs --count=10 --delay-ms=12000 --session-per-request"
+    "chat:reliability": "node scripts/chat-reliability-assessment.mjs"
   },
   "dependencies": {
     "@astrojs/vercel": "^9.0.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "storyblok:verify:viddel-mvp": "node scripts/storyblok-verify-viddel-mvp.mjs",
     "kl:tasks": "node scripts/kl-task-layer.mjs",
     "vis:github:runtime-status": "node scripts/generate-github-runtime-status.mjs",
-    "vis:github:snapshot": "node scripts/vis-github-live-snapshot.mjs"
+    "vis:github:snapshot": "node scripts/vis-github-live-snapshot.mjs",
+    "chat:reliability": "node scripts/chat-reliability-assessment.mjs --count=10 --delay-ms=12000 --session-per-request"
   },
   "dependencies": {
     "@astrojs/vercel": "^9.0.5",

--- a/scripts/chat-reliability-assessment.mjs
+++ b/scripts/chat-reliability-assessment.mjs
@@ -9,8 +9,9 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const DEFAULT_BASE = "https://vox.raddum.no";
-const RETRY_DELAY_MS = 600;
-const RETRYABLE = new Set(["upstream", "empty_response"]);
+/** Stay under production burst guard (10 / 10 min per IP). */
+const DEFAULT_COUNT = 8;
+const DEFAULT_DELAY_MS = 8_000;
 
 /** Fixed prompts — used internally only; never written to output. */
 const SEED_PROMPTS = [
@@ -42,20 +43,18 @@ const FREEFORM_PROMPTS = [
 function parseArgs(argv) {
   const args = {
     base: DEFAULT_BASE,
-    count: 20,
+    count: DEFAULT_COUNT,
     out: "",
     direct: false,
-    delayMs: 800,
-    sessionPerRequest: false,
-    noClientRetry: false,
+    delayMs: DEFAULT_DELAY_MS,
+    sessionPerRequest: true,
   };
   for (const arg of argv) {
     if (arg.startsWith("--base=")) args.base = arg.slice(7).replace(/\/$/, "");
     else if (arg.startsWith("--count=")) args.count = Number(arg.slice(8));
     else if (arg.startsWith("--out=")) args.out = arg.slice(6);
     else if (arg === "--direct") args.direct = true;
-    else if (arg === "--session-per-request") args.sessionPerRequest = true;
-    else if (arg === "--no-client-retry") args.noClientRetry = true;
+    else if (arg === "--shared-session") args.sessionPerRequest = false;
     else if (arg.startsWith("--delay-ms=")) args.delayMs = Number(arg.slice(11));
   }
   return args;
@@ -67,6 +66,27 @@ function durationBucket(ms) {
   if (ms < 8000) return "3-8s";
   if (ms < 20000) return "8-20s";
   return ">20s";
+}
+
+/** Classify outcome for reporting — no message content. */
+function errorCategory(errorCode, httpStatus) {
+  if (errorCode === "rate_limited" || httpStatus === 429) return "rate_limit";
+  if (errorCode === "timeout" || httpStatus === 504) return "timeout";
+  if (errorCode === "upstream" || errorCode === "empty_response") return "ces_upstream";
+  if (
+    errorCode === "invalid_message" ||
+    errorCode === "invalid_session" ||
+    errorCode === "invalid_json" ||
+    errorCode === "forbidden_origin" ||
+    errorCode === "message_too_long" ||
+    errorCode === "configuration_missing" ||
+    errorCode === "guard_unavailable" ||
+    errorCode === "auth" ||
+    errorCode === "internal_error"
+  ) {
+    return "app_error";
+  }
+  return "other";
 }
 
 function buildPlan(count) {
@@ -94,33 +114,15 @@ async function callProxy(base, sessionId, message) {
   const payload = await response.json().catch(() => ({}));
   const errorCode = typeof payload.error === "string" ? payload.error : null;
   const hasText = typeof payload.text === "string" && payload.text.trim().length > 0;
+  const category = hasText ? "success" : errorCategory(errorCode, response.status);
   return {
     httpStatus: response.status,
     errorCode,
+    category,
     success: response.ok && hasText,
     durationMs,
     durationBucket: durationBucket(durationMs),
   };
-}
-
-async function callWithClientRetry(base, sessionId, message) {
-  let first = await callProxy(base, sessionId, message);
-  let retryUsed = false;
-  if (!first.success && first.errorCode && RETRYABLE.has(first.errorCode)) {
-    retryUsed = true;
-    await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
-    const second = await callProxy(base, sessionId, message);
-    return {
-      ...second,
-      retryUsed,
-      firstAttempt: {
-        httpStatus: first.httpStatus,
-        errorCode: first.errorCode,
-        durationBucket: first.durationBucket,
-      },
-    };
-  }
-  return { ...first, retryUsed, firstAttempt: null };
 }
 
 function readCesEnv() {
@@ -210,30 +212,37 @@ async function callDirectCes(env, sessionId, message) {
     success: response.ok && hasText,
     durationMs,
     durationBucket: durationBucket(durationMs),
+    category: hasText ? "success" : response.ok ? "ces_upstream" : "ces_upstream",
   };
 }
 
 function summarize(results) {
   const total = results.length;
-  const success = results.filter((r) => r.finalSuccess).length;
-  const upstream = results.filter((r) => r.finalErrorCode === "upstream").length;
-  const empty = results.filter((r) => r.finalErrorCode === "empty_response").length;
-  const retryHelped = results.filter((r) => r.retryUsed && r.finalSuccess).length;
-  const retryAttempted = results.filter((r) => r.retryUsed).length;
+  const byCategory = {
+    success: 0,
+    ces_upstream: 0,
+    rate_limit: 0,
+    timeout: 0,
+    app_error: 0,
+    other: 0,
+  };
+  for (const row of results) {
+    byCategory[row.category] = (byCategory[row.category] ?? 0) + 1;
+  }
   const buckets = {};
   for (const r of results) {
     buckets[r.durationBucket] = (buckets[r.durationBucket] ?? 0) + 1;
   }
+  const success = byCategory.success;
   return {
     total,
     success,
     error: total - success,
     successRate: total ? Number(((success / total) * 100).toFixed(1)) : 0,
-    upstream502Proxy: upstream,
-    emptyResponse: empty,
-    retryAttempted,
-    retryHelped,
+    byCategory,
     durationBuckets: buckets,
+    guardNote:
+      "Default 8 calls / 8s spacing stays under 10-per-10min burst. One /api/chat per row (server retry is internal).",
   };
 }
 
@@ -243,50 +252,53 @@ async function main() {
   const plan = buildPlan(args.count);
   const results = [];
 
+  console.log(
+    `chat-reliability: ${args.count} calls, ${args.delayMs}ms spacing, sessionPerRequest=${args.sessionPerRequest}`,
+  );
+
   for (const item of plan) {
     const requestSessionId = args.sessionPerRequest
       ? `viddel-rel-${Date.now().toString(36)}-${item.n}`
       : sessionId;
-    const proxy = args.noClientRetry
-      ? { ...(await callProxy(args.base, requestSessionId, item.message)), retryUsed: false, firstAttempt: null }
-      : await callWithClientRetry(args.base, requestSessionId, item.message);
+    const proxy = await callProxy(args.base, requestSessionId, item.message);
     const row = {
       request: item.n,
       inputType: item.inputType,
       channel: "proxy",
       httpStatus: proxy.httpStatus,
       errorCode: proxy.errorCode,
+      category: proxy.category,
       finalSuccess: proxy.success,
-      finalErrorCode: proxy.success ? null : proxy.errorCode,
       durationMs: proxy.durationMs,
       durationBucket: proxy.durationBucket,
-      retryUsed: proxy.retryUsed,
-      firstAttempt: proxy.firstAttempt,
     };
 
     if (args.direct) {
       const { env, missing } = readCesEnv();
       if (missing.length === 0) {
         try {
-          const direct = await callDirectCes(env, `${sessionId}-d${item.n}`, item.message);
+          const direct = await callDirectCes(env, `${requestSessionId}-direct`, item.message);
           row.direct = {
             cesHttpStatus: direct.cesHttpStatus,
             success: direct.success,
             durationBucket: direct.durationBucket,
+            category: direct.category,
           };
         } catch (err) {
-          row.direct = { error: String(err.message ?? err).slice(0, 40) };
+          row.direct = { error: String(err.message ?? err).slice(0, 40), category: "app_error" };
         }
       } else {
-        row.direct = { skipped: true, missingKeys: missing.length };
+        row.direct = { skipped: true, missingKeys: missing.length, category: "other" };
       }
     }
 
     results.push(row);
     process.stdout.write(
-      `#${row.request} ${row.inputType} ${row.finalSuccess ? "OK" : "ERR"} code=${row.finalErrorCode ?? "none"} retry=${row.retryUsed} ${row.durationBucket}\n`,
+      `#${row.request} ${row.inputType} ${row.category} http=${row.httpStatus} code=${row.errorCode ?? "none"} ${row.durationBucket}\n`,
     );
-    if (args.delayMs > 0) await new Promise((r) => setTimeout(r, args.delayMs));
+    if (args.delayMs > 0 && item.n < plan.length) {
+      await new Promise((r) => setTimeout(r, args.delayMs));
+    }
   }
 
   const summary = summarize(results);
@@ -294,20 +306,12 @@ async function main() {
   const report = {
     generatedAt: new Date().toISOString(),
     base: args.base,
-    sessionIdPrefix: sessionId.slice(0, 16),
-    endpointFromCode: {
-      hostname: "ces.googleapis.com",
-      apiVersion: "v1beta",
-      pathPattern: "projects/{projectId}/locations/{location}/apps/{appId}/sessions/{sessionId}:runSession",
-      documentedEnv: {
-        projectId: "hearing-aid-mvp (.env.example)",
-        location: "eu",
-        appId: "1741e68d-0528-4625-8b83-99a0dbb5298f",
-        deploymentId: "edb2938a-a2bf-4555-b4c9-d54963531db4",
-      },
-      widgetDeploymentNote:
-        "BaseLayout widget uses dc1619d0-44a1-401b-92a6-1357c29274ea (Messenger) — separate from headless API deployment",
+    config: {
+      count: args.count,
+      delayMs: args.delayMs,
+      sessionPerRequest: args.sessionPerRequest,
     },
+    sessionIdPrefix: sessionId.slice(0, 16),
     directEnvAvailable: cesEnv.missing.length === 0,
     summary,
     results,

--- a/scripts/chat-reliability-assessment.mjs
+++ b/scripts/chat-reliability-assessment.mjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+/* CONTRACT: Safe chat reliability probe — metadata only, no prompt/answer logging. */
+
+import { createSign } from "node:crypto";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_BASE = "https://vox.raddum.no";
+const RETRY_DELAY_MS = 600;
+const RETRYABLE = new Set(["upstream", "empty_response"]);
+
+/** Fixed prompts — used internally only; never written to output. */
+const SEED_PROMPTS = [
+  "Hvordan kobler jeg høreapparatet til mobilen?",
+  "Hvorfor blir lyden så slitsom på restaurant?",
+  "Hva gjør jeg når appen ikke finner høreapparatet?",
+  "Hvordan vet jeg om jeg bør kontakte audiograf?",
+  "Hva kan jeg prøve hvis lyden fra TV-en blir utydelig?",
+];
+
+const FREEFORM_PROMPTS = [
+  "Hvorfor blir lyd fra høreapparat slitsom i støy?",
+  "Hva kan jeg gjøre når musikk høres flatt med høreapparat?",
+  "Hvordan justerer jeg volum mellom ulike situasjoner?",
+  "Hvorfor hører jeg egen stemme annerledes med apparat?",
+  "Hva betyr det når appen sier tilkobling tapt?",
+  "Kan vind påvirke lydkvaliteten merkbart?",
+  "Hvordan håndterer jeg ekko i store rom?",
+  "Hva er normal tilvenningstid for nye innstillinger?",
+  "Hvorfor blir tale uklar selv med apparat?",
+  "Hvordan vet jeg om batteriet er lavt?",
+  "Hva kan jeg prøve før jeg ringer audiograf?",
+  "Hvorfor forsvinner lyden kort i telefonsamtaler?",
+  "Hvordan reduserer jeg bakgrunnsstøy i kafé?",
+  "Er det normalt at ørene føles tette første uke?",
+  "Hva gjør jeg hvis bare ett apparat kobler til?",
+];
+
+function parseArgs(argv) {
+  const args = {
+    base: DEFAULT_BASE,
+    count: 20,
+    out: "",
+    direct: false,
+    delayMs: 800,
+    sessionPerRequest: false,
+    noClientRetry: false,
+  };
+  for (const arg of argv) {
+    if (arg.startsWith("--base=")) args.base = arg.slice(7).replace(/\/$/, "");
+    else if (arg.startsWith("--count=")) args.count = Number(arg.slice(8));
+    else if (arg.startsWith("--out=")) args.out = arg.slice(6);
+    else if (arg === "--direct") args.direct = true;
+    else if (arg === "--session-per-request") args.sessionPerRequest = true;
+    else if (arg === "--no-client-retry") args.noClientRetry = true;
+    else if (arg.startsWith("--delay-ms=")) args.delayMs = Number(arg.slice(11));
+  }
+  return args;
+}
+
+function durationBucket(ms) {
+  if (ms < 1000) return "<1s";
+  if (ms < 3000) return "1-3s";
+  if (ms < 8000) return "3-8s";
+  if (ms < 20000) return "8-20s";
+  return ">20s";
+}
+
+function buildPlan(count) {
+  const plan = [];
+  for (let i = 0; i < count; i += 1) {
+    const inputType = i % 3 === 0 ? "seed" : "freeform";
+    const pool = inputType === "seed" ? SEED_PROMPTS : FREEFORM_PROMPTS;
+    plan.push({ n: i + 1, inputType, message: pool[i % pool.length] });
+  }
+  return plan;
+}
+
+async function callProxy(base, sessionId, message) {
+  const started = performance.now();
+  const response = await fetch(`${base}/api/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: base,
+      Referer: `${base}/no/chat/`,
+    },
+    body: JSON.stringify({ message, sessionId }),
+  });
+  const durationMs = Math.round(performance.now() - started);
+  const payload = await response.json().catch(() => ({}));
+  const errorCode = typeof payload.error === "string" ? payload.error : null;
+  const hasText = typeof payload.text === "string" && payload.text.trim().length > 0;
+  return {
+    httpStatus: response.status,
+    errorCode,
+    success: response.ok && hasText,
+    durationMs,
+    durationBucket: durationBucket(durationMs),
+  };
+}
+
+async function callWithClientRetry(base, sessionId, message) {
+  let first = await callProxy(base, sessionId, message);
+  let retryUsed = false;
+  if (!first.success && first.errorCode && RETRYABLE.has(first.errorCode)) {
+    retryUsed = true;
+    await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+    const second = await callProxy(base, sessionId, message);
+    return {
+      ...second,
+      retryUsed,
+      firstAttempt: {
+        httpStatus: first.httpStatus,
+        errorCode: first.errorCode,
+        durationBucket: first.durationBucket,
+      },
+    };
+  }
+  return { ...first, retryUsed, firstAttempt: null };
+}
+
+function readCesEnv() {
+  const keys = [
+    "CES_PROJECT_ID",
+    "CES_LOCATION",
+    "CES_APP_ID",
+    "CES_APP_VERSION_ID",
+    "CES_DEPLOYMENT_ID",
+    "GOOGLE_SERVICE_ACCOUNT_JSON",
+  ];
+  const env = Object.fromEntries(keys.map((k) => [k, (process.env[k] ?? "").trim()]));
+  const missing = keys.filter((k) => !env[k]);
+  return { env, missing };
+}
+
+function cesResourceBase(env) {
+  return `projects/${env.CES_PROJECT_ID}/locations/${env.CES_LOCATION}/apps/${env.CES_APP_ID}`;
+}
+
+function buildRunSessionUrl(env, sessionId) {
+  return `https://ces.googleapis.com/v1beta/${cesResourceBase(env)}/sessions/${encodeURIComponent(sessionId)}:runSession`;
+}
+
+async function getGoogleAccessToken(serviceAccountJson) {
+  const parsed = JSON.parse(serviceAccountJson);
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      iss: parsed.client_email,
+      sub: parsed.client_email,
+      aud: "https://oauth2.googleapis.com/token",
+      iat: now,
+      exp: now + 3600,
+      scope: "https://www.googleapis.com/auth/cloud-platform",
+    }),
+  ).toString("base64url");
+  const signInput = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signInput);
+  signer.end();
+  const signature = signer.sign(parsed.private_key, "base64url");
+  const assertion = `${signInput}.${signature}`;
+
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+  if (!response.ok) throw new Error(`auth_${response.status}`);
+  const body = await response.json();
+  if (!body.access_token) throw new Error("auth_no_token");
+  return body.access_token;
+}
+
+async function callDirectCes(env, sessionId, message) {
+  const started = performance.now();
+  const token = await getGoogleAccessToken(env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  const base = cesResourceBase(env);
+  const response = await fetch(buildRunSessionUrl(env, sessionId), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      config: {
+        session: `${base}/sessions/${sessionId}`,
+        deployment: `${base}/deployments/${env.CES_DEPLOYMENT_ID}`,
+      },
+      inputs: [{ text: message }],
+    }),
+  });
+  const durationMs = Math.round(performance.now() - started);
+  let hasText = false;
+  if (response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const outputs = Array.isArray(payload.outputs) ? payload.outputs : [];
+    hasText = outputs.some((o) => typeof o?.text === "string" && o.text.trim());
+  }
+  return {
+    cesHttpStatus: response.status,
+    success: response.ok && hasText,
+    durationMs,
+    durationBucket: durationBucket(durationMs),
+  };
+}
+
+function summarize(results) {
+  const total = results.length;
+  const success = results.filter((r) => r.finalSuccess).length;
+  const upstream = results.filter((r) => r.finalErrorCode === "upstream").length;
+  const empty = results.filter((r) => r.finalErrorCode === "empty_response").length;
+  const retryHelped = results.filter((r) => r.retryUsed && r.finalSuccess).length;
+  const retryAttempted = results.filter((r) => r.retryUsed).length;
+  const buckets = {};
+  for (const r of results) {
+    buckets[r.durationBucket] = (buckets[r.durationBucket] ?? 0) + 1;
+  }
+  return {
+    total,
+    success,
+    error: total - success,
+    successRate: total ? Number(((success / total) * 100).toFixed(1)) : 0,
+    upstream502Proxy: upstream,
+    emptyResponse: empty,
+    retryAttempted,
+    retryHelped,
+    durationBuckets: buckets,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const sessionId = `viddel-rel-${Date.now().toString(36)}`;
+  const plan = buildPlan(args.count);
+  const results = [];
+
+  for (const item of plan) {
+    const requestSessionId = args.sessionPerRequest
+      ? `viddel-rel-${Date.now().toString(36)}-${item.n}`
+      : sessionId;
+    const proxy = args.noClientRetry
+      ? { ...(await callProxy(args.base, requestSessionId, item.message)), retryUsed: false, firstAttempt: null }
+      : await callWithClientRetry(args.base, requestSessionId, item.message);
+    const row = {
+      request: item.n,
+      inputType: item.inputType,
+      channel: "proxy",
+      httpStatus: proxy.httpStatus,
+      errorCode: proxy.errorCode,
+      finalSuccess: proxy.success,
+      finalErrorCode: proxy.success ? null : proxy.errorCode,
+      durationMs: proxy.durationMs,
+      durationBucket: proxy.durationBucket,
+      retryUsed: proxy.retryUsed,
+      firstAttempt: proxy.firstAttempt,
+    };
+
+    if (args.direct) {
+      const { env, missing } = readCesEnv();
+      if (missing.length === 0) {
+        try {
+          const direct = await callDirectCes(env, `${sessionId}-d${item.n}`, item.message);
+          row.direct = {
+            cesHttpStatus: direct.cesHttpStatus,
+            success: direct.success,
+            durationBucket: direct.durationBucket,
+          };
+        } catch (err) {
+          row.direct = { error: String(err.message ?? err).slice(0, 40) };
+        }
+      } else {
+        row.direct = { skipped: true, missingKeys: missing.length };
+      }
+    }
+
+    results.push(row);
+    process.stdout.write(
+      `#${row.request} ${row.inputType} ${row.finalSuccess ? "OK" : "ERR"} code=${row.finalErrorCode ?? "none"} retry=${row.retryUsed} ${row.durationBucket}\n`,
+    );
+    if (args.delayMs > 0) await new Promise((r) => setTimeout(r, args.delayMs));
+  }
+
+  const summary = summarize(results);
+  const cesEnv = readCesEnv();
+  const report = {
+    generatedAt: new Date().toISOString(),
+    base: args.base,
+    sessionIdPrefix: sessionId.slice(0, 16),
+    endpointFromCode: {
+      hostname: "ces.googleapis.com",
+      apiVersion: "v1beta",
+      pathPattern: "projects/{projectId}/locations/{location}/apps/{appId}/sessions/{sessionId}:runSession",
+      documentedEnv: {
+        projectId: "hearing-aid-mvp (.env.example)",
+        location: "eu",
+        appId: "1741e68d-0528-4625-8b83-99a0dbb5298f",
+        deploymentId: "edb2938a-a2bf-4555-b4c9-d54963531db4",
+      },
+      widgetDeploymentNote:
+        "BaseLayout widget uses dc1619d0-44a1-401b-92a6-1357c29274ea (Messenger) — separate from headless API deployment",
+    },
+    directEnvAvailable: cesEnv.missing.length === 0,
+    summary,
+    results,
+  };
+
+  const outPath =
+    args.out ||
+    join(__dirname, "..", "tmp", "chat-reliability", `run-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  console.log("\n--- summary ---");
+  console.log(JSON.stringify(summary, null, 2));
+  console.log(`\nWrote ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -77,7 +77,7 @@ export const mvpCurrentState = {
   } satisfies CurrentSprint,
   closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
-    "Hybrid AI monitoring v0.1 (#188) implementeres — drift via Upstash/Vercel og smale PostHog EU-events. Intern test Thomas/Vibeke før ekstern deling.",
+    "#188 landet teknisk — reliability hardening v0.1 for stabil /no/chat/. Ekstern pilot venter. PostHog fortsatt av.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -111,7 +111,7 @@ export const mvpCurrentState = {
       label: "Spør Viddel",
       route: "/no/chat/",
       status: "Applied",
-      note: "Production UI live. CES prod env aktiv. Upstash guard + Hybrid monitoring v0.1 (#188). Intern test Thomas/Vibeke.",
+      note: "Production UI live. Reliability hardening v0.1 (#188 remaining). Guard aktiv. Ekstern pilot venter.",
       visFrontpage: true,
       kind: "public",
       frontpageDescription: "Standalone headless AI — live i production (intern test). Guard aktiv.",

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -51,22 +51,22 @@ export const visRuntimeFeed = {
       area: "Data, monitoring og innsikt",
       why:
         "Vi må se om chatten virker, om den feiler, og hvilke innganger som brukes — uten å lagre spørsmål eller svar.",
-      status: "Implementert i PR #194. Venter privacy/logging QA før merge.",
-      possibleSolution: "Drift via Upstash nå. PostHog EU aktiveres senere med egen Vercel-nøkkel.",
-      nextDecision: "Merge driftsspor først. PostHog aktiveres senere med egen Vercel-nøkkel.",
+      status: "Landet teknisk (#194/#195). Reliability hardening v0.1 pågår — ekstern pilot venter på stabil chat.",
+      possibleSolution: "Drift via Upstash + script-basert driftcheck. PostHog EU aktiveres senere.",
+      nextDecision: "Merge reliability hardening. Ekstern pilot når chat >80% success over script-serie.",
       issue: "#188",
       issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
       progressSteps: [
-        { id: "implement", label: "Implementert", state: "done" },
-        { id: "qa", label: "Privacy/logging QA", state: "current" },
-        { id: "merge", label: "Merge", state: "upcoming" },
+        { id: "implement", label: "Monitoring levert", state: "done" },
+        { id: "reliability", label: "Reliability hardening", state: "current" },
+        { id: "pilot", label: "Ekstern pilot", state: "upcoming" },
       ],
     },
   ],
   recentlyCompletedSummary:
     "VIS Tree Navigation v0.1 (#192), IA Inventory v0.3.1 (#191) og Backstage v0.1 i production.",
   lastReturnTicketSummary:
-    "Privacy/logging QA er gjort i kode. Live Vercel logs og Upstash teller må fortsatt verifiseres.",
+    "Chat reliability hardening v0.1: server-side retry, CES timeout, safe metadata logging. Ekstern pilot venter.",
   links: {
     primary: [
       {

--- a/src/lib/ces-run-session.ts
+++ b/src/lib/ces-run-session.ts
@@ -3,6 +3,10 @@
 import { getGoogleAccessToken } from "./ces-auth";
 import { cesResourceBase, type CesEnvConfig } from "./ces-env";
 
+export const CES_FETCH_TIMEOUT_MS = 25_000;
+export const CES_RETRY_DELAY_MS = 600;
+export const CES_MAX_ATTEMPTS = 2;
+
 export type CesRunSessionInput = {
   message: string;
   sessionId: string;
@@ -12,7 +16,17 @@ export type CesRunSessionResult = {
   text: string;
   turnCompleted: boolean;
   turnIndex: number;
+  meta: CesRunSessionMeta;
 };
+
+export type CesRunSessionMeta = {
+  attemptCount: number;
+  retryUsed: boolean;
+  durationMs: number;
+  durationBucket: DurationBucket;
+};
+
+export type DurationBucket = "<1s" | "1-3s" | "3-8s" | "8-20s" | ">20s";
 
 type CesRunSessionApiOutput = {
   text?: string;
@@ -25,15 +39,41 @@ type CesRunSessionApiResponse = {
   outputs?: CesRunSessionApiOutput[];
 };
 
+export type CesErrorCode = "upstream" | "empty_response" | "auth" | "timeout";
+
+const RETRYABLE_CODES = new Set<CesErrorCode>(["upstream", "empty_response"]);
+
 export class CesRunSessionError extends Error {
+  upstreamHttpStatus: number | null = null;
+  attemptCount = 1;
+  retryUsed = false;
+  durationMs = 0;
+  durationBucket: DurationBucket = "<1s";
+
   constructor(
     message: string,
-    readonly code: "upstream" | "empty_response" | "auth",
+    readonly code: CesErrorCode,
     readonly status = 502,
+    upstreamHttpStatus?: number | null,
   ) {
     super(message);
     this.name = "CesRunSessionError";
+    if (upstreamHttpStatus !== undefined) {
+      this.upstreamHttpStatus = upstreamHttpStatus;
+    }
   }
+}
+
+export function durationBucket(ms: number): DurationBucket {
+  if (ms < 1000) return "<1s";
+  if (ms < 3000) return "1-3s";
+  if (ms < 8000) return "3-8s";
+  if (ms < 20000) return "8-20s";
+  return ">20s";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function buildRunSessionUrl(config: CesEnvConfig, sessionId: string): string {
@@ -49,14 +89,14 @@ function buildDeploymentResource(config: CesEnvConfig): string {
   return `${cesResourceBase(config)}/deployments/${config.deploymentId}`;
 }
 
-function normalizeOutput(outputs: CesRunSessionApiOutput[] | undefined): CesRunSessionResult {
+function normalizeOutput(outputs: CesRunSessionApiOutput[] | undefined): Omit<CesRunSessionResult, "meta"> {
   const candidate =
     outputs?.find((item) => typeof item.text === "string" && item.text.trim()) ??
     outputs?.find((item) => typeof item.text === "string");
 
   const text = candidate?.text?.trim() ?? "";
   if (!text) {
-    throw new CesRunSessionError("empty_agent_response", "empty_response", 502);
+    throw new CesRunSessionError("empty_agent_response", "empty_response", 502, 200);
   }
 
   return {
@@ -66,37 +106,118 @@ function normalizeOutput(outputs: CesRunSessionApiOutput[] | undefined): CesRunS
   };
 }
 
-/** Call CES runSession with server credentials. Never returns diagnosticInfo. */
+function attachAttemptMeta(
+  error: CesRunSessionError,
+  attemptCount: number,
+  retryUsed: boolean,
+  durationMs: number,
+): CesRunSessionError {
+  error.attemptCount = attemptCount;
+  error.retryUsed = retryUsed;
+  error.durationMs = durationMs;
+  error.durationBucket = durationBucket(durationMs);
+  return error;
+}
+
+async function runCesSessionOnce(
+  config: CesEnvConfig,
+  input: CesRunSessionInput,
+  accessToken: string,
+): Promise<Omit<CesRunSessionResult, "meta">> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), CES_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(buildRunSessionUrl(config, input.sessionId), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        config: {
+          session: buildSessionResource(config, input.sessionId),
+          deployment: buildDeploymentResource(config),
+        },
+        inputs: [{ text: input.message }],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new CesRunSessionError(`ces_upstream_${response.status}`, "upstream", 502, response.status);
+    }
+
+    const payload = (await response.json()) as CesRunSessionApiResponse;
+    const normalized = normalizeOutput(payload.outputs);
+    return {
+      text: normalized.text,
+      turnCompleted: normalized.turnCompleted,
+      turnIndex: normalized.turnIndex,
+    };
+  } catch (error) {
+    if (error instanceof CesRunSessionError) {
+      throw error;
+    }
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new CesRunSessionError("ces_fetch_timeout", "timeout", 504, null);
+    }
+    throw new CesRunSessionError("ces_network_error", "upstream", 502, null);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/** Call CES runSession with server credentials. Retries transient upstream/empty once. Never returns diagnosticInfo. */
 export async function runCesSession(
   config: CesEnvConfig,
   input: CesRunSessionInput,
 ): Promise<CesRunSessionResult> {
+  const started = performance.now();
+
   let accessToken: string;
   try {
     accessToken = await getGoogleAccessToken(config.serviceAccountJson);
   } catch {
-    throw new CesRunSessionError("google_auth_failed", "auth", 503);
+    const durationMs = Math.round(performance.now() - started);
+    throw attachAttemptMeta(
+      new CesRunSessionError("google_auth_failed", "auth", 503, null),
+      1,
+      false,
+      durationMs,
+    );
   }
 
-  const response = await fetch(buildRunSessionUrl(config, input.sessionId), {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json; charset=utf-8",
-    },
-    body: JSON.stringify({
-      config: {
-        session: buildSessionResource(config, input.sessionId),
-        deployment: buildDeploymentResource(config),
-      },
-      inputs: [{ text: input.message }],
-    }),
-  });
+  let lastError: CesRunSessionError | undefined;
+  let attemptsMade = 0;
 
-  if (!response.ok) {
-    throw new CesRunSessionError(`ces_upstream_${response.status}`, "upstream", 502);
+  for (let attempt = 1; attempt <= CES_MAX_ATTEMPTS; attempt += 1) {
+    attemptsMade = attempt;
+    try {
+      const result = await runCesSessionOnce(config, input, accessToken);
+      const durationMs = Math.round(performance.now() - started);
+      return {
+        ...result,
+        meta: {
+          attemptCount: attempt,
+          retryUsed: attempt > 1,
+          durationMs,
+          durationBucket: durationBucket(durationMs),
+        },
+      };
+    } catch (error) {
+      if (!(error instanceof CesRunSessionError)) {
+        throw error;
+      }
+      lastError = error;
+      const canRetry = attempt < CES_MAX_ATTEMPTS && RETRYABLE_CODES.has(error.code);
+      if (!canRetry) {
+        break;
+      }
+      await sleep(CES_RETRY_DELAY_MS);
+    }
   }
 
-  const payload = (await response.json()) as CesRunSessionApiResponse;
-  return normalizeOutput(payload.outputs);
+  const durationMs = Math.round(performance.now() - started);
+  throw attachAttemptMeta(lastError!, attemptsMade, attemptsMade > 1, durationMs);
 }

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -119,6 +119,13 @@ export const POST: APIRoute = async ({ request }) => {
   try {
     const result = await runCesSession(env.config, { message, sessionId });
     recordChatDriftSignal("success");
+    console.info("[api/chat] ces_run_session_ok", {
+      error_code: null,
+      upstream_http_status: null,
+      duration_bucket: result.meta.durationBucket,
+      retry_used: result.meta.retryUsed,
+      attempt_count: result.meta.attemptCount,
+    });
     return jsonResponse(
       {
         text: result.text,
@@ -130,9 +137,12 @@ export const POST: APIRoute = async ({ request }) => {
   } catch (error) {
     if (error instanceof CesRunSessionError) {
       console.error("[api/chat] ces_run_session_failed", {
-        code: error.code,
-        status: error.status,
-        sessionIdLength: sessionId.length,
+        error_code: error.code,
+        upstream_http_status: error.upstreamHttpStatus,
+        duration_bucket: error.durationBucket,
+        retry_used: error.retryUsed,
+        attempt_count: error.attemptCount,
+        session_id_length: sessionId.length,
       });
       recordChatDriftSignal("error", { error_code: error.code });
       return jsonResponse(

--- a/src/pages/no/chat.astro
+++ b/src/pages/no/chat.astro
@@ -311,9 +311,7 @@ const aiHeadingId = "viddel-standalone-chat-ai";
           window.viddelTrack("chat_question_sent", trackProps);
         }
 
-        const retryableErrors = new Set(["upstream", "empty_response"]);
-
-        const requestChat = async () => {
+        try {
           const response = await fetch("/api/chat", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -323,21 +321,9 @@ const aiHeadingId = "viddel-standalone-chat-ai";
             }),
           });
           const payload = await response.json().catch(() => ({}));
-          return { response, payload };
-        };
-
-        try {
-          let { response, payload } = await requestChat();
-          let errorCode = typeof payload?.error === "string" ? payload.error : "";
-
-          if (!response.ok && retryableErrors.has(errorCode)) {
-            await new Promise((resolve) => window.setTimeout(resolve, 600));
-            ({ response, payload } = await requestChat());
-            errorCode = typeof payload?.error === "string" ? payload.error : "";
-          }
 
           if (!response.ok) {
-            const trackedCode = errorCode || "unknown";
+            const trackedCode = typeof payload?.error === "string" ? payload.error : "unknown";
             if (typeof window.viddelTrack === "function") {
               if (trackedCode === "rate_limited") {
                 window.viddelTrack("chat_rate_limited", { entry_surface: entrySurface, error_code: trackedCode });


### PR DESCRIPTION
## Summary
- Flytter transient retry fra client til server-side CES (`upstream` / `empty_response`, max 2 forsøk, 600 ms)
- Ett brukerforsøk = ett `/api/chat`-kall mot rate limit (retry skjer internt i `runCesSession`)
- Legger til CES fetch timeout (25s AbortController) med `error_code: timeout` (HTTP 504)
- Safe diagnostic logging uten innhold: `upstream_http_status`, `error_code`, `duration_bucket`, `retry_used`, `attempt_count`
- Fjerner client auto-retry i `/no/chat/`
- Justerer `npm run chat:reliability` — default 8 kall / 8s spacing, kategoriserer ces_upstream vs rate_limit vs timeout vs app_error
- Oppdaterer VIS runtime feed + MVP state (#188 reliability remaining)

## Test plan
- [ ] `npm run build` ✅
- [ ] `/no/chat/` — ett send = ett nettverkskall ved feil (ikke to)
- [ ] Vercel logs: `[api/chat] ces_run_session_failed` med upstream_http_status
- [ ] `npm run chat:reliability` — ingen rate_limit i 8-kall serie
- [ ] Ingen prompt/svar i logger

## Scope
Ingen PostHog, ingen CES-env-endring, ingen rate limit-endring, ingen UI-redesign.

Related: #188, #196

Made with [Cursor](https://cursor.com)