### PR TITLE
Security / guard strategy v0.2 — ops reliability token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ GOOGLE_SERVICE_ACCOUNT_JSON=
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
+# Ops reliability testing (#188 guard v0.2) — server-only, NEVER PUBLIC_ prefix, never in frontend.
+# When set, requests with header x-viddel-ops-test-token matching this value bypass public IP rate limits.
+# Used by npm run chat:reliability only — not exposed to users.
+VIDDEL_OPS_TEST_TOKEN=
+
 # PostHog EU (#188) — optional public keys for client-side product events only.
 # No session replay, no user profiles, no message content.
 PUBLIC_POSTHOG_KEY=

--- a/scripts/chat-reliability-assessment.mjs
+++ b/scripts/chat-reliability-assessment.mjs
@@ -2,14 +2,15 @@
 /* CONTRACT: Safe chat reliability probe — metadata only, no prompt/answer logging. */
 
 import { createSign } from "node:crypto";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+const OPS_TEST_HEADER = "x-viddel-ops-test-token";
 const DEFAULT_BASE = "https://vox.raddum.no";
-/** Stay under production burst guard (10 / 10 min per IP). */
+/** Stay under production burst guard (10 / 10 min per IP) unless ops token is set. */
 const DEFAULT_COUNT = 8;
 const DEFAULT_DELAY_MS = 8_000;
 
@@ -40,6 +41,24 @@ const FREEFORM_PROMPTS = [
   "Hva gjør jeg hvis bare ett apparat kobler til?",
 ];
 
+function loadEnvFile(path) {
+  if (!existsSync(path)) return {};
+  const env = {};
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq);
+    let val = trimmed.slice(eq + 1);
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    env[key] = val;
+  }
+  return env;
+}
+
 function parseArgs(argv) {
   const args = {
     base: DEFAULT_BASE,
@@ -48,6 +67,7 @@ function parseArgs(argv) {
     direct: false,
     delayMs: DEFAULT_DELAY_MS,
     sessionPerRequest: true,
+    envFile: "",
   };
   for (const arg of argv) {
     if (arg.startsWith("--base=")) args.base = arg.slice(7).replace(/\/$/, "");
@@ -56,6 +76,7 @@ function parseArgs(argv) {
     else if (arg === "--direct") args.direct = true;
     else if (arg === "--shared-session") args.sessionPerRequest = false;
     else if (arg.startsWith("--delay-ms=")) args.delayMs = Number(arg.slice(11));
+    else if (arg.startsWith("--env-file=")) args.envFile = arg.slice(11);
   }
   return args;
 }
@@ -99,15 +120,19 @@ function buildPlan(count) {
   return plan;
 }
 
-async function callProxy(base, sessionId, message) {
+async function callProxy(base, sessionId, message, opsToken) {
   const started = performance.now();
+  const headers = {
+    "Content-Type": "application/json",
+    Origin: base,
+    Referer: `${base}/no/chat/`,
+  };
+  if (opsToken) {
+    headers[OPS_TEST_HEADER] = opsToken;
+  }
   const response = await fetch(`${base}/api/chat`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Origin: base,
-      Referer: `${base}/no/chat/`,
-    },
+    headers,
     body: JSON.stringify({ message, sessionId }),
   });
   const durationMs = Math.round(performance.now() - started);
@@ -216,7 +241,7 @@ async function callDirectCes(env, sessionId, message) {
   };
 }
 
-function summarize(results) {
+function summarize(results, opsConfig) {
   const total = results.length;
   const byCategory = {
     success: 0,
@@ -226,8 +251,15 @@ function summarize(results) {
     app_error: 0,
     other: 0,
   };
+  let beforeRateLimitTotal = 0;
+  let beforeRateLimitSuccess = 0;
   for (const row of results) {
     byCategory[row.category] = (byCategory[row.category] ?? 0) + 1;
+  }
+  for (const row of results) {
+    if (row.category === "rate_limit") break;
+    beforeRateLimitTotal += 1;
+    if (row.finalSuccess) beforeRateLimitSuccess += 1;
   }
   const buckets = {};
   for (const r of results) {
@@ -239,32 +271,52 @@ function summarize(results) {
     success,
     error: total - success,
     successRate: total ? Number(((success / total) * 100).toFixed(1)) : 0,
+    successBeforeRateLimit: beforeRateLimitSuccess,
+    callsBeforeRateLimit: beforeRateLimitTotal,
+    successRateBeforeRateLimit: beforeRateLimitTotal
+      ? Number(((beforeRateLimitSuccess / beforeRateLimitTotal) * 100).toFixed(1))
+      : 0,
     byCategory,
     durationBuckets: buckets,
-    guardNote:
-      "Default 8 calls / 8s spacing stays under 10-per-10min burst. One /api/chat per row (server retry is internal).",
+    opsMode: opsConfig,
+    retryUsedNote: "Server-side retry_used — see [chat-ops-drift] in Vercel logs when ops token active",
+    guardNote: opsConfig.publicGuardBypassed
+      ? "Ops token active — public burst/daily IP limits bypassed; one /api/chat per row."
+      : "No ops token — subject to public guard (10/10 min, 50/day per IP).",
   };
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+  const fileEnv = args.envFile ? loadEnvFile(args.envFile) : {};
+  const opsToken = (process.env.VIDDEL_OPS_TEST_TOKEN ?? fileEnv.VIDDEL_OPS_TEST_TOKEN ?? "").trim();
+  const opsConfig = {
+    tokenConfiguredLocally: Boolean(opsToken),
+    publicGuardBypassed: Boolean(opsToken),
+    header: OPS_TEST_HEADER,
+  };
+
   const sessionId = `viddel-rel-${Date.now().toString(36)}`;
   const plan = buildPlan(args.count);
   const results = [];
 
   console.log(
-    `chat-reliability: ${args.count} calls, ${args.delayMs}ms spacing, sessionPerRequest=${args.sessionPerRequest}`,
+    `chat-reliability: ${args.count} calls, ${args.delayMs}ms spacing, sessionPerRequest=${args.sessionPerRequest}, opsToken=${opsConfig.tokenConfiguredLocally ? "yes" : "no"}`,
   );
+  if (!opsConfig.tokenConfiguredLocally) {
+    console.log("WARN: VIDDEL_OPS_TEST_TOKEN not set — public IP rate limits apply.");
+  }
 
   for (const item of plan) {
     const requestSessionId = args.sessionPerRequest
       ? `viddel-rel-${Date.now().toString(36)}-${item.n}`
       : sessionId;
-    const proxy = await callProxy(args.base, requestSessionId, item.message);
+    const proxy = await callProxy(args.base, requestSessionId, item.message, opsToken || undefined);
     const row = {
       request: item.n,
       inputType: item.inputType,
       channel: "proxy",
+      opsTest: opsConfig.tokenConfiguredLocally,
       httpStatus: proxy.httpStatus,
       errorCode: proxy.errorCode,
       category: proxy.category,
@@ -301,7 +353,7 @@ async function main() {
     }
   }
 
-  const summary = summarize(results);
+  const summary = summarize(results, opsConfig);
   const cesEnv = readCesEnv();
   const report = {
     generatedAt: new Date().toISOString(),
@@ -310,6 +362,7 @@ async function main() {
       count: args.count,
       delayMs: args.delayMs,
       sessionPerRequest: args.sessionPerRequest,
+      opsTest: opsConfig,
     },
     sessionIdPrefix: sessionId.slice(0, 16),
     directEnvAvailable: cesEnv.missing.length === 0,

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -3,7 +3,7 @@
 export const backstageMeta = {
   title: "Backstage",
   lead: "Backstage er kontrollrommet for hvordan Viddel fungerer bak scenen. Her forklarer vi AI-flyten, beskyttelsen, feilstater og hva som må sjekkes før vi deler med flere.",
-  updatedAt: "2026-05-30",
+  updatedAt: "2026-05-29",
   issue: "#184",
 } as const;
 
@@ -20,7 +20,8 @@ export const quickAnswers = [
   },
   {
     question: "Hva beskytter oss?",
-    answer: "Grenser på lengde og antall spørsmål, pluss sjekk av hvor forespørselen kommer fra. Mangler beskyttelsen i production, stenger Viddel trygt.",
+    answer:
+      "Public guard: grenser på lengde og antall spørsmål per IP, pluss sjekk av hvor forespørselen kommer fra. Separat ops-testmodus (hemmelig token) brukes kun internt for stabilitetstest — uten innholdslogging.",
   },
   {
     question: "Hva gjør vi når noe ikke virker?",
@@ -72,7 +73,8 @@ export const systemMapLayers: SystemMapLayer[] = [
     id: "guard",
     layer: "Beskyttelse",
     title: "Guard + Upstash",
-    human: "Viddel sjekker at spørsmålet er lovlig og innenfor grensen. Upstash teller bruk.",
+    human:
+      "Public guard beskytter brukere og kost — rate limit og origin-sjekk. Ops-test (hemmelig server-token) omgår kun IP-grenser for intern stabilitetstest.",
   },
   {
     id: "ai",
@@ -163,6 +165,22 @@ export const protectionRules = [
     tech: "guard_unavailable",
   },
 ] as const;
+
+/** Guard strategy v0.2 — public guard vs intern ops reliability testing. */
+export const guardStrategyExplainer = {
+  title: "Guard strategy v0.2",
+  lead: "To lag: public guard for ekte brukere, ops-test for intern stabilitet — uten å svekke offentlig sikkerhet.",
+  publicGuard: {
+    label: "Public guard (#180)",
+    human:
+      "Aktiv for alle uten gyldig ops-token. Origin-sjekk, maks meldingslengde, 10 / 10 min og 50 / døgn per IP. Fail closed hvis Upstash mangler i production.",
+  },
+  opsTest: {
+    label: "Ops reliability testing",
+    human:
+      "Kun script/ops med header x-viddel-ops-test-token og VIDDEL_OPS_TEST_TOKEN i Vercel. Omgår burst/daily IP-rate-limit — beholder validering, timeout, safe errors og ingen prompt/svar-logging. Token eksponeres aldri i frontend.",
+  },
+} as const;
 
 export const upstashExplainer = {
   title: "Hva betyr Upstash?",
@@ -444,6 +462,23 @@ export const firstCheckRules = [
 /** Runbooks — hvordan vi endrer operative verdier senere. */
 export const changeRunbooks: ChangeRunbook[] = [
   {
+    id: "ops-reliability",
+    title: "Ops reliability test-token",
+    whatChanges:
+      "Aktivere eller rotere hemmelig token for intern stabilitetstest — omgår kun public IP-rate-limit, ikke andre guard-regler.",
+    where:
+      "Vercel → Environment Variables: VIDDEL_OPS_TEST_TOKEN (Production, server-only). Script: scripts/chat-reliability-assessment.mjs.",
+    whereToGo:
+      "Vercel → Settings → Environment Variables. Generer sterk tilfeldig token lokalt — aldri i repo eller frontend. Redeploy Production.",
+    after:
+      "Redeploy. Kjør npm run chat:reliability med token i lokalt env — bekreft publicGuardBypassed: yes og at CES-signal kommer uten 429 fra IP-grense.",
+    test:
+      "Uten header: vanlig public guard. Feil token: ingen bypass. Riktig token fra script: reliability-serie uten rate_limit fra IP-grense.",
+    actionLinks: [backstageLinks.vercelEnv, backstageLinks.vercelDeployments, backstageLinks.guardFile],
+    envVars: ["VIDDEL_OPS_TEST_TOKEN"],
+    tech: "src/lib/chat-ops-test.ts · aldri PUBLIC_ prefix · aldri i klientkode",
+  },
+  {
     id: "rate-limits",
     title: "Endre rate limits",
     whatChanges: "Hvor mange spørsmål som tillates — per 10 minutter og per døgn (per IP).",
@@ -634,7 +669,7 @@ export const monitoringExplainer = {
       id: "drift",
       label: "Drift (Vercel + Upstash)",
       human:
-        "Server-side tellere på /api/chat: forespørsel, suksess, feil, rate limit, for lang melding, guard utilgjengelig og manglende konfigurasjon. Vercel Runtime Logs viser strukturerte [chat-drift]-linjer.",
+        "Server-side tellere på /api/chat: forespørsel, suksess, feil, rate limit, for lang melding, guard utilgjengelig og manglende konfigurasjon. Vercel Runtime Logs viser strukturerte [chat-drift]-linjer. Ops-test logges separat som [chat-ops-drift] (ops_test: true) — uten innhold, sessionId eller IP.",
       where: "Upstash Redis (dagsnøkler) + Vercel → Deployments → Runtime Logs",
     },
     {
@@ -656,6 +691,7 @@ export const monitoringExplainer = {
 export const monitoringLogged = [
   "Antall /api/chat-forespørsler per dag",
   "Utfall: suksess, feil, rate_limited, message_too_long, guard_unavailable, configuration_missing",
+  "Ops-test: [chat-ops-drift] med signal, error_code, upstream_http_status, duration_bucket, retry_used, attempt_count, ops_test: true",
   "PostHog: chat_opened, ai_entry_clicked, article_ai_seed_clicked, chat_question_sent, chat_answer_success/error",
   "Feilkoder (error_code) — aldri meldingstekst",
   "Route, entry_surface, article_slug, seed_id (hash — ikke spørsmålstekst)",
@@ -683,13 +719,14 @@ export const monitoringEvents = [
 
 export type EnvVarEntry = {
   name: string;
-  group: "upstash" | "ces" | "auth" | "posthog";
+  group: "upstash" | "ces" | "auth" | "posthog" | "ops";
   controls: string;
 };
 
 export const envVars: EnvVarEntry[] = [
   { name: "UPSTASH_REDIS_REST_URL", group: "upstash", controls: "Teller-endpoint." },
   { name: "UPSTASH_REDIS_REST_TOKEN", group: "upstash", controls: "Teller-autentisering." },
+  { name: "VIDDEL_OPS_TEST_TOKEN", group: "ops", controls: "Hemmelig ops reliability test — bypass public IP-rate-limit kun for script med riktig header. Aldri frontend." },
   { name: "CES_PROJECT_ID", group: "ces", controls: "CES prosjekt." },
   { name: "CES_LOCATION", group: "ces", controls: "CES region." },
   { name: "CES_APP_ID", group: "ces", controls: "Viddel-app i CES." },
@@ -709,6 +746,7 @@ export const envVarNotes = [
 export const sourceFiles = [
   "src/pages/api/chat.ts",
   "src/lib/chat-api-guard.ts",
+  "src/lib/chat-ops-test.ts",
   "src/lib/chat-usage-metrics.ts",
   "src/lib/viddel-analytics-events.ts",
   "src/components/analytics/ViddelAnalytics.astro",

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -77,7 +77,7 @@ export const mvpCurrentState = {
   } satisfies CurrentSprint,
   closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
-    "#188 landet teknisk — reliability hardening v0.1 for stabil /no/chat/. Ekstern pilot venter. PostHog fortsatt av.",
+    "#188 åpen — guard strategy v0.2 for ops reliability-test uten å svekke public guard. Ekstern pilot venter. PostHog fortsatt av.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -111,10 +111,10 @@ export const mvpCurrentState = {
       label: "Spør Viddel",
       route: "/no/chat/",
       status: "Applied",
-      note: "Production UI live. Reliability hardening v0.1 (#188 remaining). Guard aktiv. Ekstern pilot venter.",
+      note: "Production UI live. Guard strategy v0.2 (#188). Public guard aktiv. Ops reliability-test separat.",
       visFrontpage: true,
       kind: "public",
-      frontpageDescription: "Standalone headless AI — live i production (intern test). Guard aktiv.",
+      frontpageDescription: "Standalone headless AI — live i production (intern test). Public guard aktiv.",
     },
     {
       id: "designsystem",

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -66,7 +66,7 @@ export type ClosedSprint = {
 };
 
 export const mvpCurrentState = {
-  updatedAt: "2026-05-30",
+  updatedAt: "2026-05-29",
   currentSprint: {
     id: "2026-w21",
     label: "2026-W21",
@@ -77,7 +77,7 @@ export const mvpCurrentState = {
   } satisfies CurrentSprint,
   closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
-    "#188 åpen — guard strategy v0.2 for ops reliability-test uten å svekke public guard. Ekstern pilot venter. PostHog fortsatt av.",
+    "Monitoring levert (#188). Vi feilsøker chat-stabilitet — public guard står, ops-test gir ren CES-måling. Fallback ved behov.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -111,10 +111,10 @@ export const mvpCurrentState = {
       label: "Spør Viddel",
       route: "/no/chat/",
       status: "Applied",
-      note: "Production UI live. Guard strategy v0.2 (#188). Public guard aktiv. Ops reliability-test separat.",
+      note: "Live i production. Public guard beskytter brukere; intern ops-test måler CES-stabilitet separat (#188).",
       visFrontpage: true,
       kind: "public",
-      frontpageDescription: "Standalone headless AI — live i production (intern test). Public guard aktiv.",
+      frontpageDescription: "Headless AI-chat — live (intern test). Public guard aktiv.",
     },
     {
       id: "designsystem",

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -41,33 +41,36 @@ export type VisRuntimeFeed = {
 
 /** Manually updated after important Return Tickets — not synced from GitHub. */
 export const visRuntimeFeed = {
-  updatedAt: "2026-06-01",
+  updatedAt: "2026-05-29",
   activeNow: [
     {
       id: "ai-usage-monitoring-v01",
       headline:
-        "Vi legger inn trygg måling av AI-chatten før vi deler Viddel med flere.",
+        "Vi skiller brukerbeskyttelse fra intern stabilitetstest av AI-chatten.",
       workTitle: "AI usage monitoring v0.1 (#188)",
       area: "Data, monitoring og innsikt",
       why:
         "Vi må se om chatten virker, om den feiler, og hvilke innganger som brukes — uten å lagre spørsmål eller svar.",
-      status: "Landet teknisk (#194/#195/#197). Guard strategy v0.2 pågår — reliability testing blokkert av public guard er identifisert.",
-      possibleSolution: "Todelt guard: public guard + ops token for intern stabilitetstest. PostHog EU aktiveres senere.",
-      nextDecision: "Merge guard strategy v0.2. Ops-basert reliability-test for gyldig CES-signal. Ekstern pilot når chat >80% success.",
+      status:
+        "Monitoring er levert. Nå justerer vi guard-strategien slik at Cursor kan teste CES-stabilitet uten å bli stoppet av vanlig public rate limit.",
+      possibleSolution:
+        "Public guard står fast. Ops-test får hemmelig server-token for måling.",
+      nextDecision:
+        "Kjør ren ops-test. Hvis CES fortsatt er ustabil, start fallback-spike.",
       issue: "#188",
       issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
       progressSteps: [
-        { id: "implement", label: "Monitoring levert", state: "done" },
-        { id: "reliability", label: "Reliability hardening", state: "done" },
+        { id: "monitoring", label: "Monitoring levert", state: "done" },
         { id: "guard-v02", label: "Guard strategy v0.2", state: "current" },
-        { id: "pilot", label: "Ekstern pilot", state: "upcoming" },
+        { id: "ces-test", label: "Ren CES-test", state: "upcoming" },
+        { id: "fallback", label: "Fallback ved behov", state: "upcoming" },
       ],
     },
   ],
   recentlyCompletedSummary:
     "VIS Tree Navigation v0.1 (#192), IA Inventory v0.3.1 (#191) og Backstage v0.1 i production.",
   lastReturnTicketSummary:
-    "Guard strategy v0.2: ops token bypasser kun public IP-rate-limit for intern reliability-test. Public guard uendret.",
+    "VIS-språk oppdatert: vi feilsøker chat-stabilitet og skiller public guard fra intern ops-test (#199).",
   links: {
     primary: [
       {
@@ -76,8 +79,8 @@ export const visRuntimeFeed = {
         kind: "issue",
       },
       {
-        label: "PR #194",
-        href: "https://github.com/THUNDERPLUNDER/vox-web/pull/194",
+        label: "PR #199",
+        href: "https://github.com/THUNDERPLUNDER/vox-web/pull/199",
         kind: "issue",
       },
     ],

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -51,14 +51,15 @@ export const visRuntimeFeed = {
       area: "Data, monitoring og innsikt",
       why:
         "Vi må se om chatten virker, om den feiler, og hvilke innganger som brukes — uten å lagre spørsmål eller svar.",
-      status: "Landet teknisk (#194/#195). Reliability hardening v0.1 pågår — ekstern pilot venter på stabil chat.",
-      possibleSolution: "Drift via Upstash + script-basert driftcheck. PostHog EU aktiveres senere.",
-      nextDecision: "Merge reliability hardening. Ekstern pilot når chat >80% success over script-serie.",
+      status: "Landet teknisk (#194/#195/#197). Guard strategy v0.2 pågår — reliability testing blokkert av public guard er identifisert.",
+      possibleSolution: "Todelt guard: public guard + ops token for intern stabilitetstest. PostHog EU aktiveres senere.",
+      nextDecision: "Merge guard strategy v0.2. Ops-basert reliability-test for gyldig CES-signal. Ekstern pilot når chat >80% success.",
       issue: "#188",
       issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
       progressSteps: [
         { id: "implement", label: "Monitoring levert", state: "done" },
-        { id: "reliability", label: "Reliability hardening", state: "current" },
+        { id: "reliability", label: "Reliability hardening", state: "done" },
+        { id: "guard-v02", label: "Guard strategy v0.2", state: "current" },
         { id: "pilot", label: "Ekstern pilot", state: "upcoming" },
       ],
     },
@@ -66,7 +67,7 @@ export const visRuntimeFeed = {
   recentlyCompletedSummary:
     "VIS Tree Navigation v0.1 (#192), IA Inventory v0.3.1 (#191) og Backstage v0.1 i production.",
   lastReturnTicketSummary:
-    "Chat reliability hardening v0.1: server-side retry, CES timeout, safe metadata logging. Ekstern pilot venter.",
+    "Guard strategy v0.2: ops token bypasser kun public IP-rate-limit for intern reliability-test. Public guard uendret.",
   links: {
     primary: [
       {

--- a/src/lib/backstage-guard.ts
+++ b/src/lib/backstage-guard.ts
@@ -33,6 +33,7 @@ const REQUIRED_ERROR_CODES = [
 ] as const;
 
 const REQUIRED_RUNBOOK_IDS = [
+  "ops-reliability",
   "rate-limits",
   "max-length",
   "upstash",

--- a/src/lib/chat-api-guard.ts
+++ b/src/lib/chat-api-guard.ts
@@ -2,6 +2,7 @@
 
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
+import { isOpsReliabilityRequest } from "./chat-ops-test.ts";
 
 export const CHAT_MAX_MESSAGE_LENGTH = 2000;
 
@@ -120,11 +121,15 @@ function getRateLimiters(): RateLimitState | null {
 }
 
 export type RateLimitCheckResult =
-  | { ok: true; skipped?: boolean }
+  | { ok: true; skipped?: boolean; opsBypass?: boolean }
   | { ok: false; status: 429 | 503; error: string; message: string };
 
-/** Fail closed in production when Upstash env is missing. */
+/** Fail closed in production when Upstash env is missing. Ops reliability token bypasses burst/daily only. */
 export async function checkChatRateLimit(request: Request): Promise<RateLimitCheckResult> {
+  if (isOpsReliabilityRequest(request)) {
+    return { ok: true, skipped: true, opsBypass: true };
+  }
+
   const limiters = getRateLimiters();
   if (!limiters) {
     if (isChatGuardProduction()) {

--- a/src/lib/chat-ops-test.ts
+++ b/src/lib/chat-ops-test.ts
@@ -1,0 +1,26 @@
+/* CONTRACT: Ops-only reliability test gate for /api/chat — bypasses public IP rate limits, never exposed to client. */
+
+import { timingSafeEqual } from "node:crypto";
+
+export const OPS_TEST_HEADER = "x-viddel-ops-test-token";
+
+function readEnv(name: string): string {
+  return (process.env[name] ?? import.meta.env[name] ?? "").trim();
+}
+
+function tokensMatch(provided: string, expected: string): boolean {
+  if (!provided || !expected) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** True when server token is configured and request header matches exactly. */
+export function isOpsReliabilityRequest(request: Request): boolean {
+  const expected = readEnv("VIDDEL_OPS_TEST_TOKEN");
+  if (!expected) return false;
+  const provided = request.headers.get(OPS_TEST_HEADER)?.trim() ?? "";
+  if (!provided) return false;
+  return tokensMatch(provided, expected);
+}

--- a/src/lib/chat-usage-metrics.ts
+++ b/src/lib/chat-usage-metrics.ts
@@ -66,6 +66,42 @@ export function recordChatDriftSignal(signal: ChatDriftSignal, meta?: { error_co
   }
 }
 
+export type ChatOpsDriftMeta = {
+  error_code?: string | null;
+  upstream_http_status?: number | null;
+  duration_bucket?: string | null;
+  retry_used?: boolean;
+  attempt_count?: number;
+};
+
+/** Ops reliability tests — separate log stream and counters; never logs content, sessionId or IP. */
+export function recordChatOpsDriftSignal(signal: ChatDriftSignal, meta?: ChatOpsDriftMeta): void {
+  try {
+    console.info("[chat-ops-drift]", {
+      signal,
+      ops_test: true,
+      error_code: meta?.error_code ?? null,
+      upstream_http_status: meta?.upstream_http_status ?? null,
+      duration_bucket: meta?.duration_bucket ?? null,
+      retry_used: meta?.retry_used ?? false,
+      attempt_count: meta?.attempt_count ?? 1,
+    });
+
+    const redis = getMetricsRedis();
+    if (!redis) return;
+
+    const key = `viddel:chat:ops-drift:${signal}:${dayKey()}`;
+    void redis
+      .incr(key)
+      .then(() => redis.expire(key, 60 * 60 * 24 * 45))
+      .catch(() => {
+        console.error("[chat-ops-drift] metrics_incr_failed", { signal });
+      });
+  } catch {
+    console.error("[chat-ops-drift] metrics_record_failed", { signal });
+  }
+}
+
 /** Test helper — reset cached redis client between tests. */
 export function resetChatMetricsRedisForTests(): void {
   redisClient = undefined;

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -6,9 +6,11 @@ import {
   checkChatOrigin,
   checkChatRateLimit,
 } from "../../lib/chat-api-guard";
+import { isOpsReliabilityRequest } from "../../lib/chat-ops-test";
 import {
   mapApiErrorToDriftSignal,
   recordChatDriftSignal,
+  recordChatOpsDriftSignal,
   type ChatDriftSignal,
 } from "../../lib/chat-usage-metrics";
 import { resolveCesEnv } from "../../lib/ces-env";
@@ -30,24 +32,52 @@ function jsonResponse(body: Record<string, unknown>, status: number): Response {
   });
 }
 
+function trackDrift(
+  opsTest: boolean,
+  signal: ChatDriftSignal,
+  meta?: {
+    error_code?: string;
+    upstream_http_status?: number | null;
+    duration_bucket?: string | null;
+    retry_used?: boolean;
+    attempt_count?: number;
+  },
+): void {
+  if (opsTest) {
+    recordChatOpsDriftSignal(signal, {
+      error_code: meta?.error_code ?? null,
+      upstream_http_status: meta?.upstream_http_status ?? null,
+      duration_bucket: meta?.duration_bucket ?? null,
+      retry_used: meta?.retry_used ?? false,
+      attempt_count: meta?.attempt_count ?? 1,
+    });
+    return;
+  }
+  recordChatDriftSignal(signal, meta?.error_code ? { error_code: meta.error_code } : undefined);
+}
+
 function respond(
+  opsTest: boolean,
   body: Record<string, unknown>,
   status: number,
   signal?: ChatDriftSignal,
   errorCode?: string,
 ): Response {
   if (signal) {
-    recordChatDriftSignal(signal, errorCode ? { error_code: errorCode } : undefined);
+    trackDrift(opsTest, signal, errorCode ? { error_code: errorCode } : undefined);
   }
   return jsonResponse(body, status);
 }
 
 export const POST: APIRoute = async ({ request }) => {
+  const opsTest = isOpsReliabilityRequest(request);
+
   let body: ChatRequestBody;
   try {
     body = (await request.json()) as ChatRequestBody;
   } catch {
     return respond(
+      opsTest,
       { error: "invalid_json", message: CHAT_GUARD_MESSAGES.invalidRequest },
       400,
       "error",
@@ -60,6 +90,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   if (!message) {
     return respond(
+      opsTest,
       { error: "invalid_message", message: "Skriv et spørsmål før du sender." },
       400,
       "error",
@@ -69,6 +100,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   if (message.length > CHAT_MAX_MESSAGE_LENGTH) {
     return respond(
+      opsTest,
       { error: "message_too_long", message: CHAT_GUARD_MESSAGES.messageTooLong },
       400,
       "message_too_long",
@@ -78,6 +110,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   if (!sessionId || !SESSION_ID_PATTERN.test(sessionId)) {
     return respond(
+      opsTest,
       { error: "invalid_session", message: CHAT_GUARD_MESSAGES.invalidRequest },
       400,
       "error",
@@ -88,6 +121,7 @@ export const POST: APIRoute = async ({ request }) => {
   const originCheck = checkChatOrigin(request);
   if (!originCheck.ok) {
     return respond(
+      opsTest,
       { error: "forbidden_origin", message: originCheck.message },
       403,
       "error",
@@ -98,14 +132,21 @@ export const POST: APIRoute = async ({ request }) => {
   const rateLimit = await checkChatRateLimit(request);
   if (!rateLimit.ok) {
     const signal = mapApiErrorToDriftSignal(rateLimit.error);
-    return respond({ error: rateLimit.error, message: rateLimit.message }, rateLimit.status, signal, rateLimit.error);
+    return respond(
+      opsTest,
+      { error: rateLimit.error, message: rateLimit.message },
+      rateLimit.status,
+      signal,
+      rateLimit.error,
+    );
   }
 
-  recordChatDriftSignal("request");
+  trackDrift(opsTest, "request");
 
   const env = resolveCesEnv();
   if (!env.ok) {
     return respond(
+      opsTest,
       {
         error: "configuration_missing",
         message: "Viddel er ikke tilgjengelig akkurat nå.",
@@ -118,14 +159,20 @@ export const POST: APIRoute = async ({ request }) => {
 
   try {
     const result = await runCesSession(env.config, { message, sessionId });
-    recordChatDriftSignal("success");
-    console.info("[api/chat] ces_run_session_ok", {
-      error_code: null,
-      upstream_http_status: null,
+    trackDrift(opsTest, "success", {
       duration_bucket: result.meta.durationBucket,
       retry_used: result.meta.retryUsed,
       attempt_count: result.meta.attemptCount,
     });
+    if (!opsTest) {
+      console.info("[api/chat] ces_run_session_ok", {
+        error_code: null,
+        upstream_http_status: null,
+        duration_bucket: result.meta.durationBucket,
+        retry_used: result.meta.retryUsed,
+        attempt_count: result.meta.attemptCount,
+      });
+    }
     return jsonResponse(
       {
         text: result.text,
@@ -136,15 +183,23 @@ export const POST: APIRoute = async ({ request }) => {
     );
   } catch (error) {
     if (error instanceof CesRunSessionError) {
-      console.error("[api/chat] ces_run_session_failed", {
+      trackDrift(opsTest, "error", {
         error_code: error.code,
         upstream_http_status: error.upstreamHttpStatus,
         duration_bucket: error.durationBucket,
         retry_used: error.retryUsed,
         attempt_count: error.attemptCount,
-        session_id_length: sessionId.length,
       });
-      recordChatDriftSignal("error", { error_code: error.code });
+      if (!opsTest) {
+        console.error("[api/chat] ces_run_session_failed", {
+          error_code: error.code,
+          upstream_http_status: error.upstreamHttpStatus,
+          duration_bucket: error.durationBucket,
+          retry_used: error.retryUsed,
+          attempt_count: error.attemptCount,
+          session_id_length: sessionId.length,
+        });
+      }
       return jsonResponse(
         {
           error: error.code,
@@ -158,6 +213,12 @@ export const POST: APIRoute = async ({ request }) => {
     }
 
     console.error("[api/chat] unexpected_error");
-    return respond({ error: "internal_error", message: CHAT_GUARD_MESSAGES.invalidRequest }, 500, "error", "internal_error");
+    return respond(
+      opsTest,
+      { error: "internal_error", message: CHAT_GUARD_MESSAGES.invalidRequest },
+      500,
+      "error",
+      "internal_error",
+    );
   }
 };

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -9,6 +9,7 @@ import {
   envVarNotes,
   envVars,
   productionChecklist,
+  guardStrategyExplainer,
   protectionRules,
   quickAnswers,
   sourceFiles,
@@ -32,6 +33,7 @@ const envGroups = [
   { id: "upstash", label: "Upstash (teller + drift)" },
   { id: "ces", label: "CES (AI-motor)" },
   { id: "auth", label: "Google auth" },
+  { id: "ops", label: "Ops reliability (intern test)" },
   { id: "posthog", label: "PostHog EU (produktinnsikt)" },
 ] as const;
 
@@ -138,6 +140,21 @@ const layerTone: Record<string, string> = {
           </li>
         ))}
       </ul>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-guard-strategy">
+      <h2 id="bs-guard-strategy" class="bs__section-title">{guardStrategyExplainer.title}</h2>
+      <p class="bs__section-lead">{guardStrategyExplainer.lead}</p>
+      <div class="bs__quick-grid">
+        <article class="bs__quick-card">
+          <h3 class="bs__quick-q">{guardStrategyExplainer.publicGuard.label}</h3>
+          <p class="bs__quick-a">{guardStrategyExplainer.publicGuard.human}</p>
+        </article>
+        <article class="bs__quick-card">
+          <h3 class="bs__quick-q">{guardStrategyExplainer.opsTest.label}</h3>
+          <p class="bs__quick-a">{guardStrategyExplainer.opsTest.human}</p>
+        </article>
+      </div>
     </section>
 
     <section class="bs__explainers">


### PR DESCRIPTION
## Summary
- Split public guard (#180) from intern ops reliability testing via server-only `VIDDEL_OPS_TEST_TOKEN` and header `x-viddel-ops-test-token`.
- Ops requests bypass public IP burst/daily rate limits only; validation, max length, origin check, CES timeout, safe errors and no content logging remain unchanged.
- Separate `[chat-ops-drift]` metrics stream with `ops_test: true` and safe metadata fields.
- Reliability script sends ops header when token is set locally and reports `publicGuardBypassed` + success before rate limit.
- Backstage/VIS updated with guard strategy v0.2 explainer.

## Test plan
- [ ] Vanlig bruker uten token: public guard uendret (10/10 min, 50/dag)
- [ ] Feil/manglende token: ingen bypass
- [ ] Sett `VIDDEL_OPS_TEST_TOKEN` i Vercel Production (server-only), redeploy
- [ ] `VIDDEL_OPS_TEST_TOKEN=... npm run chat:reliability` → `publicGuardBypassed: yes`, ren CES-måling
- [ ] Bekreft ingen prompt/svar i Vercel logs — kun `[chat-ops-drift]` metadata
- [ ] `npm run build` grønn

## After merge
Thomas setter `VIDDEL_OPS_TEST_TOKEN` i Vercel Production og kjører ops-basert reliability-test for gyldig CES-signal (#188).


Made with [Cursor](https://cursor.com)