### PR TITLE
Guard limits via Vercel env v0.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ GOOGLE_SERVICE_ACCOUNT_JSON=
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
+# Public guard rate limits (#180) — optional; positive integers only. Defaults: 10 burst / 10 min, 50 daily / 24h.
+# Pre-pilot reliability test (temporary): e.g. 100 and 500 — redeploy after change, restore after test.
+VIDDEL_CHAT_BURST_LIMIT=
+VIDDEL_CHAT_DAILY_LIMIT=
+
 # Ops reliability testing (#188 guard v0.2) — server-only, NEVER PUBLIC_ prefix, never in frontend.
 # When set, requests with header x-viddel-ops-test-token matching this value bypass public IP rate limits.
 # Used by npm run chat:reliability only — not exposed to users.

--- a/scripts/chat-reliability-assessment.mjs
+++ b/scripts/chat-reliability-assessment.mjs
@@ -10,9 +10,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const OPS_TEST_HEADER = "x-viddel-ops-test-token";
 const DEFAULT_BASE = "https://vox.raddum.no";
-/** Stay under production burst guard (10 / 10 min per IP) unless ops token is set. */
+/** Default spacing — production limits are server-side (VIDDEL_CHAT_* in Vercel). */
 const DEFAULT_COUNT = 8;
 const DEFAULT_DELAY_MS = 8_000;
+const DEFAULT_BURST_LIMIT = 10;
+const DEFAULT_DAILY_LIMIT = 50;
 
 /** Fixed prompts — used internally only; never written to output. */
 const SEED_PROMPTS = [
@@ -79,6 +81,35 @@ function parseArgs(argv) {
     else if (arg.startsWith("--env-file=")) args.envFile = arg.slice(11);
   }
   return args;
+}
+
+function parsePositiveInt(raw, fallback) {
+  const trimmed = String(raw ?? "").trim();
+  if (!trimmed) return fallback;
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return n;
+}
+
+/** Server limits live in Vercel — script only reports defaults + optional local hints. */
+function buildPublicLimitContext(fileEnv) {
+  const burstRaw = process.env.VIDDEL_CHAT_BURST_LIMIT ?? fileEnv.VIDDEL_CHAT_BURST_LIMIT ?? "";
+  const dailyRaw = process.env.VIDDEL_CHAT_DAILY_LIMIT ?? fileEnv.VIDDEL_CHAT_DAILY_LIMIT ?? "";
+  const burstLimit = parsePositiveInt(burstRaw, DEFAULT_BURST_LIMIT);
+  const dailyLimit = parsePositiveInt(dailyRaw, DEFAULT_DAILY_LIMIT);
+  return {
+    serverControlled: true,
+    envVars: ["VIDDEL_CHAT_BURST_LIMIT", "VIDDEL_CHAT_DAILY_LIMIT"],
+    defaults: { burst: DEFAULT_BURST_LIMIT, daily: DEFAULT_DAILY_LIMIT, burstWindow: "10 m", dailyWindow: "24 h" },
+    localHints: {
+      burstConfigured: Boolean(String(burstRaw).trim()),
+      dailyConfigured: Boolean(String(dailyRaw).trim()),
+      burstLimit,
+      dailyLimit,
+    },
+    prePilotSuggestion: "Set 100 / 500 in Vercel Production, redeploy, then run this script.",
+    note: "Production limits apply on server after redeploy — local env hints do not change production.",
+  };
 }
 
 function durationBucket(ms) {
@@ -241,7 +272,7 @@ async function callDirectCes(env, sessionId, message) {
   };
 }
 
-function summarize(results, opsConfig) {
+function summarize(results, opsConfig, publicLimitContext) {
   const total = results.length;
   const byCategory = {
     success: 0,
@@ -279,10 +310,11 @@ function summarize(results, opsConfig) {
     byCategory,
     durationBuckets: buckets,
     opsMode: opsConfig,
-    retryUsedNote: "Server-side retry_used — see [chat-ops-drift] in Vercel logs when ops token active",
+    publicLimitContext,
+    retryUsedNote: "Server-side retry_used — see [chat-drift] in Vercel Runtime Logs",
     guardNote: opsConfig.publicGuardBypassed
-      ? "Ops token active — public burst/daily IP limits bypassed; one /api/chat per row."
-      : "No ops token — subject to public guard (10/10 min, 50/day per IP).",
+      ? "Ops token bypassed public IP limits (optional path — not required for pre-pilot test)."
+      : `Public guard active — server limits from Vercel env (default ${DEFAULT_BURST_LIMIT}/10m, ${DEFAULT_DAILY_LIMIT}/day).`,
   };
 }
 
@@ -295,16 +327,20 @@ async function main() {
     publicGuardBypassed: Boolean(opsToken),
     header: OPS_TEST_HEADER,
   };
+  const publicLimitContext = buildPublicLimitContext(fileEnv);
 
   const sessionId = `viddel-rel-${Date.now().toString(36)}`;
   const plan = buildPlan(args.count);
   const results = [];
 
   console.log(
-    `chat-reliability: ${args.count} calls, ${args.delayMs}ms spacing, sessionPerRequest=${args.sessionPerRequest}, opsToken=${opsConfig.tokenConfiguredLocally ? "yes" : "no"}`,
+    `chat-reliability: ${args.count} calls, ${args.delayMs}ms spacing, sessionPerRequest=${args.sessionPerRequest}`,
   );
-  if (!opsConfig.tokenConfiguredLocally) {
-    console.log("WARN: VIDDEL_OPS_TEST_TOKEN not set — public IP rate limits apply.");
+  console.log(
+    `publicGuard: active (server limits — default ${DEFAULT_BURST_LIMIT}/10m ${DEFAULT_DAILY_LIMIT}/day; set VIDDEL_CHAT_* in Vercel + redeploy for pre-pilot)`,
+  );
+  if (opsConfig.tokenConfiguredLocally) {
+    console.log("opsToken: yes (optional bypass — not required for standard pre-pilot flow)");
   }
 
   for (const item of plan) {
@@ -353,7 +389,7 @@ async function main() {
     }
   }
 
-  const summary = summarize(results, opsConfig);
+  const summary = summarize(results, opsConfig, publicLimitContext);
   const cesEnv = readCesEnv();
   const report = {
     generatedAt: new Date().toISOString(),
@@ -363,6 +399,7 @@ async function main() {
       delayMs: args.delayMs,
       sessionPerRequest: args.sessionPerRequest,
       opsTest: opsConfig,
+      publicLimitContext,
     },
     sessionIdPrefix: sessionId.slice(0, 16),
     directEnvAvailable: cesEnv.missing.length === 0,

--- a/src/data/backstage-v01.ts
+++ b/src/data/backstage-v01.ts
@@ -21,7 +21,7 @@ export const quickAnswers = [
   {
     question: "Hva beskytter oss?",
     answer:
-      "Public guard: grenser på lengde og antall spørsmål per IP, pluss sjekk av hvor forespørselen kommer fra. Separat ops-testmodus (hemmelig token) brukes kun internt for stabilitetstest — uten innholdslogging.",
+      "Public guard: lengde, origin og IP-rate-limit (default 10/10 min, 50/døgn). Grensene kan midlertidig heves i Vercel for pre-pilot — uten innholdslogging.",
   },
   {
     question: "Hva gjør vi når noe ikke virker?",
@@ -74,7 +74,7 @@ export const systemMapLayers: SystemMapLayer[] = [
     layer: "Beskyttelse",
     title: "Guard + Upstash",
     human:
-      "Public guard beskytter brukere og kost — rate limit og origin-sjekk. Ops-test (hemmelig server-token) omgår kun IP-grenser for intern stabilitetstest.",
+      "Public guard beskytter brukere og kost — rate limit og origin-sjekk. Grenser styres via VIDDEL_CHAT_* i Vercel (default 10/50).",
   },
   {
     id: "ai",
@@ -126,7 +126,7 @@ export const chatFlowSteps: ChatFlowStep[] = [
     title: "Upstash sjekker bruksmengde",
     human: "Teller hvor mange spørsmål som kommer fra samme IP.",
     why: "Dette beskytter kostnad og misbruk.",
-    tech: "10 / 10 min · 50 / døgn",
+    tech: "VIDDEL_CHAT_BURST_LIMIT / VIDDEL_CHAT_DAILY_LIMIT (default 10 / 10 min · 50 / døgn)",
   },
   {
     step: 5,
@@ -150,13 +150,15 @@ export const protectionRules = [
   },
   {
     title: "Kort sikt",
-    value: "10 spørsmål per 10 minutter",
-    human: "Beskyttelse mot rask spam fra samme IP.",
+    value: "10 per 10 min (default)",
+    human:
+      "Beskyttelse mot rask spam fra samme IP. Kan midlertidig heves i Vercel via VIDDEL_CHAT_BURST_LIMIT under pre-pilot eller reliability-test.",
   },
   {
     title: "Døgn",
-    value: "50 spørsmål per døgn",
-    human: "Tak på total bruk per IP per dag.",
+    value: "50 per døgn (default)",
+    human:
+      "Tak på total bruk per IP per dag. Kan midlertidig heves i Vercel via VIDDEL_CHAT_DAILY_LIMIT — sett tilbake etter test.",
   },
   {
     title: "Trygg stenging",
@@ -166,20 +168,33 @@ export const protectionRules = [
   },
 ] as const;
 
-/** Guard strategy v0.2 — public guard vs intern ops reliability testing. */
+/** Guard strategy — public guard med Vercel-styrte grenser (#180 + env v0.1). */
 export const guardStrategyExplainer = {
-  title: "Guard strategy v0.2",
-  lead: "To lag: public guard for ekte brukere, ops-test for intern stabilitet — uten å svekke offentlig sikkerhet.",
+  title: "Public guard og testgrenser",
+  lead: "Public guard beskytter chatten alltid. Under pre-pilot kan Thomas heve grensene i Vercel — uten lokal token eller kodeendring.",
   publicGuard: {
     label: "Public guard (#180)",
     human:
-      "Aktiv for alle uten gyldig ops-token. Origin-sjekk, maks meldingslengde, 10 / 10 min og 50 / døgn per IP. Fail closed hvis Upstash mangler i production.",
+      "Origin-sjekk, maks meldingslengde og IP-rate-limit via Upstash. Standard: 10 / 10 min og 50 / døgn. Fail closed hvis Upstash mangler i production.",
   },
-  opsTest: {
-    label: "Ops reliability testing",
+  vercelLimits: {
+    label: "Juster grenser i Vercel (v0.1)",
     human:
-      "Kun script/ops med header x-viddel-ops-test-token og VIDDEL_OPS_TEST_TOKEN i Vercel. Omgår burst/daily IP-rate-limit — beholder validering, timeout, safe errors og ingen prompt/svar-logging. Token eksponeres aldri i frontend.",
+      "VIDDEL_CHAT_BURST_LIMIT og VIDDEL_CHAT_DAILY_LIMIT — positive heltall. Ugyldig eller tom verdi → default 10 og 50. Redeploy etter endring.",
   },
+} as const;
+
+/** Anbefalt midlertidig testmodus før ekstern pilot — ikke permanent produksjonsnivå. */
+export const prePilotReliabilityExplainer = {
+  title: "Reliability-test uten lokal token",
+  steps: [
+    "Sett midlertidig i Vercel Production: VIDDEL_CHAT_BURST_LIMIT=100 og VIDDEL_CHAT_DAILY_LIMIT=500.",
+    "Redeploy Production.",
+    "Kjør npm run chat:reliability (spaced calls) — Cursor trenger ikke lokal token.",
+    "Vurder CES-stabilitet fra safe metadata (suksess, upstream, timeout, rate_limit).",
+    "Sett grensene tilbake til 10/50 eller fjern env-vars etter test.",
+  ],
+  note: "Guard forblir aktiv — vi justerer bare terskelen midlertidig.",
 } as const;
 
 export const upstashExplainer = {
@@ -480,19 +495,17 @@ export const changeRunbooks: ChangeRunbook[] = [
   },
   {
     id: "rate-limits",
-    title: "Endre rate limits",
-    whatChanges: "Hvor mange spørsmål som tillates — per 10 minutter og per døgn (per IP).",
-    where: "I chat guard-koden. Nåværende grenser: 10 per 10 min og 50 per døgn.",
-    whereToGo:
-      "GitHub/Cursor for kodeendring i guard. Etterpå Vercel → Deployments. Ikke Vercel env alene — grensene ligger i kode i dag.",
-    after: "Commit, deploy til Production, og test at chat fortsatt fungerer.",
-    test: "Ett vanlig spørsmål (skal fungere). 11 raske spørsmål (skal stoppe med tydelig melding). For lang melding (skal avvises).",
-    actionLinks: [
-      backstageLinks.guardFile,
-      backstageLinks.githubPulls,
-      backstageLinks.vercelDeployments,
-    ],
-    tech: "src/lib/chat-api-guard.ts",
+    title: "Endre rate limits (Vercel env)",
+    whatChanges: "Hvor mange spørsmål som tillates per IP — burst (10 min) og døgn. Default 10 og 50 hvis env mangler.",
+    where:
+      "Vercel → Environment Variables: VIDDEL_CHAT_BURST_LIMIT, VIDDEL_CHAT_DAILY_LIMIT. Kun positive heltall — ellers faller systemet tilbake til default.",
+    whereToGo: "Vercel → Settings → Environment Variables → Redeploy Production.",
+    after:
+      "Redeploy. For reliability-test: midlertidig 100/500, kjør script, sett tilbake etterpå. For permanent endring: avklar med @navigator først.",
+    test: "Ett vanlig spørsmål (skal fungere). reliability-script uten rate_limit-blokkering når grensene er hevet. For lang melding (skal avvises).",
+    actionLinks: [backstageLinks.vercelEnv, backstageLinks.vercelDeployments, backstageLinks.guardFile],
+    envVars: ["VIDDEL_CHAT_BURST_LIMIT", "VIDDEL_CHAT_DAILY_LIMIT"],
+    tech: "src/lib/chat-guard-limits.ts · src/lib/chat-api-guard.ts",
   },
   {
     id: "max-length",
@@ -719,13 +732,23 @@ export const monitoringEvents = [
 
 export type EnvVarEntry = {
   name: string;
-  group: "upstash" | "ces" | "auth" | "posthog" | "ops";
+  group: "upstash" | "guard" | "ces" | "auth" | "posthog" | "ops";
   controls: string;
 };
 
 export const envVars: EnvVarEntry[] = [
   { name: "UPSTASH_REDIS_REST_URL", group: "upstash", controls: "Teller-endpoint." },
   { name: "UPSTASH_REDIS_REST_TOKEN", group: "upstash", controls: "Teller-autentisering." },
+  {
+    name: "VIDDEL_CHAT_BURST_LIMIT",
+    group: "guard",
+    controls: "Spørsmål per IP per 10 min. Default 10. Pre-pilot test: midlertidig 100.",
+  },
+  {
+    name: "VIDDEL_CHAT_DAILY_LIMIT",
+    group: "guard",
+    controls: "Spørsmål per IP per døgn. Default 50. Pre-pilot test: midlertidig 500.",
+  },
   { name: "VIDDEL_OPS_TEST_TOKEN", group: "ops", controls: "Hemmelig ops reliability test — bypass public IP-rate-limit kun for script med riktig header. Aldri frontend." },
   { name: "CES_PROJECT_ID", group: "ces", controls: "CES prosjekt." },
   { name: "CES_LOCATION", group: "ces", controls: "CES region." },
@@ -746,6 +769,7 @@ export const envVarNotes = [
 export const sourceFiles = [
   "src/pages/api/chat.ts",
   "src/lib/chat-api-guard.ts",
+  "src/lib/chat-guard-limits.ts",
   "src/lib/chat-ops-test.ts",
   "src/lib/chat-usage-metrics.ts",
   "src/lib/viddel-analytics-events.ts",

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -77,7 +77,7 @@ export const mvpCurrentState = {
   } satisfies CurrentSprint,
   closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
-    "Monitoring levert (#188). Vi feilsøker chat-stabilitet — public guard står, ops-test gir ren CES-måling. Fallback ved behov.",
+    "Monitoring levert (#188). Reliability-test via Vercel guard-limits (100/500 midlertidig) — ikke lokal token. Fallback ved behov.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -111,7 +111,7 @@ export const mvpCurrentState = {
       label: "Spør Viddel",
       route: "/no/chat/",
       status: "Applied",
-      note: "Live i production. Public guard beskytter brukere; intern ops-test måler CES-stabilitet separat (#188).",
+      note: "Live i production. Public guard aktiv — grenser justerbare i Vercel for pre-pilot CES-test (#188).",
       visFrontpage: true,
       kind: "public",
       frontpageDescription: "Headless AI-chat — live (intern test). Public guard aktiv.",

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -41,36 +41,36 @@ export type VisRuntimeFeed = {
 
 /** Manually updated after important Return Tickets — not synced from GitHub. */
 export const visRuntimeFeed = {
-  updatedAt: "2026-05-29",
+  updatedAt: "2026-06-02",
   activeNow: [
     {
       id: "ai-usage-monitoring-v01",
       headline:
-        "Vi skiller brukerbeskyttelse fra intern stabilitetstest av AI-chatten.",
+        "Vi forenkler reliability-test ved å styre public guard-grenser fra Vercel.",
       workTitle: "AI usage monitoring v0.1 (#188)",
       area: "Data, monitoring og innsikt",
       why:
         "Vi må se om chatten virker, om den feiler, og hvilke innganger som brukes — uten å lagre spørsmål eller svar.",
       status:
-        "Monitoring er levert. Nå justerer vi guard-strategien slik at Cursor kan teste CES-stabilitet uten å bli stoppet av vanlig public rate limit.",
+        "Monitoring og guard v0.2 er levert. Nå kan Thomas midlertidig heve burst/daily limits i Vercel (100/500) og kjøre reliability-test uten lokal token.",
       possibleSolution:
-        "Public guard står fast. Ops-test får hemmelig server-token for måling.",
+        "VIDDEL_CHAT_BURST_LIMIT og VIDDEL_CHAT_DAILY_LIMIT i Vercel — public guard forblir aktiv.",
       nextDecision:
-        "Kjør ren ops-test. Hvis CES fortsatt er ustabil, start fallback-spike.",
+        "Thomas setter høyere limits, redeployer, Cursor kjører reliability-test. Vurder CES — deretter fallback-spike ved behov.",
       issue: "#188",
       issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
       progressSteps: [
         { id: "monitoring", label: "Monitoring levert", state: "done" },
-        { id: "guard-v02", label: "Guard strategy v0.2", state: "current" },
+        { id: "guard-env", label: "Guard limits via Vercel", state: "current" },
         { id: "ces-test", label: "Ren CES-test", state: "upcoming" },
         { id: "fallback", label: "Fallback ved behov", state: "upcoming" },
       ],
     },
   ],
   recentlyCompletedSummary:
-    "VIS Tree Navigation v0.1 (#192), IA Inventory v0.3.1 (#191) og Backstage v0.1 i production.",
+    "Guard strategy v0.2 (#199) merged. INT-007 Anne-spor registrert i gitbuss (#200–#204).",
   lastReturnTicketSummary:
-    "VIS-språk oppdatert: vi feilsøker chat-stabilitet og skiller public guard fra intern ops-test (#199).",
+    "Guard limits via Vercel env v0.1 — reliability-test uten lokal ops-token.",
   links: {
     primary: [
       {

--- a/src/lib/backstage-guard.ts
+++ b/src/lib/backstage-guard.ts
@@ -13,6 +13,12 @@ import {
 } from "../data/backstage-v01.ts";
 import { getVisFrontpageHubs } from "../data/vis-frontpage-hubs-v01.ts";
 import { CHAT_MAX_MESSAGE_LENGTH } from "./chat-api-guard.ts";
+import {
+  CHAT_BURST_LIMIT_ENV,
+  CHAT_DAILY_LIMIT_ENV,
+  DEFAULT_CHAT_BURST_LIMIT,
+  DEFAULT_CHAT_DAILY_LIMIT,
+} from "./chat-guard-limits.ts";
 
 const REQUIRED_ENV_VARS = [
   "UPSTASH_REDIS_REST_URL",
@@ -126,24 +132,28 @@ export function validateBackstageGuard(): string[] {
 
   const burstRule = protectionRules.find((r) => r.title === "Kort sikt");
   const dailyRule = protectionRules.find((r) => r.title === "Døgn");
-  if (!burstRule?.value.includes("10")) {
-    errors.push("Backstage burst limit text must reference 10 per 10 minutes");
+  if (!burstRule?.value.includes(String(DEFAULT_CHAT_BURST_LIMIT))) {
+    errors.push(`Backstage burst limit text must reference default ${DEFAULT_CHAT_BURST_LIMIT} per 10 minutes`);
   }
-  if (!dailyRule?.value.includes("50")) {
-    errors.push("Backstage daily limit text must reference 50 per day");
+  if (!dailyRule?.value.includes(String(DEFAULT_CHAT_DAILY_LIMIT))) {
+    errors.push(`Backstage daily limit text must reference default ${DEFAULT_CHAT_DAILY_LIMIT} per day`);
   }
 
   const guardPath = join(srcRoot, "lib/chat-api-guard.ts");
+  const limitsPath = join(srcRoot, "lib/chat-guard-limits.ts");
   if (existsSync(guardPath)) {
     const guardSource = readFileSync(guardPath, "utf8");
-    if (!guardSource.includes('slidingWindow(10, "10 m")')) {
-      errors.push("chat-api-guard.ts burst limit changed — update Backstage protection rules");
-    }
-    if (!guardSource.includes('slidingWindow(50, "24 h")')) {
-      errors.push("chat-api-guard.ts daily limit changed — update Backstage protection rules");
+    if (!guardSource.includes("getChatRateLimitConfig")) {
+      errors.push("chat-api-guard.ts must use getChatRateLimitConfig for rate limits");
     }
     if (!guardSource.includes(`CHAT_MAX_MESSAGE_LENGTH = ${CHAT_MAX_MESSAGE_LENGTH}`)) {
       errors.push("CHAT_MAX_MESSAGE_LENGTH changed — update Backstage protection rules");
+    }
+  }
+  if (existsSync(limitsPath)) {
+    const limitsSource = readFileSync(limitsPath, "utf8");
+    if (!limitsSource.includes(CHAT_BURST_LIMIT_ENV) || !limitsSource.includes(CHAT_DAILY_LIMIT_ENV)) {
+      errors.push("chat-guard-limits.ts must define Vercel env var names for burst/daily limits");
     }
   }
 

--- a/src/lib/chat-api-guard.ts
+++ b/src/lib/chat-api-guard.ts
@@ -2,6 +2,7 @@
 
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
+import { getChatRateLimitConfig } from "./chat-guard-limits.ts";
 import { isOpsReliabilityRequest } from "./chat-ops-test.ts";
 
 export const CHAT_MAX_MESSAGE_LENGTH = 2000;
@@ -105,15 +106,16 @@ function getRateLimiters(): RateLimitState | null {
     return null;
   }
   const redis = Redis.fromEnv();
+  const { burstLimit, dailyLimit } = getChatRateLimitConfig();
   rateLimitState = {
     burst: new Ratelimit({
       redis,
-      limiter: Ratelimit.slidingWindow(10, "10 m"),
+      limiter: Ratelimit.slidingWindow(burstLimit, "10 m"),
       prefix: "viddel-chat-burst",
     }),
     daily: new Ratelimit({
       redis,
-      limiter: Ratelimit.slidingWindow(50, "24 h"),
+      limiter: Ratelimit.slidingWindow(dailyLimit, "24 h"),
       prefix: "viddel-chat-daily",
     }),
   };

--- a/src/lib/chat-guard-limits.ts
+++ b/src/lib/chat-guard-limits.ts
@@ -1,0 +1,40 @@
+/* CONTRACT: Public chat rate limit config from Vercel env — safe parse, defaults 10/50 (#180). */
+
+export const DEFAULT_CHAT_BURST_LIMIT = 10;
+export const DEFAULT_CHAT_DAILY_LIMIT = 50;
+
+export const CHAT_BURST_LIMIT_ENV = "VIDDEL_CHAT_BURST_LIMIT";
+export const CHAT_DAILY_LIMIT_ENV = "VIDDEL_CHAT_DAILY_LIMIT";
+
+function readEnv(name: string): string {
+  return (process.env[name] ?? import.meta.env[name] ?? "").trim();
+}
+
+/** Positive integer only; invalid or missing → default. */
+export function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = readEnv(name);
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return n;
+}
+
+export type ChatRateLimitConfig = {
+  burstLimit: number;
+  dailyLimit: number;
+  burstFromEnv: boolean;
+  dailyFromEnv: boolean;
+};
+
+export function getChatRateLimitConfig(): ChatRateLimitConfig {
+  const burstRaw = readEnv(CHAT_BURST_LIMIT_ENV);
+  const dailyRaw = readEnv(CHAT_DAILY_LIMIT_ENV);
+  const burstLimit = parsePositiveIntEnv(CHAT_BURST_LIMIT_ENV, DEFAULT_CHAT_BURST_LIMIT);
+  const dailyLimit = parsePositiveIntEnv(CHAT_DAILY_LIMIT_ENV, DEFAULT_CHAT_DAILY_LIMIT);
+  return {
+    burstLimit,
+    dailyLimit,
+    burstFromEnv: Boolean(burstRaw) && burstLimit === Number.parseInt(burstRaw, 10),
+    dailyFromEnv: Boolean(dailyRaw) && dailyLimit === Number.parseInt(dailyRaw, 10),
+  };
+}

--- a/src/pages/backstage/index.astro
+++ b/src/pages/backstage/index.astro
@@ -10,6 +10,7 @@ import {
   envVars,
   productionChecklist,
   guardStrategyExplainer,
+  prePilotReliabilityExplainer,
   protectionRules,
   quickAnswers,
   sourceFiles,
@@ -31,9 +32,10 @@ const base = import.meta.env.BASE_URL;
 
 const envGroups = [
   { id: "upstash", label: "Upstash (teller + drift)" },
+  { id: "guard", label: "Public guard (rate limits)" },
   { id: "ces", label: "CES (AI-motor)" },
   { id: "auth", label: "Google auth" },
-  { id: "ops", label: "Ops reliability (intern test)" },
+  { id: "ops", label: "Ops reliability (valgfritt)" },
   { id: "posthog", label: "PostHog EU (produktinnsikt)" },
 ] as const;
 
@@ -151,10 +153,25 @@ const layerTone: Record<string, string> = {
           <p class="bs__quick-a">{guardStrategyExplainer.publicGuard.human}</p>
         </article>
         <article class="bs__quick-card">
-          <h3 class="bs__quick-q">{guardStrategyExplainer.opsTest.label}</h3>
-          <p class="bs__quick-a">{guardStrategyExplainer.opsTest.human}</p>
+          <h3 class="bs__quick-q">{guardStrategyExplainer.vercelLimits.label}</h3>
+          <p class="bs__quick-a">{guardStrategyExplainer.vercelLimits.human}</p>
         </article>
       </div>
+    </section>
+
+    <section class="bs__section" aria-labelledby="bs-pre-pilot-test">
+      <h2 id="bs-pre-pilot-test" class="bs__section-title">{prePilotReliabilityExplainer.title}</h2>
+      <ol class="bs-flow">
+        {prePilotReliabilityExplainer.steps.map((step, index) => (
+          <li class="bs-flow__step">
+            <span class="bs-flow__num">{index + 1}</span>
+            <div class="bs-flow__body">
+              <p class="bs-flow__human">{step}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+      <p class="bs__section-lead">{prePilotReliabilityExplainer.note}</p>
     </section>
 
     <section class="bs__explainers">


### PR DESCRIPTION
## Summary
- Public chat rate limits are configurable via Vercel env: `VIDDEL_CHAT_BURST_LIMIT` and `VIDDEL_CHAT_DAILY_LIMIT`.
- Safe parsing: positive integers only; invalid/missing values fall back to defaults (10 / 10 min, 50 / day).
- Backstage + VIS updated for Thomas/Vibeke: pre-pilot reliability test via Vercel (e.g. temporary 100/500) without local ops token.
- Reliability script reports `publicLimitContext` (metadata only).

## Test plan
- [ ] Without env vars: production still uses 10/50
- [ ] Set `VIDDEL_CHAT_BURST_LIMIT=100` and `VIDDEL_CHAT_DAILY_LIMIT=500` in Vercel Production → redeploy
- [ ] `npm run chat:reliability` — no rate_limit wall on 8 spaced calls
- [ ] Invalid env (e.g. `abc`) falls back to 10/50
- [ ] `npm run build` green
- [ ] Restore limits after CES test

Closes operational blocker for #188 reliability testing without local token handling.


Made with [Cursor](https://cursor.com)