### PR TITLE
Google Agent Search direct API spike v0.1 — preview probe (#198)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ GOOGLE_SERVICE_ACCOUNT_JSON=
 AGENT_SEARCH_ENGINE_ID=
 # Valgfri override (default default_serving_config for :answer).
 # AGENT_SEARCH_SERVING_CONFIG=default_serving_config
+# :answer session — omit (default) eller full resource path …/sessions/-
+# AGENT_SEARCH_ANSWER_SESSION=omit
+# AGENT_SEARCH_ANSWER_SESSION=full
 
 # Public AI guard (#180) — Upstash Redis for /api/chat rate limits (server-side only).
 # Required in Vercel Production before enabling public AI on /no/chat/.

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ CES_APP_VERSION_ID=91cc4831-f020-4bb1-a17c-650859401cb1
 CES_DEPLOYMENT_ID=edb2938a-a2bf-4555-b4c9-d54963531db4
 GOOGLE_SERVICE_ACCOUNT_JSON=
 
+# Agent Search direct :answer probe (#198) — Discovery Engine engine ID (NOT CES_APP_ID).
+# Finn i GCP: Agent Builder → engines/… eller gcloud discovery-engine engines list.
+AGENT_SEARCH_ENGINE_ID=
+# Valgfri override (default default_serving_config for :answer).
+# AGENT_SEARCH_SERVING_CONFIG=default_serving_config
+
 # Public AI guard (#180) — Upstash Redis for /api/chat rate limits (server-side only).
 # Required in Vercel Production before enabling public AI on /no/chat/.
 # Create at https://console.upstash.com/ — REST API URL + token.

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ AGENT_SEARCH_ENGINE_ID=
 # AGENT_SEARCH_ANSWER_SESSION=omit
 # AGENT_SEARCH_ANSWER_SESSION=full
 
+# AI backend mode (#198) — default ces_channel if unset. Do not set google_agent_search_direct in Production until reliability QA passes.
+# VIDDEL_AI_BACKEND=ces_channel
+# VIDDEL_AI_BACKEND=google_agent_search_direct
+
 # Public AI guard (#180) — Upstash Redis for /api/chat rate limits (server-side only).
 # Required in Vercel Production before enabling public AI on /no/chat/.
 # Create at https://console.upstash.com/ — REST API URL + token.

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 STORYBLOK_DELIVERY_API_TOKEN=
 
 # CES headless (#125M-B) — server-side only; sett i Vercel env, aldri i client bundle.
+# CES_APP_ID = CES channel / runSession (ces.googleapis.com/.../apps/...) — IKKE Discovery Engine engine ID.
 CES_PROJECT_ID=hearing-aid-mvp
 CES_LOCATION=eu
 CES_APP_ID=1741e68d-0528-4625-8b83-99a0dbb5298f
@@ -10,8 +11,9 @@ CES_APP_VERSION_ID=91cc4831-f020-4bb1-a17c-650859401cb1
 CES_DEPLOYMENT_ID=edb2938a-a2bf-4555-b4c9-d54963531db4
 GOOGLE_SERVICE_ACCOUNT_JSON=
 
-# Agent Search direct :answer probe (#198) — Discovery Engine engine ID (NOT CES_APP_ID).
-# Finn i GCP: Agent Builder → engines/… eller gcloud discovery-engine engines list.
+# Agent Search direct :answer (#198) — Discovery Engine engines/{id} — MUST differ from CES_APP_ID.
+# Known-good preview: h-rehjelpen-v1-2_1771939983615 (app Hørehjelpen v1.2, Search, store HearingNorwaystore).
+# Docs: docs/project/GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md
 AGENT_SEARCH_ENGINE_ID=
 # Valgfri override (default default_serving_config for :answer).
 # AGENT_SEARCH_SERVING_CONFIG=default_serving_config

--- a/docs/project/GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md
@@ -1,0 +1,131 @@
+# Google Agent Search `:answer` contract audit v0.1
+
+Status: **Audit + contract fix** (ikke UI, ikke merge #213 ennå).  
+Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [#213](https://github.com/THUNDERPLUNDER/vox-web/pull/213)
+
+---
+
+## Observasjon (preview QA `0c29802a`)
+
+| Signal | Verdi |
+|--------|--------|
+| Route / Vercel | OK — GET readiness 200, `route_reached: yes` |
+| Google upstream | **HTTP 400** på alle 5 kall |
+| Vår wrapper | HTTP 502 (viderefører Google-feil) |
+| Varighet | `<1s` — rask avvisning, ikke timeout |
+
+**Tolkning:** Deterministisk **request contract**-feil, ikke reliability og ikke route/auth.
+
+---
+
+## 1. Endpoint og metode
+
+| Sjekk | Status | Detalj |
+|-------|--------|--------|
+| Host EU | OK | `https://eu-discoveryengine.googleapis.com` for `location=eu` |
+| Metode | OK | `POST …/servingConfigs/{id}:answer` (REST `servingConfigs.answer`) |
+| Collection | OK | `default_collection` (standard) |
+| Ikke blandet med `:search` | OK | Vi kaller `:answer`, ikke `:search` |
+
+**URL vi bygger:**
+
+```
+POST https://eu-discoveryengine.googleapis.com/v1/projects/hearing-aid-mvp/locations/eu/collections/default_collection/engines/{engine_id}/servingConfigs/default_serving_config:answer
+```
+
+**Dokumentasjon:** [servingConfigs.answer](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/projects.locations.collections.engines.servingConfigs/answer)
+
+**Merk:** Noen curl-eksempler bruker `default_search:answer`; SDK-eksempler bruker `default_serving_config`. Begge kan være gyldige avhengig av app-type — verifiser i GCP om appen forventer `default_search` vs `default_serving_config`.
+
+---
+
+## 2. Engine / app ID
+
+| ID | Kilde | API-ressurs |
+|----|--------|-------------|
+| `1741e68d-0528-4625-8b83-99a0dbb5298f` | `CES_APP_ID` / env | `…/engines/{id}/…` |
+
+| Hypotese | Bevis |
+|----------|--------|
+| Samme UUID for Agent Search app og CES app | Google docs kaller engine path `APP_ID`; CES checklist bekrefter samme UUID i `apps/` |
+| **Ikke** bevist at `engines/{CES_APP_ID}` finnes | **404** ville vært typisk for feil engine — vi får **400** |
+| CES channel kan fungere uten at raw `:answer` er aktivert på samme app | 25% runSession vs 0% direct kan bety at channel bruker annet runtime |
+
+**Neste operator-sjekk (GCP):**
+
+1. Agent Builder / Discovery Engine → Apps → finn app → noter **Engine ID** i resource name.
+2. Sammenlign med `CES_APP_ID`. Hvis ulik → sett `AGENT_SEARCH_ENGINE_ID` i Vercel.
+3. Sjekk at app har **Answer / conversational search** (Enterprise / LLM add-on) — 400 kan også skyldes `LLM_ADDON_NOT_ENABLED` (FailedPrecondition, ikke alltid 400).
+
+---
+
+## 3. Payload vs dokumentert schema
+
+### Query
+
+| Felt | Vår kode | Dokumentasjon | Status |
+|------|----------|---------------|--------|
+| `query.text` | Ja | `Query.text` required | OK |
+
+### Session
+
+| Felt | Vår kode | Dokumentasjon | Status |
+|------|----------|---------------|--------|
+| `session: "-"` | Ja | Auto session wildcard | OK |
+
+### GroundingSpec — **FEIL FUNNET**
+
+| Felt | Vår kode (før fix) | Dokumentasjon | Status |
+|------|-------------------|---------------|--------|
+| `includeGrounding` | `true` | **Finnes ikke** | **INVALID** |
+| `includeGroundingSupports` | manglet | [GroundingSpec](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/GroundingSpec) | Skal brukes |
+
+Protobuf/JSON med ukjent felt → typisk **`INVALID_ARGUMENT` (HTTP 400)**.
+
+### AnswerGenerationSpec
+
+| Felt | Vår kode | Status |
+|------|----------|--------|
+| `ignoreAdversarialQuery` | true | Sannsynlig OK (camelCase i REST JSON) |
+| `ignoreNonAnswerSeekingQuery` | false | Sannsynlig OK |
+
+**Fix:** Minimal kontrakt først: `query` + `session` + valgfri korrekt `groundingSpec`.
+
+---
+
+## 4. Auth
+
+| Sjekk | Status |
+|-------|--------|
+| Scope `cloud-platform` | OK (samme SA som CES) |
+| IAM `discoveryengine.servingConfigs.answer` | Må verifiseres i GCP — **403** ville vært typisk; vi får **400** |
+| Token nås | OK (ellers auth-feil før Google) |
+
+---
+
+## 5. Konklusjon
+
+| Spørsmål | Svar |
+|----------|------|
+| Er route/Vercel/UI fortsatt problemet? | **Nei** — løst i `0c29802a` |
+| Er dette reliability? | **Nei** — 100% deterministisk 400 |
+| Primær sannsynlig årsak | **`groundingSpec.includeGrounding`** (ugyldig felt) |
+| Sekundære risikoer | Feil `servingConfig` navn; engine ID ≠ CES app; LLM add-on / app edition |
+| Passer direct `:answer` denne agenten? | **Ja, trolig** — samme GCP-prosjekt/app, men contract må rettes og verifiseres i GCP |
+
+---
+
+## 6. Kodeendring (v0.1 fix)
+
+- Fjern `includeGrounding`; bruk `includeGroundingSupports` eller dropp `groundingSpec` i minimal variant.
+- `error_code`: `google_400_bad_request` ved upstream 400.
+- Safe metadata: `google_rpc_status`, `google_error_hint` (kort, fra `error.status` / `error.message` — ikke logget server-side).
+
+---
+
+## 7. Neste steg
+
+1. **Redeploy preview** etter contract-fix commit — forvent enten Google 200 + `has_answer`, eller mer spesifikk `google_error_hint`.
+2. Hvis fortsatt 400: prøv `AGENT_SEARCH_SERVING_CONFIG=default_search` (env).
+3. Hvis `LLM_ADDON_NOT_ENABLED` / edition: direct API passer ikke uten GCP endring — da CES channel fortsatt riktig vei.
+4. **Ikke** merge #213 før ett gyldig 200 eller presis GCP-blokker.

--- a/docs/project/GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md
@@ -125,7 +125,7 @@ Protobuf/JSON med ukjent felt → typisk **`INVALID_ARGUMENT` (HTTP 400)**.
 
 ## 7. Neste steg
 
-1. **Redeploy preview** etter contract-fix commit — forvent enten Google 200 + `has_answer`, eller mer spesifikk `google_error_hint`.
-2. Hvis fortsatt 400: prøv `AGENT_SEARCH_SERVING_CONFIG=default_search` (env).
-3. Hvis `LLM_ADDON_NOT_ENABLED` / edition: direct API passer ikke uten GCP endring — da CES channel fortsatt riktig vei.
-4. **Ikke** merge #213 før ett gyldig 200 eller presis GCP-blokker.
+1. ~~Redeploy etter contract-fix~~ — **Done:** Google svarer **403** `discoveryengine.servingConfigs.answer` denied.
+2. **GCP IAM:** se **[GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md](./GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md)** — legg til `roles/discoveryengine.user` på samme SA som `GOOGLE_SERVICE_ACCOUNT_JSON`.
+3. Hvis fortsatt feil etter IAM: `AGENT_SEARCH_SERVING_CONFIG`, engine ID, LLM add-on.
+4. **Ikke** merge #213 før 200 eller presis GCP-konklusjon.

--- a/docs/project/GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md
@@ -71,7 +71,9 @@ POST https://eu-discoveryengine.googleapis.com/v1/projects/hearing-aid-mvp/locat
 
 | Felt | Vår kode | Dokumentasjon | Status |
 |------|----------|---------------|--------|
-| `session: "-"` | Ja | Auto session wildcard | OK |
+| `session` utelatt (default probe) | Ja | Single-turn uten session | Preview etter engine-fix |
+| `session: …/sessions/-` (full) | Valgfri | `AGENT_SEARCH_ANSWER_SESSION=full` | Hvis omit feiler |
+| ~~`session: "-"`~~ | Nei | Google: `Invalid session name: -` | Fjernet |
 
 ### GroundingSpec — **FEIL FUNNET**
 

--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
@@ -1,7 +1,8 @@
 # Google Agent Search direct API spike v0.1
 
-Status: **Assessment + optional probe** — ikke production-bytt.  
-Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [#188](https://github.com/THUNDERPLUNDER/vox-web/issues/188)
+Status: **Direct `:answer` validated in preview (5/5)** — ikke production-bytt.  
+Known-good config: [GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md](./GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md)  
+Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [#188](https://github.com/THUNDERPLUNDER/vox-web/issues/188), [#213](https://github.com/THUNDERPLUNDER/vox-web/pull/213)
 
 ---
 
@@ -56,13 +57,14 @@ Offisiell dokumentasjon: [Agent Search REST](https://cloud.google.com/generative
 https://eu-discoveryengine.googleapis.com/v1/projects/{PROJECT}/locations/eu/collections/default_collection/engines/{ENGINE_ID}/servingConfigs/{SERVING_CONFIG}:{method}
 ```
 
-**Vår app (fra env):**
+**Vår app (known-good — se [known-good doc](./GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md)):**
 
 | Felt | Verdi |
 |------|-------|
 | project | `hearing-aid-mvp` |
 | location | `eu` |
-| engine/app id | `1741e68d-0528-4625-8b83-99a0dbb5298f` (må verifiseres som **engine** i Discovery Engine, ikke bare CES app) |
+| **engine id** | `AGENT_SEARCH_ENGINE_ID` = `h-rehjelpen-v1-2_1771939983615` |
+| **CES app id** (ikke engine) | `CES_APP_ID` = `1741e68d-0528-4625-8b83-99a0dbb5298f` |
 
 **Auth / IAM:**
 
@@ -81,7 +83,7 @@ https://eu-discoveryengine.googleapis.com/v1/projects/{PROJECT}/locations/eu/col
 - `default_search` — søk/retrieval + streamAnswer
 - `default_serving_config` — answer query (anbefalt for chat-lignende svar)
 
-**Multi-turn:** `session` felt i answer request (auto session med `-` eller eksplisitt session resource).
+**Multi-turn:** `session` — known-good single-turn probe **omits** session; optional full path via `AGENT_SEARCH_ANSWER_SESSION=full`. **Never** `session: "-"`.
 
 ---
 
@@ -89,7 +91,7 @@ https://eu-discoveryengine.googleapis.com/v1/projects/{PROJECT}/locations/eu/col
 
 | Spørsmål | Channel/runSession (A) | Direct answer API (B) |
 |----------|------------------------|------------------------|
-| Stabilitet (observasjon) | **25%** (16 kall, 2 serier) | **TBD** — kjør probe |
+| Stabilitet (observasjon) | **25%** (16 kall, 2 serier) | **100%** (5/5 preview probe, known-good env) |
 | Svar med kvalitet | Ja når 200 | TBD |
 | Citations/grounding | Via CES/agent (ikke eksponert) | `groundingSpec` i API |
 | Beholde `/api/chat`-kontrakt? | Ja (nåværende) | Ja — map `answerText` → `text` |
@@ -116,18 +118,35 @@ Logger kun safe metadata — ingen prompt/svar.
 
 ---
 
-## F. Beslutningspunkt
+## F. Final status (preview QA)
 
-**Hvis direct API er stabilt (f.eks. ≥80% has_answer over probe-serie):**
+| Resultat | Verdi |
+|----------|--------|
+| Direct `:answer` | **Teknisk validert** i Vercel Preview |
+| Første gyldige serie | **5/5** success, `has_answer` + citations |
+| Channel baseline | **4/16 (25%)** — uendret |
+| Production backend | **Ikke byttet** — fortsatt CES `runSession` |
+| PR #213 | **Ikke merge** ennå |
 
-- Anbefal liten PR: `VIDDEL_AI_BACKEND=ces_channel | google_agent_search_direct`
-- Default `ces_channel` til QA er ferdig
-- Ingen frontend-endring
+Full config + troubleshooting: [GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md](./GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md).
 
-**Hvis direct API også er ustabilt:**
+---
 
-- Anbefal videre fallback-assessment: OpenAI File Search, Vercel AI Gateway, Supabase pgvector / Pinecone, Anthropic citations
-- **Ikke** implementer ekstern fallback i samme PR
+## G. Beslutningspunkt (neste)
+
+Direct API er **stabilt nok i preview** for neste vurdering — ikke for umiddelbar prod-switch.
+
+**Anbefalt neste steg:**
+
+- Liten assessment / design for `VIDDEL_AI_BACKEND=ces_channel | google_agent_search_direct`
+- Default `ces_channel` til produksjons-QA og drift er ferdig
+- Ingen frontend-endring i første backend-modus-PR
+- **Ikke** aktiver PostHog, **ikke** reset guard limits, **ikke** fjerne channel-kode ennå
+
+**Hvis direct API feiler igjen i prod-lignende test:**
+
+- Videre fallback-assessment (OpenAI File Search, Vercel AI Gateway, pgvector, etc.)
+- **Ikke** implementer ekstern fallback uten eget mandat
 
 ---
 

--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
@@ -109,7 +109,15 @@ Logger kun safe metadata — ingen prompt/svar.
 
 ---
 
-## E. Beslutningspunkt
+## E. Contract audit (400 upstream)
+
+Se **[GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md](./GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md)**.
+
+Kort: Preview QA viste deterministisk Google **HTTP 400** — sannsynlig `groundingSpec.includeGrounding` (ugyldig felt; skal være `includeGroundingSupports`). Fix i `agent-search-direct.ts` + `google_400_bad_request`.
+
+---
+
+## F. Beslutningspunkt
 
 **Hvis direct API er stabilt (f.eks. ≥80% has_answer over probe-serie):**
 

--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
@@ -1,0 +1,135 @@
+# Google Agent Search direct API spike v0.1
+
+Status: **Assessment + optional probe** — ikke production-bytt.  
+Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [#188](https://github.com/THUNDERPLUNDER/vox-web/issues/188)
+
+---
+
+## Beslutning
+
+Etter to rene reliability-serier (guard 100/500): **25% success, 75% upstream (502), 0 rate_limit**.  
+Public guard er ikke problemet. Thomas vil **først** teste Googles dokumenterte **Agent Search answer/search API** direkte før ekstern fallback (OpenAI, Vercel AI Gateway, pgvector).
+
+**Hypotese:** Ustabilitet kan ligge i **CES channel / deployment / runSession-laget**, ikke nødvendigvis i Agent Search/RAG-kjernen.
+
+---
+
+## A. Dagens implementasjon (`/api/chat`)
+
+| Lag | Detalj |
+|-----|--------|
+| Entry | `POST /api/chat` → `src/pages/api/chat.ts` |
+| Backend | `runCesSession()` i `src/lib/ces-run-session.ts` |
+| API | **CES Conversational Agents** — `ces.googleapis.com/v1beta` |
+| Metode | `projects/.../apps/.../sessions/{id}:runSession` |
+| Auth | Service account JWT → `cloud-platform` scope (`src/lib/ces-auth.ts`) |
+| Deployment | `CES_DEPLOYMENT_ID` (API access channel, f.eks. `edb2938a-…`) |
+| Location | `CES_LOCATION=eu` (multi-region, **ikke** compute-region) |
+| Payload | `{ config: { session, deployment }, inputs: [{ text }] }` |
+| Upstream 502 | Kastes i `runCesSessionOnce` når `!response.ok` → `error_code=upstream` |
+
+**Gjenbruk ved alternativ backend:**
+
+- Public guard (`chat-api-guard.ts`, `chat-guard-limits.ts`)
+- Timeout/retry-mønster (`CES_FETCH_TIMEOUT_MS`, 2 forsøk)
+- Safe metadata (`chat-usage-metrics.ts`, `[chat-drift]`)
+- Frontend-kontrakt: `{ message, sessionId }` → `{ text, turnCompleted, turnIndex }`
+- Viddel-svarformat (ren tekst, ingen `diagnosticInfo` til klient)
+
+**Ikke gjenbruk direkte:** CES session/deployment resource paths, `runSession` payload.
+
+---
+
+## B. Google Agent Search direct API (Discovery Engine)
+
+Offisiell dokumentasjon: [Agent Search REST](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/projects.locations.collections.engines.servingConfigs)
+
+| Metode | Formål | Serving config (typisk) |
+|--------|--------|-------------------------|
+| **`:search`** | Dokumentsøk / retrieval | `default_search` |
+| **`:answer`** | Generert svar + grounding | `default_serving_config` |
+| **`:streamAnswer`** | Streaming svar | `default_search` |
+
+**EU endpoint (viktig):** bruk host **`eu-discoveryengine.googleapis.com`**, ikke global default.
+
+```
+https://eu-discoveryengine.googleapis.com/v1/projects/{PROJECT}/locations/eu/collections/default_collection/engines/{ENGINE_ID}/servingConfigs/{SERVING_CONFIG}:{method}
+```
+
+**Vår app (fra env):**
+
+| Felt | Verdi |
+|------|-------|
+| project | `hearing-aid-mvp` |
+| location | `eu` |
+| engine/app id | `1741e68d-0528-4625-8b83-99a0dbb5298f` (må verifiseres som **engine** i Discovery Engine, ikke bare CES app) |
+
+**Auth / IAM:**
+
+- OAuth scope: `https://www.googleapis.com/auth/cloud-platform` (samme som i dag)
+- Permission: `discoveryengine.servingConfigs.answer` / `.search` (i tillegg til evt. `ces.sessions.runSession`)
+
+**Response-felt (answer) — kun metadata i probe:**
+
+- `answer.state` (f.eks. SUCCEEDED)
+- `answer.answerText` — **ikke logget** i probe
+- Grounding / citations via `groundingSpec` og svar-struktur
+- `relatedQuestions`, support scores avhengig av spec
+
+**Forskjell default_search vs default_serving_config:**
+
+- `default_search` — søk/retrieval + streamAnswer
+- `default_serving_config` — answer query (anbefalt for chat-lignende svar)
+
+**Multi-turn:** `session` felt i answer request (auto session med `-` eller eksplisitt session resource).
+
+---
+
+## C. Sammenligning (vurdering)
+
+| Spørsmål | Channel/runSession (A) | Direct answer API (B) |
+|----------|------------------------|------------------------|
+| Stabilitet (observasjon) | **25%** (16 kall, 2 serier) | **TBD** — kjør probe |
+| Svar med kvalitet | Ja når 200 | TBD |
+| Citations/grounding | Via CES/agent (ikke eksponert) | `groundingSpec` i API |
+| Beholde `/api/chat`-kontrakt? | Ja (nåværende) | Ja — map `answerText` → `text` |
+| Vi mister | — | CES deployment/channel, runSession tools |
+| Vi vinner (hvis stabilt) | — | Færre lag, tydeligere API, EU host eksplisitt |
+
+---
+
+## D. Probe-script
+
+`scripts/agent-search-direct-probe.mjs` — **ikke** koblet til `/api/chat`.
+
+```bash
+# Krever samme server-env som CES (GOOGLE_SERVICE_ACCOUNT_JSON, CES_*)
+npm run agent-search:probe -- --count=5 --delay-ms=8000
+```
+
+Logger kun safe metadata (status, error_code, duration_bucket, has_answer, has_citations, support_score).
+
+---
+
+## E. Beslutningspunkt
+
+**Hvis direct API er stabilt (f.eks. ≥80% has_answer over probe-serie):**
+
+- Anbefal liten PR: `VIDDEL_AI_BACKEND=ces_channel | google_agent_search_direct`
+- Default `ces_channel` til QA er ferdig
+- Ingen frontend-endring
+
+**Hvis direct API også er ustabilt:**
+
+- Anbefal videre fallback-assessment: OpenAI File Search, Vercel AI Gateway, Supabase pgvector / Pinecone, Anthropic citations
+- **Ikke** implementer ekstern fallback i samme PR
+
+---
+
+## Out of scope
+
+- Production backend-bytt
+- Fjerne CES channel-kode
+- PostHog
+- Innholdslogging
+- Flere channel-reliability-serier

--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
@@ -138,7 +138,7 @@ Direct API er **stabilt nok i preview** for neste vurdering — ikke for umiddel
 
 **Anbefalt neste steg:**
 
-- Liten assessment / design for `VIDDEL_AI_BACKEND=ces_channel | google_agent_search_direct`
+- Assessment: [VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md](./VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md) — implement env switch (default `ces_channel`), no prod switch yet
 - Default `ces_channel` til produksjons-QA og drift er ferdig
 - Ingen frontend-endring i første backend-modus-PR
 - **Ikke** aktiver PostHog, **ikke** reset guard limits, **ikke** fjerne channel-kode ennå

--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
@@ -109,11 +109,10 @@ Logger kun safe metadata — ingen prompt/svar.
 
 ---
 
-## E. Contract audit (400 upstream)
+## E. Contract audit + IAM (400 → 403)
 
-Se **[GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md](./GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md)**.
-
-Kort: Preview QA viste deterministisk Google **HTTP 400** — sannsynlig `groundingSpec.includeGrounding` (ugyldig felt; skal være `includeGroundingSupports`). Fix i `agent-search-direct.ts` + `google_400_bad_request`.
+- **400 (payload):** [GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md](./GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md) — `includeGroundingSupports` fix i `e4401c11`.
+- **403 (IAM):** [GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md](./GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md) — SA trenger `roles/discoveryengine.user` (eller custom) i tillegg til `roles/ces.client`.
 
 ---
 

--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md
@@ -98,16 +98,14 @@ https://eu-discoveryengine.googleapis.com/v1/projects/{PROJECT}/locations/eu/col
 
 ---
 
-## D. Probe-script
+## D. Probe (preview-first)
 
-`scripts/agent-search-direct-probe.mjs` — **ikke** koblet til `/api/chat`.
+**Anbefalt for Thomas:** Vercel Preview → `/vis/system/agent-search-direct-probe/` → «Kjør 5 direct API-kall».  
+Bruker `POST /api/agent-search-direct-probe` (ett kall per request, deaktivert når `VERCEL_ENV=production`).
 
-```bash
-# Krever samme server-env som CES (GOOGLE_SERVICE_ACCOUNT_JSON, CES_*)
-npm run agent-search:probe -- --count=5 --delay-ms=8000
-```
+Valgfritt CLI (utviklere): `npm run agent-search:probe -- --count=5 --delay-ms=8000`
 
-Logger kun safe metadata (status, error_code, duration_bucket, has_answer, has_citations, support_score).
+Logger kun safe metadata — ingen prompt/svar.
 
 ---
 

--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md
@@ -1,0 +1,176 @@
+# Google Agent Search direct `:answer` — known-good configuration v0.1
+
+Status: **Validated in Vercel Preview** (2026-06) — do not lose this setup.  
+Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [#213](https://github.com/THUNDERPLUNDER/vox-web/pull/213) (spike PR — **not merged**)
+
+---
+
+## 1. Purpose
+
+Spike whether Viddel can call Google **Discovery Engine** `servingConfigs.answer` directly instead of unstable **CES channel** `runSession` (`/api/chat` → `ces.googleapis.com`).
+
+**Outcome:** Direct `:answer` is **technically viable** in preview when env, IAM, engine ID, and request contract are correct. This doc records the working configuration so we do not repeat the debugging chain (403 IAM → 400 wrong engine → 400 invalid session).
+
+---
+
+## 2. Final working preview result
+
+Observed on preview probe after full fix chain (`/vis/system/agent-search-direct-probe/` → **GET `?run=1`**, 5 calls):
+
+| Metric | Value |
+|--------|--------|
+| Total calls | 5 |
+| Success | 5 |
+| Google errors | 0 |
+| Success rate | **100%** |
+| API HTTP | 200 |
+| `has_answer` | yes |
+| `has_citations` | yes |
+| Note | Google `:answer` OK (GET `?run=1`) |
+
+**Channel baseline (unchanged):** CES `runSession` reliability test **4/16 success (25%)** — [#188](https://github.com/THUNDERPLUNDER/vox-web/issues/188).
+
+---
+
+## 3. Known-good environment (Vercel Preview)
+
+| Variable | Value / rule |
+|----------|----------------|
+| `CES_PROJECT_ID` | `hearing-aid-mvp` |
+| `CES_LOCATION` | `eu` |
+| **`AGENT_SEARCH_ENGINE_ID`** | **`h-rehjelpen-v1-2_1771939983615`** |
+| `CES_APP_ID` | `1741e68d-0528-4625-8b83-99a0dbb5298f` — **CES only**, **not** engine ID |
+| `AGENT_SEARCH_ANSWER_SESSION` | **omitted / default** (`omit`) — single-turn probe |
+| `AGENT_SEARCH_SERVING_CONFIG` | default `default_serving_config` (unset) |
+| `GOOGLE_SERVICE_ACCOUNT_JSON` | same SA as CES (`viddel-ces-run-session@…`) |
+
+**Do not conflate:**
+
+- `CES_APP_ID` → `ces.googleapis.com/.../apps/{id}` + `runSession`
+- `AGENT_SEARCH_ENGINE_ID` → `eu-discoveryengine.googleapis.com/.../engines/{id}/...:answer`
+
+---
+
+## 4. GCP context
+
+| Item | Value |
+|------|--------|
+| Project | `hearing-aid-mvp` |
+| Location | `eu` |
+| AI Applications app | **Hørehjelpen v1.2** |
+| App type | **Search** |
+| Connected data store | **HearingNorwaystore** |
+| Discovery Engine engine ID | `h-rehjelpen-v1-2_1771939983615` |
+
+---
+
+## 5. IAM
+
+| Item | Value |
+|------|--------|
+| Service account | `viddel-ces-run-session@hearing-aid-mvp.iam.gserviceaccount.com` |
+| CES (existing) | `roles/ces.client` (or equivalent for `runSession`) |
+| **Added for `:answer`** | **`roles/discoveryengine.user`** |
+
+Permission required: `discoveryengine.servingConfigs.answer` on the serving config resource.
+
+See [GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md](./GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md).
+
+---
+
+## 6. Request contract (`:answer`)
+
+**Endpoint (EU):**
+
+```
+POST https://eu-discoveryengine.googleapis.com/v1/projects/hearing-aid-mvp/locations/eu/collections/default_collection/engines/h-rehjelpen-v1-2_1771939983615/servingConfigs/default_serving_config:answer
+```
+
+**Body (known-good):**
+
+- `query.text` — user message (probe uses fixed test prompt server-side)
+- `groundingSpec.includeGroundingSupports: true`
+- `answerGenerationSpec` — `includeCitations: true`, adversarial/non-answer flags per spike
+- **`session` — omitted** for single-turn probe (default in code)
+- **Do not use** `session: "-"` (Google returns `Invalid session name: -`)
+
+**Fallback if session required later:** set `AGENT_SEARCH_ANSWER_SESSION=full` → full resource:
+
+```
+projects/hearing-aid-mvp/locations/eu/collections/default_collection/engines/h-rehjelpen-v1-2_1771939983615/sessions/-
+```
+
+Implementation: `src/lib/agent-search-direct.ts` — `buildAnswerRequestBody()`.
+
+Contract audit: [GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md](./GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md).
+
+---
+
+## 7. Preview constraint (Vercel)
+
+| Issue | Mitigation |
+|-------|------------|
+| Deployment Protection blocks **POST** to `/api/agent-search-direct-probe` on preview | Probe runs via **GET `?run=1`** (same JSON envelope, server-side Google call) |
+
+UI: `/vis/system/agent-search-direct-probe/`  
+API: `/api/agent-search-direct-probe` and `/api/agent-search-direct-probe?run=1`
+
+---
+
+## 8. Safe logging rule (mandatory)
+
+Never log or return to clients:
+
+- Prompt / query text (beyond fixed internal probe seed)
+- Answer body / `answerText`
+- Authorization headers or tokens
+- `GOOGLE_SERVICE_ACCOUNT_JSON` or private keys
+- Raw Google response JSON in UI or application logs
+
+Probe and API return **metadata only** (`has_answer`, `has_citations`, `error_code`, `google_error_hint` truncated, duration buckets, etc.).
+
+---
+
+## 9. Troubleshooting
+
+| Symptom / `error_code` | Cause | Fix |
+|------------------------|-------|-----|
+| `google_403` / `PERMISSION_DENIED` … `discoveryengine.servingConfigs.answer` | Missing IAM on SA | Add `roles/discoveryengine.user` on `hearing-aid-mvp` for `viddel-ces-run-session@…` |
+| `google_engine_not_found` / *Cannot fetch Engine for 1741e68d…* | Using **`CES_APP_ID`** as engine ID | Set **`AGENT_SEARCH_ENGINE_ID`** = Discovery Engine `engines/…` ID |
+| `google_invalid_session_name` / *Invalid session name: -* | Bare `"-"` as session | Omit `session` (default) or `AGENT_SEARCH_ANSWER_SESSION=full` |
+| `google_400_bad_request` (other) | Payload field typo | See [contract audit](./GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md) |
+| `configuration_missing` | Missing `AGENT_SEARCH_ENGINE_ID` in Vercel | Set engine ID; redeploy preview |
+| Route 404 | Wrong probe API path | Use `/api/agent-search-direct-probe` (see `agent-search-probe-path.ts`) |
+| POST 403 HTML / non-JSON | Vercel Deployment Protection | Use **GET `?run=1`** from probe UI |
+
+---
+
+## 10. What is **not** decided yet
+
+- **Do not merge #213** until product/backend decision.
+- **Do not switch production** `/api/chat` to direct `:answer` yet.
+- **Do not remove** CES channel backend yet.
+- **Do not activate PostHog** for this spike.
+- **Do not reset** public guard limits until next decision.
+
+**Recommended next step:** Small assessment for optional backend mode:
+
+```bash
+VIDDEL_AI_BACKEND=ces_channel | google_agent_search_direct
+```
+
+Default remains `ces_channel` until QA and ops sign off on stability, session/multi-turn, and production env parity.
+
+Spike overview: [GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md](./GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md).
+
+---
+
+## 11. Debug chain (historical — avoid repeating)
+
+1. Probe route / client bundling → API path fix  
+2. Vercel POST blocked → GET `?run=1`  
+3. `includeGrounding` → `includeGroundingSupports`  
+4. 403 IAM → `roles/discoveryengine.user`  
+5. 400 wrong engine → `AGENT_SEARCH_ENGINE_ID` ≠ `CES_APP_ID`  
+6. 400 invalid session → omit `session`  
+7. **5/5 success** — this document

--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md
@@ -153,11 +153,7 @@ Probe and API return **metadata only** (`has_answer`, `has_citations`, `error_co
 - **Do not activate PostHog** for this spike.
 - **Do not reset** public guard limits until next decision.
 
-**Recommended next step:** Small assessment for optional backend mode:
-
-```bash
-VIDDEL_AI_BACKEND=ces_channel | google_agent_search_direct
-```
+**Recommended next step:** [VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md](./VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md) — optional env switch (`ces_channel` default); no production switch in that doc.
 
 Default remains `ces_channel` until QA and ops sign off on stability, session/multi-turn, and production env parity.
 

--- a/docs/project/GOOGLE_AGENT_SEARCH_ENGINE_RESOURCE_VERIFICATION_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_ENGINE_RESOURCE_VERIFICATION_v0_1.md
@@ -1,0 +1,149 @@
+# Google Agent Search — Engine / ServingConfig resource verification v0.1
+
+Status: **Konklusjon etter IAM-fix + preview QA**  
+Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [IAM audit](./GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md)
+
+---
+
+## 1. Konklusjon (bekreftet av Google)
+
+| Felt | Verdi | API-ressurs |
+|------|--------|-------------|
+| `CES_APP_ID` | `1741e68d-0528-4625-8b83-99a0dbb5298f` | **CES:** `projects/…/locations/eu/**apps**/{id}` |
+| Discovery Engine | **annen ID** | **DE:** `projects/…/locations/eu/collections/default_collection/**engines**/{id}` |
+
+**Google-feil etter IAM-fix:**
+
+```
+INVALID_ARGUMENT — Cannot fetch Engine for: 1741e68d-0528-4625-8b83-99a0dbb5298f
+```
+
+**Tolkning:** IAM (`discoveryengine.servingConfigs.answer`) er OK. Vi har kalt `:answer` med **CES app UUID** som om det var en **engine** — det er feil resource type.
+
+**Direct `:answer` passer ikke dette oppsettet** med kun `CES_APP_ID` — med mindre dere finner en tilhørende Discovery Engine med **egen** engine-ID i GCP.
+
+---
+
+## 2. To parallelle lag (samme GCP-prosjekt, ulik API)
+
+```mermaid
+flowchart LR
+  subgraph ces [CES API]
+    A[apps/1741e68d…]
+    D[deployments/edb2938a…]
+    A --> runSession[runSession 25% QA]
+    D --> runSession
+  end
+  subgraph de [Discovery Engine API]
+    E[engines/????]
+    S[servingConfigs/default_serving_config]
+    E --> answer[:answer direct]
+    S --> answer
+  end
+  ces -.->|ikke samme ID| de
+```
+
+| Lag | Base URL | Headless i Viddel |
+|-----|----------|-------------------|
+| CES | `ces.googleapis.com/v1beta` | `/api/chat` → `runSession` ✅ |
+| Discovery Engine | `eu-discoveryengine.googleapis.com/v1` | Direct `:answer` — krever **AGENT_SEARCH_ENGINE_ID** |
+
+---
+
+## 3. Finn riktig Engine ID (Thomas / GCP)
+
+### A. Console
+
+1. [Google Cloud Console](https://console.cloud.google.com/) → prosjekt **`hearing-aid-mvp`**
+2. **Agent Builder** / **Vertex AI Search** / **Discovery Engine** → **Apps** eller **Engines**
+3. Åpne appen som skal brukes til **søk/svar** (ikke bare CES Agent Studio «API access»-kanal)
+4. Noter resource name — siste segment etter `engines/`:
+
+```
+projects/hearing-aid-mvp/locations/eu/collections/default_collection/engines/{ENGINE_ID}
+```
+
+**Ikke** bruk ID fra `…/apps/1741e68d-…` (CES).
+
+### B. gcloud (liste engines)
+
+```bash
+gcloud discovery-engine engines list \
+  --project=hearing-aid-mvp \
+  --location=eu \
+  --collection=default_collection
+```
+
+Eller REST (med SA eller user token):
+
+```http
+GET https://eu-discoveryengine.googleapis.com/v1/projects/hearing-aid-mvp/locations/eu/collections/default_collection/engines
+```
+
+### C. Sammenlign med CES
+
+| Spørsmål | Forventet |
+|----------|-----------|
+| Er `1741e68d-…` i engine-listen? | **Nei** (preview QA bekrefter via Google) |
+| Finnes annen engine for Viddel? | Noter **den** ID-en |
+| Finnes ingen engine? | Direct `:answer` er **ikke** koblet til CES-appen — behold `runSession` |
+
+---
+
+## 4. ServingConfig for `:answer`
+
+| Config | Bruk |
+|--------|------|
+| **`default_serving_config`** | Anbefalt for `:answer` (offisielle SDK-eksempler) |
+| `default_search` | Ofte brukt i curl for `:answer` på search apps; kan testes via env |
+| `default_agent_answer` | Kun når custom AI_MODE agent engine er satt opp |
+
+**Env:**
+
+```bash
+AGENT_SEARCH_SERVING_CONFIG=default_serving_config   # default i kode
+# AGENT_SEARCH_SERVING_CONFIG=default_search         # alternativ test
+```
+
+**Path (etter engine ID er funnet):**
+
+```
+…/engines/{AGENT_SEARCH_ENGINE_ID}/servingConfigs/{AGENT_SEARCH_SERVING_CONFIG}:answer
+```
+
+---
+
+## 5. Env-endring (repo)
+
+| Variabel | Formål |
+|----------|--------|
+| `CES_APP_ID` | **Kun** CES `runSession` — ikke Discovery Engine |
+| `AGENT_SEARCH_ENGINE_ID` | **Påkrevd** for direct `:answer` / probe |
+| `AGENT_SEARCH_SERVING_CONFIG` | Valgfri override (default `default_serving_config`) |
+| `AGENT_SEARCH_LOCATION` | Valgfri override (default `CES_LOCATION` / `eu`) |
+
+**Kode (fra denne commit):** `resolveAgentSearchEnv()` bruker **ikke** lenger `CES_APP_ID` som fallback til engine.
+
+Sett i **Vercel Preview** (og test deretter):
+
+```
+AGENT_SEARCH_ENGINE_ID=<engine-id-fra-gcp>
+```
+
+---
+
+## 6. Acceptance etter fix
+
+1. `AGENT_SEARCH_ENGINE_ID` satt til ekte engine fra GCP
+2. Preview probe → minst **ett** kall: Google **200**, `has_answer: ja`, `error_code` null
+3. Eller presis konklusjon: **ingen engine** for denne agenten → direct API er ikke riktig spor; fortsett CES channel + vurder fallback (#198)
+
+**Ikke merge #213** før 200 eller skriftlig GCP-konklusjon.
+
+---
+
+## 7. Referanser
+
+- [servingConfigs.answer](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/projects.locations.collections.engines.servingConfigs/answer)
+- [engines.list](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/projects.locations.collections.engines/list)
+- [CES env checklist](./CES_ENV_VERIFICATION_CHECKLIST_v0_1.md)

--- a/docs/project/GOOGLE_AGENT_SEARCH_ENGINE_RESOURCE_VERIFICATION_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_ENGINE_RESOURCE_VERIFICATION_v0_1.md
@@ -1,6 +1,6 @@
 # Google Agent Search — Engine / ServingConfig resource verification v0.1
 
-Status: **Konklusjon etter IAM-fix + preview QA**  
+Status: **Resolved** — working engine ID documented in [known-good](./GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md)  
 Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [IAM audit](./GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md)
 
 ---

--- a/docs/project/GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md
@@ -62,7 +62,7 @@ Fra `src/lib/agent-search-direct.ts` (preview QA `e4401c11`):
 | Project | `hearing-aid-mvp` |
 | Location | `eu` |
 | Collection | `default_collection` |
-| Engine ID | `CES_APP_ID` → `1741e68d-0528-4625-8b83-99a0dbb5298f` (overstyr med `AGENT_SEARCH_ENGINE_ID` hvis annet) |
+| Engine ID | **`AGENT_SEARCH_ENGINE_ID` påkrevd** — `CES_APP_ID` er **ikke** engine (se [engine verification](./GOOGLE_AGENT_SEARCH_ENGINE_RESOURCE_VERIFICATION_v0_1.md)) |
 | Serving config | `default_serving_config` (overstyr med `AGENT_SEARCH_SERVING_CONFIG`) |
 
 **Full resource name (servingConfig i path + IAM-feilmelding):**
@@ -161,27 +161,32 @@ Dette krever mer IAM-arbeid; `roles/discoveryengine.user` er raskest for spike/Q
 
 ---
 
-## 6. Engine / servingConfig (hvis IAM er OK men fortsatt feil)
+## 6. Engine / servingConfig (etter IAM-fix — bekreftet preview QA)
 
-Etter IAM-fix, hvis fortsatt feil:
+Etter `roles/discoveryengine.user`: **403 → 400** `INVALID_ARGUMENT` — *Cannot fetch Engine for: 1741e68d-…*
 
-| Sjekk | Handling |
-|-------|----------|
-| Engine ID ≠ CES app ID | GCP Agent Builder → App → resource name → sett `AGENT_SEARCH_ENGINE_ID` i Vercel |
-| Feil serving config | Prøv `AGENT_SEARCH_SERVING_CONFIG=default_search` (noen curl-eksempler bruker `default_search:answer`) |
-| LLM add-on / edition | Console-feil `LLM_ADDON_NOT_ENABLED` / FailedPrecondition — krever GCP produkt, ikke kode |
+| Sjekk | Konklusjon |
+|-------|------------|
+| IAM på SA | **OK** |
+| `1741e68d-…` som engine | **Feil** — det er `CES_APP_ID` (`apps/…`), ikke `engines/…` |
+| Neste steg | Finn engine-ID i GCP → `AGENT_SEARCH_ENGINE_ID` i Vercel Preview |
 
-403 **PERMISSION_DENIED** på `servingConfigs.answer` matcher **ikke** feil engine (404 mer typisk) og **ikke** LLM add-on (ofte annen status/message).
+Full guide: [GOOGLE_AGENT_SEARCH_ENGINE_RESOURCE_VERIFICATION_v0_1.md](./GOOGLE_AGENT_SEARCH_ENGINE_RESOURCE_VERIFICATION_v0_1.md)
+
+| Videre test | Handling |
+|-------------|----------|
+| Feil serving config | `AGENT_SEARCH_SERVING_CONFIG=default_search` |
+| LLM add-on / edition | `LLM_ADDON_NOT_ENABLED` / FailedPrecondition — GCP produkt |
 
 ---
 
 ## 7. Acceptance etter GCP-fix
 
-1. Preview: `/vis/system/agent-search-direct-probe/` → 5 kall
-2. Minst **ett** kall: Google HTTP **200**, `has_answer: ja`, `error_code` null
-3. Eller ny presis Google-feil (ikke 403 permission) → dokumenter neste steg
+1. Sett **`AGENT_SEARCH_ENGINE_ID`** (ekte engine fra GCP) i Vercel Preview
+2. Preview probe → minst **ett** kall: Google **200**, `has_answer: ja`
+3. Eller konklusjon: ingen engine for denne agenten → direct `:answer` passer ikke CES-only oppsett
 
-**Ikke merge #213** før IAM verifisert og minst ett gyldig 200 **eller** ny GCP-konklusjon.
+**Ikke merge #213** før 200 **eller** skriftlig engine/GCP-konklusjon.
 
 ---
 

--- a/docs/project/GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md
@@ -1,0 +1,193 @@
+# Google Agent Search IAM / resource verification v0.1
+
+Status: **Operator GCP-oppgave** — probe OK, Google svarer **403 PERMISSION_DENIED**.  
+Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [#213](https://github.com/THUNDERPLUNDER/vox-web/pull/213)
+
+---
+
+## 1. Konklusjon (etter QA `e4401c11`)
+
+| Lag | Status |
+|-----|--------|
+| Preview route / GET readiness | OK |
+| Payload contract (400) | **Løst** — Google svarer nå **403**, ikke 400 |
+| **Aktuell blokkering** | **IAM:** `discoveryengine.servingConfigs.answer` denied |
+| Reliability / UI-probe | **Stopp** — ikke videre arbeid her |
+
+**Tolkning:** Samme service account som headless CES (`GOOGLE_SERVICE_ACCOUNT_JSON`) har sannsynligvis **`roles/ces.client`** (eller tilsvarende) for `runSession`, men **mangler Discovery Engine answer-tillatelse** for direct `:answer`.
+
+---
+
+## 2. Hvilken service account preview bruker
+
+| Felt | Verdi |
+|------|--------|
+| Vercel env (Preview + Production) | `GOOGLE_SERVICE_ACCOUNT_JSON` |
+| Samme SA som | `/api/chat` → `runCesSession` (`src/lib/ces-auth.ts`) |
+| Secret | **Aldri** i repo, logger eller probe-output |
+
+### Identifisere `client_email` (uten å dele nøkkel)
+
+**Metode A — lokal checklist (anbefalt):**
+
+```bash
+npm run verify:ces-env -- --env-file=.env.local
+```
+
+Skriver kun: `client_email=<name>@<project>.iam.gserviceaccount.com` (ikke private_key).
+
+**Metode B — Vercel:**
+
+1. [Vercel → vox-web → Settings → Environment Variables](https://vercel.com/raddum-5965s-projects/vox-web/settings/environment-variables)
+2. Filter **Preview** (og Production når relevant)
+3. `GOOGLE_SERVICE_ACCOUNT_JSON` — **ikke** åpne/lim inn i issue; noter kun **client_email** fra JSON-feltet i Vercel UI
+
+**Metode C — GCP IAM:**
+
+1. [IAM → Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts?project=hearing-aid-mvp)
+2. Finn kontoen som brukes til CES headless (samme som i Vercel)
+
+**Dokumenter i issue:** kun e-postadressen, f.eks. `viddel-headless@hearing-aid-mvp.iam.gserviceaccount.com` (eksempel — erstatt med faktisk fra steg over).
+
+---
+
+## 3. Eksakt Google resource path (`:answer`)
+
+Fra `src/lib/agent-search-direct.ts` (preview QA `e4401c11`):
+
+| Segment | Verdi |
+|---------|--------|
+| Host | `https://eu-discoveryengine.googleapis.com` |
+| Method | `POST …:answer` |
+| Project | `hearing-aid-mvp` |
+| Location | `eu` |
+| Collection | `default_collection` |
+| Engine ID | `CES_APP_ID` → `1741e68d-0528-4625-8b83-99a0dbb5298f` (overstyr med `AGENT_SEARCH_ENGINE_ID` hvis annet) |
+| Serving config | `default_serving_config` (overstyr med `AGENT_SEARCH_SERVING_CONFIG`) |
+
+**Full resource name (servingConfig i path + IAM-feilmelding):**
+
+```
+projects/hearing-aid-mvp/locations/eu/collections/default_collection/engines/1741e68d-0528-4625-8b83-99a0dbb5298f/servingConfigs/default_serving_config
+```
+
+**HTTP:**
+
+```
+POST https://eu-discoveryengine.googleapis.com/v1/projects/hearing-aid-mvp/locations/eu/collections/default_collection/engines/1741e68d-0528-4625-8b83-99a0dbb5298f/servingConfigs/default_serving_config:answer
+```
+
+**Merk:** 403 (ikke 404) tyder på at **ressurs-stien gjenkjennes** — primær fix er IAM på SA, ikke path-typo.
+
+---
+
+## 4. IAM — hva som trengs
+
+### Påkrevd permission (fra Google)
+
+- `discoveryengine.servingConfigs.answer` på **servingConfig**-ressursen over  
+- Dokumentasjon: [servingConfigs.answer](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/projects.locations.collections.engines.servingConfigs/answer)
+
+### Hva CES-SA sannsynligvis har i dag
+
+| API | Rolle (typisk) | Permission |
+|-----|----------------|------------|
+| CES `runSession` | `roles/ces.client` | `ces.sessions.runSession` |
+| Discovery `:answer` | **Mangler** | `discoveryengine.servingConfigs.answer` |
+
+Se [CES IAM](https://cloud.google.com/iam/docs/roles-permissions/ces) vs [Discovery Engine IAM](https://cloud.google.com/iam/docs/roles-permissions/discoveryengine).
+
+### Verifisere eksisterende roller (Thomas / gcloud)
+
+Erstatt `SA_EMAIL` med faktisk `client_email`:
+
+```bash
+gcloud projects get-iam-policy hearing-aid-mvp \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:serviceAccount:SA_EMAIL" \
+  --format="table(bindings.role)"
+```
+
+Forventet funn i dag: f.eks. `roles/ces.client` — **uten** `roles/discoveryengine.user` / `roles/discoveryengine.editor`.
+
+Test permission (valgfritt):
+
+```bash
+gcloud auth activate-service-account --key-file=/path/to/key.json   # kun lokalt, ikke del
+gcloud projects get-iam-policy hearing-aid-mvp \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:serviceAccount:SA_EMAIL"
+```
+
+---
+
+## 5. Minste nødvendige IAM-endring (anbefaling)
+
+### Anbefalt (minste forhåndsdefinerte rolle med `:answer`)
+
+Gi **samme service account** som `GOOGLE_SERVICE_ACCOUNT_JSON`:
+
+| Rolle | ID | Inneholder |
+|-------|-----|------------|
+| **Discovery Engine User** | `roles/discoveryengine.user` | `discoveryengine.servingConfigs.answer`, `.search`, `.recommend` |
+
+**Scope:** prosjekt `hearing-aid-mvp` (samme som CES).
+
+```bash
+gcloud projects add-iam-policy-binding hearing-aid-mvp \
+  --member="serviceAccount:SA_EMAIL" \
+  --role="roles/discoveryengine.user" \
+  --condition=None
+```
+
+**Hvorfor ikke bare utvide `roles/ces.client`?** CES-rolle dekker ikke Discovery Engine API — separate produkt-API.
+
+### Strammere alternativ (custom role)
+
+Hvis dere vil unngå bred `discoveryengine.user`:
+
+1. Opprett custom role med kun:
+   - `discoveryengine.servingConfigs.answer`
+   - (ev.) `discoveryengine.servingConfigs.get`
+2. Bind til `SA_EMAIL` på prosjekt eller engine-resource.
+
+Dette krever mer IAM-arbeid; `roles/discoveryengine.user` er raskest for spike/QA.
+
+### Ikke nødvendig for denne feilen
+
+- Ny service account (med mindre dere vil splitte CES vs Discovery)
+- Endre Vercel `CES_APP_ID` kun for IAM — 403 er permission, ikke unknown resource
+- PostHog, backend-bytt, eller ekstern fallback
+
+---
+
+## 6. Engine / servingConfig (hvis IAM er OK men fortsatt feil)
+
+Etter IAM-fix, hvis fortsatt feil:
+
+| Sjekk | Handling |
+|-------|----------|
+| Engine ID ≠ CES app ID | GCP Agent Builder → App → resource name → sett `AGENT_SEARCH_ENGINE_ID` i Vercel |
+| Feil serving config | Prøv `AGENT_SEARCH_SERVING_CONFIG=default_search` (noen curl-eksempler bruker `default_search:answer`) |
+| LLM add-on / edition | Console-feil `LLM_ADDON_NOT_ENABLED` / FailedPrecondition — krever GCP produkt, ikke kode |
+
+403 **PERMISSION_DENIED** på `servingConfigs.answer` matcher **ikke** feil engine (404 mer typisk) og **ikke** LLM add-on (ofte annen status/message).
+
+---
+
+## 7. Acceptance etter GCP-fix
+
+1. Preview: `/vis/system/agent-search-direct-probe/` → 5 kall
+2. Minst **ett** kall: Google HTTP **200**, `has_answer: ja`, `error_code` null
+3. Eller ny presis Google-feil (ikke 403 permission) → dokumenter neste steg
+
+**Ikke merge #213** før IAM verifisert og minst ett gyldig 200 **eller** ny GCP-konklusjon.
+
+---
+
+## 8. Referanser
+
+- [Discovery Engine IAM roles](https://cloud.google.com/iam/docs/roles-permissions/discoveryengine)
+- [Agent Search access control](https://cloud.google.com/generative-ai-app-builder/docs/access-control)
+- [Contract audit](./GOOGLE_AGENT_SEARCH_ANSWER_CONTRACT_AUDIT_v0_1.md)
+- [CES env checklist](./CES_ENV_VERIFICATION_CHECKLIST_v0_1.md)

--- a/docs/project/GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_IAM_VERIFICATION_v0_1.md
@@ -188,6 +188,8 @@ Full guide: [GOOGLE_AGENT_SEARCH_ENGINE_RESOURCE_VERIFICATION_v0_1.md](./GOOGLE_
 
 **Ikke merge #213** før 200 **eller** skriftlig engine/GCP-konklusjon.
 
+**Oppdatert:** Preview 5/5 success med IAM + riktig engine — se [known-good](./GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md).
+
 ---
 
 ## 8. Referanser

--- a/docs/project/VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md
+++ b/docs/project/VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md
@@ -1,0 +1,317 @@
+# Viddel AI backend mode assessment v0.1
+
+Status: **Assessment / spec** — no production switch in this document.  
+Decision driver: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198) — Direct `:answer` **5/5** preview vs CES channel **4/16 (25%)**.  
+Known-good: [GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md](./GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md)  
+Spike PR: [#213](https://github.com/THUNDERPLUNDER/vox-web/pull/213) — **do not merge as production backend change**
+
+---
+
+## Recommendation (executive)
+
+| Question | Answer |
+|----------|--------|
+| Implement `VIDDEL_AI_BACKEND`? | **Yes — small, env-only switch** behind default `ces_channel` |
+| Switch production now? | **No** |
+| Merge #213 to main as-is? | **No** — close or keep open as spike; land **docs-only** (or cherry-pick `docs/` + `.env.example`) first |
+| Next implementation PR | New focused PR: backend router + `runAgentSearchAnswer()` for `/api/chat` only; probe stays preview-only |
+
+**Rationale:** Preview proves direct `:answer` works with documented env/IAM/contract. Channel instability is still the production risk. An env flag allows staged QA and instant rollback without redeploying frontend.
+
+---
+
+## 1. Backend selection model
+
+### Env variable
+
+```bash
+VIDDEL_AI_BACKEND=ces_channel | google_agent_search_direct
+```
+
+| Rule | Behavior |
+|------|----------|
+| **Default** | `ces_channel` when unset, empty, or unknown value |
+| **Parse location** | Server-only in `/api/chat` (and shared resolver in `src/lib/`) |
+| **Invalid value** | Log safe warning (`backend_mode_invalid`), treat as `ces_channel` |
+| **Scope** | Only affects `POST /api/chat` — not probe UI, not CES widget `<chat-messenger>` |
+
+### Resolver (proposed)
+
+```text
+resolveViddelAiBackend(): "ces_channel" | "google_agent_search_direct"
+  → read VIDDEL_AI_BACKEND
+  → normalize + validate
+  → default ces_channel
+```
+
+### Dispatch (proposed)
+
+```text
+POST /api/chat
+  → guard + rate limit (unchanged)
+  → resolve backend mode
+  → ces_channel        → runCesSession(...)
+  → google_agent_search_direct → runAgentSearchAnswer(...)  // new wrapper, not probe handler
+```
+
+Probe path (`/api/agent-search-direct-probe`) remains **preview-only** and **metadata-only** — not wired to `VIDDEL_AI_BACKEND`.
+
+---
+
+## 2. Frontend response contract (preserve)
+
+**Unchanged** JSON for successful chat (`src/pages/api/chat.ts` today):
+
+```json
+{
+  "text": "<string>",
+  "turnCompleted": <boolean>,
+  "turnIndex": <number>
+}
+```
+
+**Unchanged** error shape:
+
+```json
+{
+  "error": "<code>",
+  "message": "<user-facing Norwegian>"
+}
+```
+
+**Request** unchanged: `{ "message": string, "sessionId": string }`.
+
+No new fields in v0.1 response body (citations/support **not** exposed to client yet — see §9).
+
+---
+
+## 3. Default backend
+
+| Environment | Recommended `VIDDEL_AI_BACKEND` |
+|-------------|----------------------------------|
+| Production | **unset** or explicit `ces_channel` |
+| Preview (spike QA) | `google_agent_search_direct` only after dedicated reliability series |
+| Local dev | `ces_channel` unless testing direct |
+
+Production must stay on CES until reliability plan (§7) passes.
+
+---
+
+## 4. Required env per backend
+
+### `ces_channel` (current)
+
+| Variable | Required |
+|----------|----------|
+| `CES_PROJECT_ID` | yes |
+| `CES_LOCATION` | yes |
+| `CES_APP_ID` | yes |
+| `CES_APP_VERSION_ID` | yes (if used by deployment path) |
+| `CES_DEPLOYMENT_ID` | yes |
+| `GOOGLE_SERVICE_ACCOUNT_JSON` | yes |
+
+Resolver: existing `resolveCesEnv()` in `src/lib/ces-env.ts`.
+
+### `google_agent_search_direct`
+
+| Variable | Required |
+|----------|----------|
+| `CES_PROJECT_ID` | yes (project id) |
+| `CES_LOCATION` or `AGENT_SEARCH_LOCATION` | yes (`eu`) |
+| **`AGENT_SEARCH_ENGINE_ID`** | yes — **not** `CES_APP_ID` |
+| `GOOGLE_SERVICE_ACCOUNT_JSON` | yes (same SA; needs `roles/discoveryengine.user`) |
+| `AGENT_SEARCH_SERVING_CONFIG` | optional (default `default_serving_config`) |
+| `AGENT_SEARCH_ANSWER_SESSION` | optional (`omit` default; `full` for multi-turn later) |
+
+`CES_APP_ID` / `CES_DEPLOYMENT_ID` **not** used for direct `:answer` but may remain set for rollback to channel.
+
+**Config guard:** If mode is `google_agent_search_direct` and `AGENT_SEARCH_ENGINE_ID` missing → `503 configuration_missing` (same UX as today).
+
+---
+
+## 5. Rollback behavior
+
+| Mechanism | Action |
+|-----------|--------|
+| **Instant** | Set `VIDDEL_AI_BACKEND=ces_channel` or **remove** var in Vercel → redeploy |
+| **Code path** | `runCesSession` unchanged; no delete in v0.1 |
+| **Failure at runtime** | Map Google errors to same `error` codes as CES where possible (`upstream`, `auth`, `timeout`, `empty_response`) |
+| **Partial outage** | No auto-fallback channel→direct or direct→channel in v0.1 (avoid silent dual-path debugging) |
+
+**Operational rule:** One backend per deploy; flip env, do not run A/B in one instance without explicit ops test header.
+
+---
+
+## 6. Reliability test plan (before production switch)
+
+Minimum bar **before** setting `VIDDEL_AI_BACKEND=google_agent_search_direct` in **Production**:
+
+| Phase | Where | What | Pass criteria |
+|-------|--------|------|----------------|
+| A | Preview | `/api/chat` with mode=direct (not probe) | ≥80% success over **≥20** calls, mixed prompts from reliability seed set |
+| B | Preview | Same + guard limits unchanged | 0 rate_limit false positives |
+| C | Preview | CES channel baseline re-run | Document delta vs 25% baseline |
+| D | Staging/preview | Session/multi-turn if product needs `sessionId` continuity | Define before prod — known-good probe is **single-turn omit session** |
+| E | Production | **Only after A–D** | Ops sign-off + known-good env on Production |
+
+Reuse tooling:
+
+- `scripts/chat-reliability-assessment.mjs` — extend or add `--backend=direct` hitting `/api/chat`
+- `scripts/agent-search-direct-probe.mjs` — stays probe-only; not a substitute for `/api/chat` path test
+
+**Do not** reset `VIDDEL_CHAT_*` guard limits until backend decision is recorded.
+
+---
+
+## 7. Logging / safety constraints
+
+Same rules as spike + production chat today:
+
+| Never log | OK metadata |
+|-----------|-------------|
+| User `message` / prompt | `error_code`, `upstream_http_status`, `duration_bucket` |
+| Answer `text` / `answerText` | `retry_used`, `attempt_count`, `backend_mode` (enum only) |
+| Auth headers / tokens | `session_id_length` (not id value) |
+| `GOOGLE_SERVICE_ACCOUNT_JSON` | `layer: google_agent_search_direct` |
+| Raw Google JSON body | `has_answer`, `has_citations` (booleans), truncated `google_error_hint` in probe only |
+
+`[api/chat]` logs: extend with `backend_mode` field only — no new content fields.
+
+PostHog: **out of scope** — do not activate for this work.
+
+---
+
+## 8. Citations / support metadata mapping
+
+### Google `:answer` (internal only in v0.1)
+
+From `src/lib/agent-search-direct.ts` probe parsers:
+
+| Google / payload | Internal (probe) | `/api/chat` v0.1 |
+|------------------|------------------|------------------|
+| `answer.answerText` | `has_answer` | → `text` |
+| `groundingMetadata` / chunks | `has_citations`, counts | **not exposed** |
+| `supportScore` / retrieval | `support_score` | **not exposed** |
+| `answer.state` | `response_state` | **not exposed** |
+
+### CES channel (today)
+
+| CES | `/api/chat` |
+|-----|-------------|
+| `outputs[0].text` | `text` |
+| `turnCompleted`, `turnIndex` | same |
+| `diagnosticInfo` | **stripped** — never sent to client |
+
+### v0.1 policy
+
+- **Map** `answerText` → `text`; synthesize `turnCompleted: true`, `turnIndex: 0` (or increment if session mapping added later).
+- **Do not** add `citations[]` to public API until product/copy UX is specified.
+- **Do** record `has_citations` in server drift metadata only (optional extension to `chat-usage-metrics.ts`).
+
+### Future (v0.2+)
+
+Optional internal-only or VIS-only citation preview; or structured field behind feature flag — separate issue.
+
+---
+
+## 9. #213 reuse vs spike-only
+
+### Reuse in backend-mode PR (from #213 branch)
+
+| File | Reuse |
+|------|--------|
+| `src/lib/agent-search-direct.ts` | **Yes** — extract `runAgentSearchAnswer(config, { message })` from `runAgentSearchDirectProbeOnce`; shared `buildAnswerRequestBody`, error mapping |
+| `src/lib/ces-auth.ts` | **Yes** — same SA token |
+| `durationBucket` from `ces-run-session.ts` | **Yes** — shared typing |
+| `.env.example` comments | **Yes** — cherry-pick to main |
+| `docs/project/GOOGLE_AGENT_SEARCH_*.md` | **Yes** — docs-only merge/cherry-pick |
+
+### Stay spike-only (do not wire to `/api/chat` without review)
+
+| File | Reason |
+|------|--------|
+| `src/pages/vis/system/agent-search-direct-probe/` | Internal VIS diagnostics |
+| `src/scripts/agent-search-direct-probe-client.ts` | Preview UI |
+| `src/pages/api/agent-search-direct-probe.ts` | GET `?run=1` probe; Deployment Protection workaround |
+| `src/lib/agent-search-probe-handler.ts` | Metadata envelope for probe |
+| `src/lib/agent-search-probe-envelope.ts` | Preview diagnostics |
+| `src/lib/agent-search-probe-path.ts` | Probe path helper |
+
+### New code (backend PR, not #213 merge)
+
+| File | Purpose |
+|------|---------|
+| `src/lib/viddel-ai-backend.ts` | `resolveViddelAiBackend()` |
+| `src/lib/agent-search-answer.ts` (or extend `agent-search-direct.ts`) | Production-safe `runAgentSearchAnswer` with retry/timeout parity to CES |
+| `src/pages/api/chat.ts` | Dispatch on backend mode |
+| Tests / scripts | `chat-reliability` with `--backend` |
+
+---
+
+## 10. Files likely affected (implementation PR)
+
+| Path | Change |
+|------|--------|
+| `src/pages/api/chat.ts` | Backend dispatch |
+| `src/lib/viddel-ai-backend.ts` | **New** — mode resolver |
+| `src/lib/agent-search-direct.ts` | Refactor: shared answer client for chat |
+| `src/lib/ces-run-session.ts` | Unchanged behavior |
+| `src/lib/ces-env.ts` | Unchanged |
+| `src/lib/chat-usage-metrics.ts` | Optional `backend_mode` on drift signals |
+| `.env.example` | `VIDDEL_AI_BACKEND` |
+| `docs/project/VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md` | This doc |
+| `scripts/chat-reliability-assessment.mjs` | Direct mode via `/api/chat` |
+
+**Not in v0.1:** `src/pages/no/chat.astro`, CES widget, PostHog, guard limit env vars.
+
+---
+
+## 11. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Preview 5/5 ≠ production stability | Reliability plan §7 before prod env |
+| Single-turn omit `session` vs chat `sessionId` | Spike session model ≠ CES session; design mapping before prod direct |
+| Wrong engine ID in prod env | Known-good doc + separate `AGENT_SEARCH_ENGINE_ID`; never fallback to `CES_APP_ID` |
+| IAM missing on prod SA | Verify `roles/discoveryengine.user` on Production SA before switch |
+| Dual debugging paths | No auto-fallback; one mode per deploy |
+| #213 merge brings probe to prod | Merge policy: docs-only first; backend PR without VIS probe routes enabled in prod |
+
+---
+
+## 12. #213 disposition
+
+| Option | Recommendation |
+|--------|----------------|
+| **Merge #213 whole to main** | **No** — includes preview probe routes and spike scope |
+| **Close #213 as spike** | **Yes** after docs cherry-pick — link to new implementation issue |
+| **Cherry-pick / docs-only PR** | **Yes** — `docs/project/GOOGLE_AGENT_SEARCH_*.md`, `VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md`, `.env.example` |
+| **Superseded by** | New issue: «Implement VIDDEL_AI_BACKEND v0.1 (default ces_channel)» |
+
+Suggested GitHub flow:
+
+1. Open **docs-only PR** → `main` (known-good + this assessment).
+2. Close **#213** with summary + link to implementation issue.
+3. Implementation PR from fresh branch off `main`, porting `agent-search-direct.ts` logic only.
+
+---
+
+## 13. Out of scope (explicit)
+
+- Production backend switch in this assessment
+- Removing CES channel code
+- PostHog activation
+- External fallback (OpenAI, pgvector, etc.)
+- Resetting `VIDDEL_CHAT_BURST_LIMIT` / `VIDDEL_CHAT_DAILY_LIMIT`
+- Public citation fields in chat API
+- Merging #213 as production change
+
+---
+
+## References
+
+- [GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md](./GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md)
+- [GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md](./GOOGLE_AGENT_SEARCH_DIRECT_API_SPIKE_v0_1.md)
+- [AI_CHAT_RELIABILITY_ASSESSMENT_v0_1.md](./AI_CHAT_RELIABILITY_ASSESSMENT_v0_1.md)
+- `src/pages/api/chat.ts` — current contract
+- `src/lib/agent-search-direct.ts` — probe implementation to refactor

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vis:github:runtime-status": "node scripts/generate-github-runtime-status.mjs",
     "vis:github:snapshot": "node scripts/vis-github-live-snapshot.mjs",
     "chat:reliability": "node scripts/chat-reliability-assessment.mjs",
+    "agent-search:probe": "node scripts/agent-search-direct-probe.mjs",
     "verify:ces-env": "node scripts/verify-ces-env-checklist.mjs"
   },
   "dependencies": {

--- a/scripts/agent-search-direct-probe.mjs
+++ b/scripts/agent-search-direct-probe.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/* CONTRACT: Safe Agent Search direct API probe — metadata only, no prompt/answer logging. */
+
+import { createSign } from "node:crypto";
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_COUNT = 5;
+const DEFAULT_DELAY_MS = 8_000;
+const COLLECTION = "default_collection";
+const ANSWER_SERVING = "default_serving_config";
+
+/** Fixed prompts — internal only; never written to output. */
+const SEED_PROMPTS = [
+  "Hvordan kobler jeg høreapparatet til mobilen?",
+  "Hvorfor blir lyden så slitsom på restaurant?",
+  "Hva gjør jeg når appen ikke finner høreapparatet?",
+  "Hvordan vet jeg om jeg bør kontakte audiograf?",
+  "Hva kan jeg prøve hvis lyden fra TV-en blir utydelig?",
+];
+
+function loadEnvFile(path) {
+  if (!existsSync(path)) return {};
+  const env = {};
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq);
+    let val = trimmed.slice(eq + 1);
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    env[key] = val;
+  }
+  return env;
+}
+
+function parseArgs(argv) {
+  const args = {
+    count: DEFAULT_COUNT,
+    delayMs: DEFAULT_DELAY_MS,
+    out: "",
+    envFile: "",
+    location: "",
+    engineId: "",
+  };
+  for (const arg of argv) {
+    if (arg.startsWith("--count=")) args.count = Number(arg.slice(8));
+    else if (arg.startsWith("--delay-ms=")) args.delayMs = Number(arg.slice(11));
+    else if (arg.startsWith("--out=")) args.out = arg.slice(6);
+    else if (arg.startsWith("--env-file=")) args.envFile = arg.slice(11);
+    else if (arg.startsWith("--location=")) args.location = arg.slice(11);
+    else if (arg.startsWith("--engine-id=")) args.engineId = arg.slice(12);
+  }
+  return args;
+}
+
+function durationBucket(ms) {
+  if (ms < 1000) return "<1s";
+  if (ms < 3000) return "1-3s";
+  if (ms < 8000) return "3-8s";
+  if (ms < 20000) return "8-20s";
+  return ">20s";
+}
+
+function discoveryHost(location) {
+  const loc = String(location ?? "").trim().toLowerCase();
+  if (loc === "eu") return "https://eu-discoveryengine.googleapis.com";
+  if (loc === "us") return "https://us-discoveryengine.googleapis.com";
+  return "https://discoveryengine.googleapis.com";
+}
+
+function readProbeEnv(fileEnv) {
+  const merged = { ...fileEnv };
+  for (const key of [
+    "CES_PROJECT_ID",
+    "CES_LOCATION",
+    "CES_APP_ID",
+    "GOOGLE_SERVICE_ACCOUNT_JSON",
+    "AGENT_SEARCH_ENGINE_ID",
+    "AGENT_SEARCH_LOCATION",
+  ]) {
+    if (process.env[key]?.trim()) merged[key] = process.env[key].trim();
+  }
+  const projectId = merged.CES_PROJECT_ID?.trim() ?? "";
+  const location = (merged.AGENT_SEARCH_LOCATION ?? merged.CES_LOCATION ?? "").trim();
+  const engineId = (merged.AGENT_SEARCH_ENGINE_ID ?? merged.CES_APP_ID ?? "").trim();
+  const saJson = merged.GOOGLE_SERVICE_ACCOUNT_JSON?.trim() ?? "";
+  const missing = [];
+  if (!projectId) missing.push("CES_PROJECT_ID");
+  if (!location) missing.push("CES_LOCATION or AGENT_SEARCH_LOCATION");
+  if (!engineId) missing.push("CES_APP_ID or AGENT_SEARCH_ENGINE_ID");
+  if (!saJson) missing.push("GOOGLE_SERVICE_ACCOUNT_JSON");
+  return { projectId, location, engineId, saJson, missing };
+}
+
+async function getGoogleAccessToken(serviceAccountJson) {
+  const parsed = JSON.parse(serviceAccountJson);
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      iss: parsed.client_email,
+      sub: parsed.client_email,
+      aud: "https://oauth2.googleapis.com/token",
+      iat: now,
+      exp: now + 3600,
+      scope: "https://www.googleapis.com/auth/cloud-platform",
+    }),
+  ).toString("base64url");
+  const signInput = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signInput);
+  signer.end();
+  const signature = signer.sign(parsed.private_key, "base64url");
+  const assertion = `${signInput}.${signature}`;
+
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+  if (!response.ok) throw new Error(`auth_${response.status}`);
+  const body = await response.json();
+  if (!body.access_token) throw new Error("auth_no_token");
+  return body.access_token;
+}
+
+function buildAnswerUrl(host, projectId, location, engineId) {
+  const resource = `projects/${projectId}/locations/${location}/collections/${COLLECTION}/engines/${engineId}/servingConfigs/${ANSWER_SERVING}`;
+  return `${host}/v1/${resource}:answer`;
+}
+
+function countCitations(payload) {
+  const answer = payload?.answer ?? payload;
+  const chunks =
+    answer?.groundingMetadata?.groundingChunks ??
+    answer?.groundingAttributions ??
+    answer?.citations ??
+    [];
+  return Array.isArray(chunks) ? chunks.length : 0;
+}
+
+function extractSupportScore(payload) {
+  const answer = payload?.answer ?? payload;
+  const candidates = [
+    answer?.groundingMetadata?.supportScore,
+    answer?.groundingMetadata?.retrievalScore,
+    answer?.supportScore,
+  ];
+  for (const v of candidates) {
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+function extractResponseState(payload) {
+  const answer = payload?.answer ?? payload;
+  const state = answer?.state ?? answer?.answerState ?? null;
+  return typeof state === "string" ? state : null;
+}
+
+function hasAnswerText(payload) {
+  const answer = payload?.answer ?? payload;
+  const text = answer?.answerText ?? answer?.text ?? "";
+  return typeof text === "string" && text.trim().length > 0;
+}
+
+async function callAgentSearchAnswer({ host, projectId, location, engineId, token, message }) {
+  const started = performance.now();
+  const url = buildAnswerUrl(host, projectId, location, engineId);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      query: { text: message },
+      session: "-",
+      groundingSpec: { includeGrounding: true },
+      answerGenerationSpec: {
+        ignoreAdversarialQuery: true,
+        ignoreNonAnswerSeekingQuery: false,
+      },
+    }),
+  });
+  const durationMs = Math.round(performance.now() - started);
+  let payload = {};
+  if (response.ok) {
+    payload = await response.json().catch(() => ({}));
+  } else {
+    const errText = await response.text().catch(() => "");
+    const codeMatch = errText.match(/"code"\s*:\s*(\d+)/);
+    payload = { _errorSnippet: errText.slice(0, 200) };
+    if (codeMatch) payload._parsedCode = Number(codeMatch[1]);
+  }
+
+  const ok = response.ok && hasAnswerText(payload);
+  return {
+    status: ok ? "success" : "error",
+    error_code: ok ? null : response.ok ? "empty_response" : "upstream",
+    upstream_http_status: response.status,
+    duration_ms: durationMs,
+    duration_bucket: durationBucket(durationMs),
+    response_state: extractResponseState(payload),
+    has_answer: hasAnswerText(payload),
+    has_citations: countCitations(payload) > 0,
+    citation_count: countCitations(payload),
+    support_score: extractSupportScore(payload),
+  };
+}
+
+function summarize(results) {
+  const total = results.length;
+  const success = results.filter((r) => r.status === "success").length;
+  const upstream = results.filter((r) => r.error_code === "upstream").length;
+  const empty = results.filter((r) => r.error_code === "empty_response").length;
+  return {
+    total,
+    success,
+    upstream,
+    empty_response: empty,
+    success_rate_pct: total ? Math.round((success / total) * 100) : 0,
+    with_citations: results.filter((r) => r.has_citations).length,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const fileEnv = args.envFile ? loadEnvFile(args.envFile) : {};
+  const env = readProbeEnv(fileEnv);
+  if (args.location) env.location = args.location;
+  if (args.engineId) env.engineId = args.engineId;
+
+  if (env.missing.length) {
+    console.error(
+      JSON.stringify({
+        ok: false,
+        reason: "missing_env",
+        missing: env.missing,
+        hint: "Use --env-file=.env.local or set CES_* + GOOGLE_SERVICE_ACCOUNT_JSON",
+      }),
+    );
+    process.exit(2);
+  }
+
+  const host = discoveryHost(env.location);
+  const token = await getGoogleAccessToken(env.saJson);
+  const results = [];
+
+  for (let i = 0; i < args.count; i += 1) {
+    const message = SEED_PROMPTS[i % SEED_PROMPTS.length];
+    const row = await callAgentSearchAnswer({
+      host,
+      projectId: env.projectId,
+      location: env.location,
+      engineId: env.engineId,
+      token,
+      message,
+    });
+    results.push({ n: i + 1, ...row });
+    console.log(JSON.stringify({ event: "probe_call", n: i + 1, ...row }));
+    if (i < args.count - 1 && args.delayMs > 0) {
+      await new Promise((r) => setTimeout(r, args.delayMs));
+    }
+  }
+
+  const report = {
+    ok: true,
+    api: "discoveryengine.servingConfigs.answer",
+    host,
+    project_id: env.projectId,
+    location: env.location,
+    engine_id: env.engineId,
+    serving_config: ANSWER_SERVING,
+    count: args.count,
+    delay_ms: args.delayMs,
+    summary: summarize(results),
+    results,
+    note: "No prompts or answer text logged. Compare with CES runSession reliability series.",
+  };
+
+  if (args.out) {
+    mkdirSync(dirname(args.out), { recursive: true });
+    writeFileSync(args.out, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  console.log(JSON.stringify({ event: "probe_summary", ...report.summary }));
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ ok: false, reason: "probe_failed", message: String(err?.message ?? err) }));
+  process.exit(1);
+});

--- a/scripts/agent-search-direct-probe.mjs
+++ b/scripts/agent-search-direct-probe.mjs
@@ -84,6 +84,7 @@ function readProbeEnv(fileEnv) {
     "GOOGLE_SERVICE_ACCOUNT_JSON",
     "AGENT_SEARCH_ENGINE_ID",
     "AGENT_SEARCH_LOCATION",
+    "AGENT_SEARCH_ANSWER_SESSION",
   ]) {
     if (process.env[key]?.trim()) merged[key] = process.env[key].trim();
   }
@@ -96,7 +97,7 @@ function readProbeEnv(fileEnv) {
   if (!location) missing.push("CES_LOCATION or AGENT_SEARCH_LOCATION");
   if (!engineId) missing.push("AGENT_SEARCH_ENGINE_ID");
   if (!saJson) missing.push("GOOGLE_SERVICE_ACCOUNT_JSON");
-  return { projectId, location, engineId, saJson, missing };
+  return { projectId, location, engineId, saJson, missing, merged };
 }
 
 async function getGoogleAccessToken(serviceAccountJson) {
@@ -174,7 +175,31 @@ function hasAnswerText(payload) {
   return typeof text === "string" && text.trim().length > 0;
 }
 
-async function callAgentSearchAnswer({ host, projectId, location, engineId, token, message }) {
+function resolveAnswerSessionMode(env) {
+  const raw = String(env.AGENT_SEARCH_ANSWER_SESSION ?? "").trim().toLowerCase();
+  return raw === "full" ? "full" : "omit";
+}
+
+function buildAnswerSessionResource(projectId, location, engineId) {
+  return `projects/${projectId}/locations/${location}/collections/${COLLECTION}/engines/${engineId}/sessions/-`;
+}
+
+function buildAnswerRequestBody({ projectId, location, engineId, message, env }) {
+  const body = {
+    query: { text: message },
+    groundingSpec: { includeGroundingSupports: true },
+    answerGenerationSpec: {
+      ignoreAdversarialQuery: true,
+      ignoreNonAnswerSeekingQuery: false,
+    },
+  };
+  if (resolveAnswerSessionMode(env) === "full") {
+    body.session = buildAnswerSessionResource(projectId, location, engineId);
+  }
+  return body;
+}
+
+async function callAgentSearchAnswer({ host, projectId, location, engineId, token, message, env }) {
   const started = performance.now();
   const url = buildAnswerUrl(host, projectId, location, engineId);
   const response = await fetch(url, {
@@ -183,15 +208,7 @@ async function callAgentSearchAnswer({ host, projectId, location, engineId, toke
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json; charset=utf-8",
     },
-    body: JSON.stringify({
-      query: { text: message },
-      session: "-",
-      groundingSpec: { includeGroundingSupports: true },
-      answerGenerationSpec: {
-        ignoreAdversarialQuery: true,
-        ignoreNonAnswerSeekingQuery: false,
-      },
-    }),
+    body: JSON.stringify(buildAnswerRequestBody({ projectId, location, engineId, message, env })),
   });
   const durationMs = Math.round(performance.now() - started);
   let payload = {};
@@ -266,6 +283,7 @@ async function main() {
       engineId: env.engineId,
       token,
       message,
+      env: env.merged,
     });
     results.push({ n: i + 1, ...row });
     console.log(JSON.stringify({ event: "probe_call", n: i + 1, ...row }));

--- a/scripts/agent-search-direct-probe.mjs
+++ b/scripts/agent-search-direct-probe.mjs
@@ -186,7 +186,7 @@ async function callAgentSearchAnswer({ host, projectId, location, engineId, toke
     body: JSON.stringify({
       query: { text: message },
       session: "-",
-      groundingSpec: { includeGrounding: true },
+      groundingSpec: { includeGroundingSupports: true },
       answerGenerationSpec: {
         ignoreAdversarialQuery: true,
         ignoreNonAnswerSeekingQuery: false,

--- a/scripts/agent-search-direct-probe.mjs
+++ b/scripts/agent-search-direct-probe.mjs
@@ -89,12 +89,12 @@ function readProbeEnv(fileEnv) {
   }
   const projectId = merged.CES_PROJECT_ID?.trim() ?? "";
   const location = (merged.AGENT_SEARCH_LOCATION ?? merged.CES_LOCATION ?? "").trim();
-  const engineId = (merged.AGENT_SEARCH_ENGINE_ID ?? merged.CES_APP_ID ?? "").trim();
+  const engineId = (merged.AGENT_SEARCH_ENGINE_ID ?? "").trim();
   const saJson = merged.GOOGLE_SERVICE_ACCOUNT_JSON?.trim() ?? "";
   const missing = [];
   if (!projectId) missing.push("CES_PROJECT_ID");
   if (!location) missing.push("CES_LOCATION or AGENT_SEARCH_LOCATION");
-  if (!engineId) missing.push("CES_APP_ID or AGENT_SEARCH_ENGINE_ID");
+  if (!engineId) missing.push("AGENT_SEARCH_ENGINE_ID");
   if (!saJson) missing.push("GOOGLE_SERVICE_ACCOUNT_JSON");
   return { projectId, location, engineId, saJson, missing };
 }

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -77,7 +77,7 @@ export const mvpCurrentState = {
   } satisfies CurrentSprint,
   closedSprints: [] satisfies ClosedSprint[],
   currentFocus:
-    "Monitoring levert (#188). Reliability-test via Vercel guard-limits (100/500 midlertidig) — ikke lokal token. Fallback ved behov.",
+    "#188: CES channel ~25% success. #198: Google Agent Search direct API spike (før ekstern fallback). Guard 100/500 til beslutning.",
   mvpSurfaces: [
     {
       id: "frontpage",
@@ -111,7 +111,7 @@ export const mvpCurrentState = {
       label: "Spør Viddel",
       route: "/no/chat/",
       status: "Applied",
-      note: "Live i production. Public guard aktiv — grenser justerbare i Vercel for pre-pilot CES-test (#188).",
+      note: "CES channel ustabil (25%). #198 tester Agent Search answer API direkte. Guard 100/500 midlertidig (#188).",
       visFrontpage: true,
       kind: "public",
       frontpageDescription: "Headless AI-chat — live (intern test). Public guard aktiv.",

--- a/src/data/vis-runtime-feed.ts
+++ b/src/data/vis-runtime-feed.ts
@@ -41,36 +41,36 @@ export type VisRuntimeFeed = {
 
 /** Manually updated after important Return Tickets — not synced from GitHub. */
 export const visRuntimeFeed = {
-  updatedAt: "2026-06-02",
+  updatedAt: "2026-06-04",
   activeNow: [
     {
       id: "ai-usage-monitoring-v01",
       headline:
-        "Vi forenkler reliability-test ved å styre public guard-grenser fra Vercel.",
+        "Vi tester om Googles dokumenterte Agent Search API er mer stabilt enn channel-laget vi først brukte.",
       workTitle: "AI usage monitoring v0.1 (#188)",
       area: "Data, monitoring og innsikt",
       why:
         "Vi må se om chatten virker, om den feiler, og hvilke innganger som brukes — uten å lagre spørsmål eller svar.",
       status:
-        "Monitoring og guard v0.2 er levert. Nå kan Thomas midlertidig heve burst/daily limits i Vercel (100/500) og kjøre reliability-test uten lokal token.",
+        "To reliability-serier (16 kall, guard 100/500): 25% success, 0 rate_limit, 75% upstream. Guard og testoppsett OK — CES er flaskehalsen.",
       possibleSolution:
-        "VIDDEL_CHAT_BURST_LIMIT og VIDDEL_CHAT_DAILY_LIMIT i Vercel — public guard forblir aktiv.",
+        "Google Agent Search direct API spike (#198): assessment + trygg probe, før evt. ekstern fallback.",
       nextDecision:
-        "Thomas setter høyere limits, redeployer, Cursor kjører reliability-test. Vurder CES — deretter fallback-spike ved behov.",
+        "Kjør agent-search:probe lokalt med SA. Hvis stabil → optional VIDDEL_AI_BACKEND. Guard 100/500 til beslutning.",
       issue: "#188",
       issueLink: "https://github.com/THUNDERPLUNDER/vox-web/issues/188",
       progressSteps: [
         { id: "monitoring", label: "Monitoring levert", state: "done" },
-        { id: "guard-env", label: "Guard limits via Vercel", state: "current" },
-        { id: "ces-test", label: "Ren CES-test", state: "upcoming" },
-        { id: "fallback", label: "Fallback ved behov", state: "upcoming" },
+        { id: "guard-env", label: "Guard limits via Vercel", state: "done" },
+        { id: "ces-test", label: "Ren CES-test (2 serier)", state: "done" },
+        { id: "agent-search", label: "Agent Search direct #198", state: "current" },
       ],
     },
   ],
   recentlyCompletedSummary:
-    "Guard strategy v0.2 (#199) merged. INT-007 Anne-spor registrert i gitbuss (#200–#204).",
+    "Guard limits via Vercel (#212) og to rene CES-serier — 25% success, upstream dominant.",
   lastReturnTicketSummary:
-    "Guard limits via Vercel env v0.1 — reliability-test uten lokal ops-token.",
+    "Kontrollserie 25% — #198 er Google Agent Search direct API spike (ikke ekstern fallback ennå). Ingen flere channel-serier.",
   links: {
     primary: [
       {

--- a/src/lib/agent-search-direct.ts
+++ b/src/lib/agent-search-direct.ts
@@ -30,12 +30,19 @@ export type AgentSearchProbeErrorCode =
   | "timeout"
   | "configuration_missing"
   | "google_400_bad_request"
+  | "google_engine_not_found"
   | "google_403"
   | "google_404"
   | "google_502";
 
-export function mapGoogleUpstreamErrorCode(httpStatus: number): AgentSearchProbeErrorCode {
-  if (httpStatus === 400) return "google_400_bad_request";
+export function mapGoogleUpstreamErrorCode(
+  httpStatus: number,
+  hint: string | null = null,
+): AgentSearchProbeErrorCode {
+  if (httpStatus === 400) {
+    if (hint?.includes("Cannot fetch Engine")) return "google_engine_not_found";
+    return "google_400_bad_request";
+  }
   if (httpStatus === 403) return "google_403";
   if (httpStatus === 404) return "google_404";
   if (httpStatus === 502 || httpStatus === 503 || httpStatus === 504) return "google_502";
@@ -76,14 +83,14 @@ export function discoveryHost(location: string): string {
 export function resolveAgentSearchEnv(): AgentSearchEnvResult {
   const projectId = readEnv("CES_PROJECT_ID");
   const location = readEnv("AGENT_SEARCH_LOCATION") || readEnv("CES_LOCATION");
-  const engineId = readEnv("AGENT_SEARCH_ENGINE_ID") || readEnv("CES_APP_ID");
+  const engineId = readEnv("AGENT_SEARCH_ENGINE_ID");
   const serviceAccountJson = readEnv("GOOGLE_SERVICE_ACCOUNT_JSON");
   const servingConfig = readEnv("AGENT_SEARCH_SERVING_CONFIG") || DEFAULT_ANSWER_SERVING;
 
   const missing: string[] = [];
   if (!projectId) missing.push("CES_PROJECT_ID");
   if (!location) missing.push("CES_LOCATION or AGENT_SEARCH_LOCATION");
-  if (!engineId) missing.push("CES_APP_ID or AGENT_SEARCH_ENGINE_ID");
+  if (!engineId) missing.push("AGENT_SEARCH_ENGINE_ID");
   if (!serviceAccountJson) missing.push("GOOGLE_SERVICE_ACCOUNT_JSON");
 
   if (missing.length > 0) {
@@ -241,7 +248,7 @@ export async function runAgentSearchDirectProbeOnce(
         ? null
         : response.ok
           ? "empty_response"
-          : mapGoogleUpstreamErrorCode(response.status),
+          : mapGoogleUpstreamErrorCode(response.status, safeErr.hint),
       upstream_http_status: response.status,
       google_rpc_status: safeErr.rpc_status,
       google_error_hint: safeErr.hint,

--- a/src/lib/agent-search-direct.ts
+++ b/src/lib/agent-search-direct.ts
@@ -1,0 +1,219 @@
+/* CONTRACT: Server-only Agent Search :answer client — metadata only, no prompt/answer logging. */
+
+import { getGoogleAccessToken } from "./ces-auth";
+import { durationBucket, type DurationBucket } from "./ces-run-session";
+
+const COLLECTION = "default_collection";
+const ANSWER_SERVING = "default_serving_config";
+const FETCH_TIMEOUT_MS = 25_000;
+
+/** Fixed test input — never logged or returned to clients. */
+export const AGENT_SEARCH_PROBE_TEST_MESSAGE =
+  "Hva gjør jeg når appen ikke finner høreapparatet?";
+
+export type AgentSearchEnvConfig = {
+  projectId: string;
+  location: string;
+  engineId: string;
+  serviceAccountJson: string;
+};
+
+export type AgentSearchEnvResult =
+  | { ok: true; config: AgentSearchEnvConfig }
+  | { ok: false; missing: string[] };
+
+export type AgentSearchProbeErrorCode =
+  | "upstream"
+  | "empty_response"
+  | "auth"
+  | "timeout"
+  | "configuration_missing";
+
+export type AgentSearchProbeMetadata = {
+  status: "success" | "error";
+  error_code: AgentSearchProbeErrorCode | null;
+  upstream_http_status: number | null;
+  duration_bucket: DurationBucket;
+  has_answer: boolean;
+  has_citations: boolean;
+  support_score: number | null;
+  response_state: string | null;
+  layer: "google_agent_search_direct";
+  method: "discoveryengine.servingConfigs.answer";
+  endpoint_host: string;
+  serving_config: string;
+  location: string;
+  project_id: string;
+  engine_id: string;
+};
+
+function readEnv(name: string): string {
+  return (process.env[name] ?? import.meta.env[name] ?? "").trim();
+}
+
+export function discoveryHost(location: string): string {
+  const loc = location.trim().toLowerCase();
+  if (loc === "eu") return "https://eu-discoveryengine.googleapis.com";
+  if (loc === "us") return "https://us-discoveryengine.googleapis.com";
+  return "https://discoveryengine.googleapis.com";
+}
+
+export function resolveAgentSearchEnv(): AgentSearchEnvResult {
+  const projectId = readEnv("CES_PROJECT_ID");
+  const location = readEnv("AGENT_SEARCH_LOCATION") || readEnv("CES_LOCATION");
+  const engineId = readEnv("AGENT_SEARCH_ENGINE_ID") || readEnv("CES_APP_ID");
+  const serviceAccountJson = readEnv("GOOGLE_SERVICE_ACCOUNT_JSON");
+
+  const missing: string[] = [];
+  if (!projectId) missing.push("CES_PROJECT_ID");
+  if (!location) missing.push("CES_LOCATION or AGENT_SEARCH_LOCATION");
+  if (!engineId) missing.push("CES_APP_ID or AGENT_SEARCH_ENGINE_ID");
+  if (!serviceAccountJson) missing.push("GOOGLE_SERVICE_ACCOUNT_JSON");
+
+  if (missing.length > 0) {
+    return { ok: false, missing };
+  }
+
+  return {
+    ok: true,
+    config: { projectId, location, engineId, serviceAccountJson },
+  };
+}
+
+function buildAnswerUrl(host: string, config: AgentSearchEnvConfig): string {
+  const resource = `projects/${config.projectId}/locations/${config.location}/collections/${COLLECTION}/engines/${config.engineId}/servingConfigs/${ANSWER_SERVING}`;
+  return `${host}/v1/${resource}:answer`;
+}
+
+function countCitations(payload: Record<string, unknown>): number {
+  const answer = (payload.answer ?? payload) as Record<string, unknown>;
+  const grounding = answer.groundingMetadata as Record<string, unknown> | undefined;
+  const chunks =
+    grounding?.groundingChunks ?? answer.groundingAttributions ?? answer.citations ?? [];
+  return Array.isArray(chunks) ? chunks.length : 0;
+}
+
+function extractSupportScore(payload: Record<string, unknown>): number | null {
+  const answer = (payload.answer ?? payload) as Record<string, unknown>;
+  const grounding = answer.groundingMetadata as Record<string, unknown> | undefined;
+  const candidates = [grounding?.supportScore, grounding?.retrievalScore, answer.supportScore];
+  for (const v of candidates) {
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+function extractResponseState(payload: Record<string, unknown>): string | null {
+  const answer = (payload.answer ?? payload) as Record<string, unknown>;
+  const state = answer.state ?? answer.answerState;
+  return typeof state === "string" ? state : null;
+}
+
+function hasAnswerText(payload: Record<string, unknown>): boolean {
+  const answer = (payload.answer ?? payload) as Record<string, unknown>;
+  const text = answer.answerText ?? answer.text ?? "";
+  return typeof text === "string" && text.trim().length > 0;
+}
+
+/** One direct :answer call — never logs message or answer body. */
+export async function runAgentSearchDirectProbeOnce(
+  config: AgentSearchEnvConfig,
+): Promise<AgentSearchProbeMetadata> {
+  const host = discoveryHost(config.location);
+  const endpoint_host = host;
+  const started = Date.now();
+  let token: string;
+
+  try {
+    token = await getGoogleAccessToken(config.serviceAccountJson);
+  } catch {
+    return {
+      status: "error",
+      error_code: "auth",
+      upstream_http_status: null,
+      duration_bucket: durationBucket(Date.now() - started),
+      has_answer: false,
+      has_citations: false,
+      support_score: null,
+      response_state: null,
+      layer: "google_agent_search_direct",
+      method: "discoveryengine.servingConfigs.answer",
+      endpoint_host,
+      serving_config: ANSWER_SERVING,
+      location: config.location,
+      project_id: config.projectId,
+      engine_id: config.engineId,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(buildAnswerUrl(host, config), {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        query: { text: AGENT_SEARCH_PROBE_TEST_MESSAGE },
+        session: "-",
+        groundingSpec: { includeGrounding: true },
+        answerGenerationSpec: {
+          ignoreAdversarialQuery: true,
+          ignoreNonAnswerSeekingQuery: false,
+        },
+      }),
+    });
+
+    let payload: Record<string, unknown> = {};
+    if (response.ok) {
+      payload = ((await response.json().catch(() => ({}))) ?? {}) as Record<string, unknown>;
+    }
+
+    const ok = response.ok && hasAnswerText(payload);
+    const durationMs = Date.now() - started;
+
+    return {
+      status: ok ? "success" : "error",
+      error_code: ok ? null : response.ok ? "empty_response" : "upstream",
+      upstream_http_status: response.status,
+      duration_bucket: durationBucket(durationMs),
+      has_answer: hasAnswerText(payload),
+      has_citations: countCitations(payload) > 0,
+      support_score: extractSupportScore(payload),
+      response_state: extractResponseState(payload),
+      layer: "google_agent_search_direct",
+      method: "discoveryengine.servingConfigs.answer",
+      endpoint_host,
+      serving_config: ANSWER_SERVING,
+      location: config.location,
+      project_id: config.projectId,
+      engine_id: config.engineId,
+    };
+  } catch (err) {
+    const durationMs = Date.now() - started;
+    const isAbort = err instanceof Error && err.name === "AbortError";
+    return {
+      status: "error",
+      error_code: isAbort ? "timeout" : "upstream",
+      upstream_http_status: null,
+      duration_bucket: durationBucket(durationMs),
+      has_answer: false,
+      has_citations: false,
+      support_score: null,
+      response_state: null,
+      layer: "google_agent_search_direct",
+      method: "discoveryengine.servingConfigs.answer",
+      endpoint_host,
+      serving_config: ANSWER_SERVING,
+      location: config.location,
+      project_id: config.projectId,
+      engine_id: config.engineId,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/lib/agent-search-direct.ts
+++ b/src/lib/agent-search-direct.ts
@@ -27,7 +27,17 @@ export type AgentSearchProbeErrorCode =
   | "empty_response"
   | "auth"
   | "timeout"
-  | "configuration_missing";
+  | "configuration_missing"
+  | "google_403"
+  | "google_404"
+  | "google_502";
+
+export function mapGoogleUpstreamErrorCode(httpStatus: number): AgentSearchProbeErrorCode {
+  if (httpStatus === 403) return "google_403";
+  if (httpStatus === 404) return "google_404";
+  if (httpStatus === 502 || httpStatus === 503 || httpStatus === 504) return "google_502";
+  return "upstream";
+}
 
 export type AgentSearchProbeMetadata = {
   status: "success" | "error";
@@ -178,7 +188,11 @@ export async function runAgentSearchDirectProbeOnce(
 
     return {
       status: ok ? "success" : "error",
-      error_code: ok ? null : response.ok ? "empty_response" : "upstream",
+      error_code: ok
+        ? null
+        : response.ok
+          ? "empty_response"
+          : mapGoogleUpstreamErrorCode(response.status),
       upstream_http_status: response.status,
       duration_bucket: durationBucket(durationMs),
       has_answer: hasAnswerText(payload),

--- a/src/lib/agent-search-direct.ts
+++ b/src/lib/agent-search-direct.ts
@@ -31,9 +31,12 @@ export type AgentSearchProbeErrorCode =
   | "configuration_missing"
   | "google_400_bad_request"
   | "google_engine_not_found"
+  | "google_invalid_session_name"
   | "google_403"
   | "google_404"
   | "google_502";
+
+export type AgentSearchAnswerSessionMode = "omit" | "full";
 
 export function mapGoogleUpstreamErrorCode(
   httpStatus: number,
@@ -41,6 +44,7 @@ export function mapGoogleUpstreamErrorCode(
 ): AgentSearchProbeErrorCode {
   if (httpStatus === 400) {
     if (hint?.includes("Cannot fetch Engine")) return "google_engine_not_found";
+    if (hint?.includes("Invalid session name")) return "google_invalid_session_name";
     return "google_400_bad_request";
   }
   if (httpStatus === 403) return "google_403";
@@ -108,11 +112,21 @@ function buildAnswerUrl(host: string, config: AgentSearchEnvConfig): string {
   return `${host}/v1/${resource}:answer`;
 }
 
+/** Preview probe default: omit session. Override with AGENT_SEARCH_ANSWER_SESSION=full. */
+export function resolveAnswerSessionMode(): AgentSearchAnswerSessionMode {
+  const raw = readEnv("AGENT_SEARCH_ANSWER_SESSION").toLowerCase();
+  return raw === "full" ? "full" : "omit";
+}
+
+/** Full session resource for auto session (wildcard id `-`). */
+export function buildAnswerSessionResource(config: AgentSearchEnvConfig): string {
+  return `projects/${config.projectId}/locations/${config.location}/collections/${COLLECTION}/engines/${config.engineId}/sessions/-`;
+}
+
 /** Documented AnswerQueryRequest body — no unknown JSON fields. */
-export function buildAnswerRequestBody(): Record<string, unknown> {
-  return {
+export function buildAnswerRequestBody(config: AgentSearchEnvConfig): Record<string, unknown> {
+  const body: Record<string, unknown> = {
     query: { text: AGENT_SEARCH_PROBE_TEST_MESSAGE },
-    session: "-",
     groundingSpec: {
       includeGroundingSupports: true,
     },
@@ -122,6 +136,12 @@ export function buildAnswerRequestBody(): Record<string, unknown> {
       includeCitations: true,
     },
   };
+
+  if (resolveAnswerSessionMode() === "full") {
+    body.session = buildAnswerSessionResource(config);
+  }
+
+  return body;
 }
 
 /** Parse Google error JSON — status + short hint only, never full body or query text. */
@@ -229,7 +249,7 @@ export async function runAgentSearchDirectProbeOnce(
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json; charset=utf-8",
       },
-      body: JSON.stringify(buildAnswerRequestBody()),
+      body: JSON.stringify(buildAnswerRequestBody(config)),
     });
 
     const responseText = await response.text().catch(() => "");

--- a/src/lib/agent-search-direct.ts
+++ b/src/lib/agent-search-direct.ts
@@ -4,7 +4,7 @@ import { getGoogleAccessToken } from "./ces-auth";
 import { durationBucket, type DurationBucket } from "./ces-run-session";
 
 const COLLECTION = "default_collection";
-const ANSWER_SERVING = "default_serving_config";
+const DEFAULT_ANSWER_SERVING = "default_serving_config";
 const FETCH_TIMEOUT_MS = 25_000;
 
 /** Fixed test input — never logged or returned to clients. */
@@ -16,6 +16,7 @@ export type AgentSearchEnvConfig = {
   location: string;
   engineId: string;
   serviceAccountJson: string;
+  servingConfig: string;
 };
 
 export type AgentSearchEnvResult =
@@ -28,11 +29,13 @@ export type AgentSearchProbeErrorCode =
   | "auth"
   | "timeout"
   | "configuration_missing"
+  | "google_400_bad_request"
   | "google_403"
   | "google_404"
   | "google_502";
 
 export function mapGoogleUpstreamErrorCode(httpStatus: number): AgentSearchProbeErrorCode {
+  if (httpStatus === 400) return "google_400_bad_request";
   if (httpStatus === 403) return "google_403";
   if (httpStatus === 404) return "google_404";
   if (httpStatus === 502 || httpStatus === 503 || httpStatus === 504) return "google_502";
@@ -43,6 +46,8 @@ export type AgentSearchProbeMetadata = {
   status: "success" | "error";
   error_code: AgentSearchProbeErrorCode | null;
   upstream_http_status: number | null;
+  google_rpc_status: string | null;
+  google_error_hint: string | null;
   duration_bucket: DurationBucket;
   has_answer: boolean;
   has_citations: boolean;
@@ -73,6 +78,7 @@ export function resolveAgentSearchEnv(): AgentSearchEnvResult {
   const location = readEnv("AGENT_SEARCH_LOCATION") || readEnv("CES_LOCATION");
   const engineId = readEnv("AGENT_SEARCH_ENGINE_ID") || readEnv("CES_APP_ID");
   const serviceAccountJson = readEnv("GOOGLE_SERVICE_ACCOUNT_JSON");
+  const servingConfig = readEnv("AGENT_SEARCH_SERVING_CONFIG") || DEFAULT_ANSWER_SERVING;
 
   const missing: string[] = [];
   if (!projectId) missing.push("CES_PROJECT_ID");
@@ -86,13 +92,51 @@ export function resolveAgentSearchEnv(): AgentSearchEnvResult {
 
   return {
     ok: true,
-    config: { projectId, location, engineId, serviceAccountJson },
+    config: { projectId, location, engineId, serviceAccountJson, servingConfig },
   };
 }
 
 function buildAnswerUrl(host: string, config: AgentSearchEnvConfig): string {
-  const resource = `projects/${config.projectId}/locations/${config.location}/collections/${COLLECTION}/engines/${config.engineId}/servingConfigs/${ANSWER_SERVING}`;
+  const resource = `projects/${config.projectId}/locations/${config.location}/collections/${COLLECTION}/engines/${config.engineId}/servingConfigs/${config.servingConfig}`;
   return `${host}/v1/${resource}:answer`;
+}
+
+/** Documented AnswerQueryRequest body — no unknown JSON fields. */
+export function buildAnswerRequestBody(): Record<string, unknown> {
+  return {
+    query: { text: AGENT_SEARCH_PROBE_TEST_MESSAGE },
+    session: "-",
+    groundingSpec: {
+      includeGroundingSupports: true,
+    },
+    answerGenerationSpec: {
+      ignoreAdversarialQuery: true,
+      ignoreNonAnswerSeekingQuery: false,
+      includeCitations: true,
+    },
+  };
+}
+
+/** Parse Google error JSON — status + short hint only, never full body or query text. */
+export function extractSafeGoogleError(
+  responseText: string,
+): { rpc_status: string | null; hint: string | null } {
+  try {
+    const parsed = JSON.parse(responseText) as {
+      error?: { status?: string; message?: string };
+    };
+    const err = parsed.error;
+    if (!err) return { rpc_status: null, hint: null };
+    const rpc_status = typeof err.status === "string" ? err.status : null;
+    let hint: string | null = null;
+    if (typeof err.message === "string") {
+      hint = err.message.slice(0, 160);
+      if (hint.length < err.message.length) hint = `${hint}…`;
+    }
+    return { rpc_status, hint };
+  } catch {
+    return { rpc_status: null, hint: null };
+  }
 }
 
 function countCitations(payload: Record<string, unknown>): number {
@@ -125,12 +169,28 @@ function hasAnswerText(payload: Record<string, unknown>): boolean {
   return typeof text === "string" && text.trim().length > 0;
 }
 
+function baseMeta(
+  config: AgentSearchEnvConfig,
+  host: string,
+  started: number,
+): Omit<AgentSearchProbeMetadata, "status" | "error_code" | "upstream_http_status" | "google_rpc_status" | "google_error_hint" | "has_answer" | "has_citations" | "support_score" | "response_state"> {
+  return {
+    duration_bucket: durationBucket(Date.now() - started),
+    layer: "google_agent_search_direct",
+    method: "discoveryengine.servingConfigs.answer",
+    endpoint_host: host,
+    serving_config: config.servingConfig,
+    location: config.location,
+    project_id: config.projectId,
+    engine_id: config.engineId,
+  };
+}
+
 /** One direct :answer call — never logs message or answer body. */
 export async function runAgentSearchDirectProbeOnce(
   config: AgentSearchEnvConfig,
 ): Promise<AgentSearchProbeMetadata> {
   const host = discoveryHost(config.location);
-  const endpoint_host = host;
   const started = Date.now();
   let token: string;
 
@@ -141,18 +201,13 @@ export async function runAgentSearchDirectProbeOnce(
       status: "error",
       error_code: "auth",
       upstream_http_status: null,
-      duration_bucket: durationBucket(Date.now() - started),
+      google_rpc_status: null,
+      google_error_hint: null,
       has_answer: false,
       has_citations: false,
       support_score: null,
       response_state: null,
-      layer: "google_agent_search_direct",
-      method: "discoveryengine.servingConfigs.answer",
-      endpoint_host,
-      serving_config: ANSWER_SERVING,
-      location: config.location,
-      project_id: config.projectId,
-      engine_id: config.engineId,
+      ...baseMeta(config, host, started),
     };
   }
 
@@ -167,22 +222,16 @@ export async function runAgentSearchDirectProbeOnce(
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json; charset=utf-8",
       },
-      body: JSON.stringify({
-        query: { text: AGENT_SEARCH_PROBE_TEST_MESSAGE },
-        session: "-",
-        groundingSpec: { includeGrounding: true },
-        answerGenerationSpec: {
-          ignoreAdversarialQuery: true,
-          ignoreNonAnswerSeekingQuery: false,
-        },
-      }),
+      body: JSON.stringify(buildAnswerRequestBody()),
     });
 
+    const responseText = await response.text().catch(() => "");
     let payload: Record<string, unknown> = {};
-    if (response.ok) {
-      payload = ((await response.json().catch(() => ({}))) ?? {}) as Record<string, unknown>;
+    if (response.ok && responseText) {
+      payload = (JSON.parse(responseText) as Record<string, unknown>) ?? {};
     }
 
+    const safeErr = response.ok ? { rpc_status: null, hint: null } : extractSafeGoogleError(responseText);
     const ok = response.ok && hasAnswerText(payload);
     const durationMs = Date.now() - started;
 
@@ -194,18 +243,14 @@ export async function runAgentSearchDirectProbeOnce(
           ? "empty_response"
           : mapGoogleUpstreamErrorCode(response.status),
       upstream_http_status: response.status,
+      google_rpc_status: safeErr.rpc_status,
+      google_error_hint: safeErr.hint,
       duration_bucket: durationBucket(durationMs),
       has_answer: hasAnswerText(payload),
-      has_citations: countCitations(payload) > 0,
+      has_citations: countCitations(payload),
       support_score: extractSupportScore(payload),
       response_state: extractResponseState(payload),
-      layer: "google_agent_search_direct",
-      method: "discoveryengine.servingConfigs.answer",
-      endpoint_host,
-      serving_config: ANSWER_SERVING,
-      location: config.location,
-      project_id: config.projectId,
-      engine_id: config.engineId,
+      ...baseMeta(config, host, started),
     };
   } catch (err) {
     const durationMs = Date.now() - started;
@@ -214,18 +259,14 @@ export async function runAgentSearchDirectProbeOnce(
       status: "error",
       error_code: isAbort ? "timeout" : "upstream",
       upstream_http_status: null,
+      google_rpc_status: null,
+      google_error_hint: null,
       duration_bucket: durationBucket(durationMs),
       has_answer: false,
       has_citations: false,
       support_score: null,
       response_state: null,
-      layer: "google_agent_search_direct",
-      method: "discoveryengine.servingConfigs.answer",
-      endpoint_host,
-      serving_config: ANSWER_SERVING,
-      location: config.location,
-      project_id: config.projectId,
-      engine_id: config.engineId,
+      ...baseMeta(config, host, started),
     };
   } finally {
     clearTimeout(timeoutId);

--- a/src/lib/agent-search-probe-envelope.ts
+++ b/src/lib/agent-search-probe-envelope.ts
@@ -9,17 +9,26 @@ import {
 export type AgentSearchEnvReadiness = {
   has_project_id: boolean;
   has_location: boolean;
-  has_app_id_or_engine_id: boolean;
+  has_agent_search_engine_id: boolean;
+  has_ces_app_id: boolean;
   has_service_account: boolean;
 };
 
+function readEnvFlag(name: string): boolean {
+  return Boolean((process.env[name] ?? import.meta.env[name] ?? "").trim());
+}
+
 export function resolveAgentSearchEnvReadiness(): AgentSearchEnvReadiness {
   const env = resolveAgentSearchEnv();
+  const hasEngineId = readEnvFlag("AGENT_SEARCH_ENGINE_ID");
+  const hasCesAppId = readEnvFlag("CES_APP_ID");
+
   if (env.ok) {
     return {
       has_project_id: true,
       has_location: true,
-      has_app_id_or_engine_id: true,
+      has_agent_search_engine_id: true,
+      has_ces_app_id: hasCesAppId,
       has_service_account: true,
     };
   }
@@ -27,8 +36,8 @@ export function resolveAgentSearchEnvReadiness(): AgentSearchEnvReadiness {
   return {
     has_project_id: !missing.has("CES_PROJECT_ID"),
     has_location: !missing.has("CES_LOCATION") && !missing.has("AGENT_SEARCH_LOCATION"),
-    has_app_id_or_engine_id:
-      !missing.has("CES_APP_ID") && !missing.has("AGENT_SEARCH_ENGINE_ID"),
+    has_agent_search_engine_id: hasEngineId,
+    has_ces_app_id: hasCesAppId,
     has_service_account: !missing.has("GOOGLE_SERVICE_ACCOUNT_JSON"),
   };
 }
@@ -42,6 +51,8 @@ export type AgentSearchProbeEnvelope = {
   layer: "google_agent_search_direct";
   endpoint_host: string | null;
   env_readiness: AgentSearchEnvReadiness;
+  engine_id_source: "AGENT_SEARCH_ENGINE_ID" | null;
+  ces_app_id_not_engine: true;
   api_route_reached: "yes";
 };
 
@@ -63,6 +74,8 @@ export function buildProbeEnvelope(): AgentSearchProbeEnvelope {
     layer: "google_agent_search_direct",
     endpoint_host,
     env_readiness: readiness,
+    engine_id_source: env.ok ? "AGENT_SEARCH_ENGINE_ID" : null,
+    ces_app_id_not_engine: true,
     api_route_reached: "yes",
   };
 }

--- a/src/lib/agent-search-probe-envelope.ts
+++ b/src/lib/agent-search-probe-envelope.ts
@@ -71,9 +71,13 @@ export function probeDisabledBody(): Record<string, unknown> {
   const envelope = buildProbeEnvelope();
   return {
     ...envelope,
+    route_reached: true,
+    api_route_reached: "yes",
     preview_enabled: false,
     enabled: false,
     error: "disabled",
+    error_code: "disabled_in_production",
+    error_source: "app",
     message: previewDiagnosticsDisabledReason(),
   };
 }

--- a/src/lib/agent-search-probe-envelope.ts
+++ b/src/lib/agent-search-probe-envelope.ts
@@ -1,0 +1,88 @@
+/* CONTRACT: Safe API envelope for preview Agent Search probe — no secrets or content. */
+
+import { discoveryHost, resolveAgentSearchEnv } from "./agent-search-direct";
+import {
+  getPreviewDiagnosticsState,
+  previewDiagnosticsDisabledReason,
+} from "./preview-diagnostics";
+
+export type AgentSearchEnvReadiness = {
+  has_project_id: boolean;
+  has_location: boolean;
+  has_app_id_or_engine_id: boolean;
+  has_service_account: boolean;
+};
+
+export function resolveAgentSearchEnvReadiness(): AgentSearchEnvReadiness {
+  const env = resolveAgentSearchEnv();
+  if (env.ok) {
+    return {
+      has_project_id: true,
+      has_location: true,
+      has_app_id_or_engine_id: true,
+      has_service_account: true,
+    };
+  }
+  const missing = new Set(env.missing);
+  return {
+    has_project_id: !missing.has("CES_PROJECT_ID"),
+    has_location: !missing.has("CES_LOCATION") && !missing.has("AGENT_SEARCH_LOCATION"),
+    has_app_id_or_engine_id:
+      !missing.has("CES_APP_ID") && !missing.has("AGENT_SEARCH_ENGINE_ID"),
+    has_service_account: !missing.has("GOOGLE_SERVICE_ACCOUNT_JSON"),
+  };
+}
+
+export type AgentSearchProbeEnvelope = {
+  route_reached: true;
+  vercel_env: string;
+  preview_enabled: boolean;
+  preview_disabled_reason?: string;
+  vercel_env_note: string | null;
+  layer: "google_agent_search_direct";
+  endpoint_host: string | null;
+  env_readiness: AgentSearchEnvReadiness;
+  api_route_reached: "yes";
+};
+
+export function buildProbeEnvelope(): AgentSearchProbeEnvelope {
+  const preview = getPreviewDiagnosticsState();
+  const readiness = resolveAgentSearchEnvReadiness();
+  const env = resolveAgentSearchEnv();
+  const endpoint_host =
+    env.ok && readiness.has_location ? discoveryHost(env.config.location) : null;
+
+  return {
+    route_reached: true,
+    vercel_env: preview.vercel_env,
+    preview_enabled: preview.preview_enabled,
+    preview_disabled_reason: preview.preview_enabled
+      ? undefined
+      : previewDiagnosticsDisabledReason(),
+    vercel_env_note: preview.vercel_env_note,
+    layer: "google_agent_search_direct",
+    endpoint_host,
+    env_readiness: readiness,
+    api_route_reached: "yes",
+  };
+}
+
+export function probeDisabledBody(): Record<string, unknown> {
+  const envelope = buildProbeEnvelope();
+  return {
+    ...envelope,
+    preview_enabled: false,
+    enabled: false,
+    error: "disabled",
+    message: previewDiagnosticsDisabledReason(),
+  };
+}
+
+export function probeEnabledBase(): Record<string, unknown> {
+  const envelope = buildProbeEnvelope();
+  return {
+    ...envelope,
+    enabled: true,
+    preview_enabled: envelope.preview_enabled,
+  };
+}

--- a/src/lib/agent-search-probe-handler.ts
+++ b/src/lib/agent-search-probe-handler.ts
@@ -1,0 +1,61 @@
+/* CONTRACT: Shared probe execution — POST and GET ?run=1 return identical safe JSON envelope. */
+
+import { runAgentSearchDirectProbeOnce, resolveAgentSearchEnv } from "./agent-search-direct";
+import { probeDisabledBody, probeEnabledBase } from "./agent-search-probe-envelope";
+import { isPreviewDiagnosticsEnabled } from "./preview-diagnostics";
+
+export type ProbeHandlerResult = {
+  body: Record<string, unknown>;
+  status: number;
+};
+
+export async function executeAgentSearchProbeOnce(method: "GET" | "POST"): Promise<ProbeHandlerResult> {
+  if (!isPreviewDiagnosticsEnabled()) {
+    return {
+      body: {
+        ...probeDisabledBody(),
+        method,
+        api_http_status: 404,
+      },
+      status: 404,
+    };
+  }
+
+  const env = resolveAgentSearchEnv();
+  if (!env.ok) {
+    return {
+      body: {
+        ...probeEnabledBase(),
+        method,
+        status: "error",
+        error_code: "configuration_missing",
+        error_source: "config",
+        missing_env: env.missing,
+        upstream_http_status: null,
+        duration_bucket: null,
+        has_answer: false,
+        has_citations: false,
+        support_score: null,
+        response_state: null,
+        google_call_attempted: false,
+        api_http_status: 503,
+      },
+      status: 503,
+    };
+  }
+
+  const meta = await runAgentSearchDirectProbeOnce(env.config);
+  const httpStatus = meta.status === "success" ? 200 : 502;
+
+  return {
+    body: {
+      ...probeEnabledBase(),
+      ...meta,
+      method,
+      error_source: meta.status === "success" ? null : "google",
+      google_call_attempted: true,
+      api_http_status: httpStatus,
+    },
+    status: httpStatus,
+  };
+}

--- a/src/lib/agent-search-probe-path.ts
+++ b/src/lib/agent-search-probe-path.ts
@@ -1,0 +1,10 @@
+/* CONTRACT: Canonical path for Agent Search preview probe API — must match src/pages/api/agent-search-direct-probe.ts */
+
+export const AGENT_SEARCH_PROBE_API_SEGMENT = "api/agent-search-direct-probe";
+
+/** Root-absolute API path (respects Astro base for GitHub Pages). */
+export function agentSearchProbeApiPath(baseUrl = "/"): string {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const combined = `${base}${AGENT_SEARCH_PROBE_API_SEGMENT}`.replace(/\/{2,}/g, "/");
+  return combined.startsWith("/") ? combined : `/${combined}`;
+}

--- a/src/lib/preview-diagnostics.ts
+++ b/src/lib/preview-diagnostics.ts
@@ -1,0 +1,14 @@
+/* CONTRACT: Gate internal diagnostics — enabled on Vercel Preview / dev only, never production. */
+
+function readVercelEnv(): string {
+  return (process.env.VERCEL_ENV ?? import.meta.env.VERCEL_ENV ?? "").trim();
+}
+
+/** True when not deployed as Vercel production (preview, development, or local dev). */
+export function isPreviewDiagnosticsEnabled(): boolean {
+  return readVercelEnv() !== "production";
+}
+
+export function previewDiagnosticsDisabledReason(): string {
+  return "Kun tilgjengelig i Vercel Preview (ikke production).";
+}

--- a/src/lib/preview-diagnostics.ts
+++ b/src/lib/preview-diagnostics.ts
@@ -1,6 +1,12 @@
 /* CONTRACT: Gate internal diagnostics — enabled on Vercel Preview / dev only, never production. */
 
-function readVercelEnv(): string {
+export type PreviewDiagnosticsState = {
+  vercel_env: string;
+  preview_enabled: boolean;
+  vercel_env_note: string | null;
+};
+
+export function readVercelEnv(): string {
   return (process.env.VERCEL_ENV ?? import.meta.env.VERCEL_ENV ?? "").trim();
 }
 
@@ -11,4 +17,23 @@ export function isPreviewDiagnosticsEnabled(): boolean {
 
 export function previewDiagnosticsDisabledReason(): string {
   return "Kun tilgjengelig i Vercel Preview (ikke production).";
+}
+
+export function getPreviewDiagnosticsState(): PreviewDiagnosticsState {
+  const vercel_env = readVercelEnv();
+  const preview_enabled = vercel_env !== "production";
+  let vercel_env_note: string | null = null;
+  if (!vercel_env) {
+    vercel_env_note =
+      "VERCEL_ENV er ikke satt — behandles som ikke-production (lokalt/preview). Bekreft at du bruker Vercel Preview-URL.";
+  } else if (vercel_env === "preview") {
+    vercel_env_note = null;
+  } else if (vercel_env === "development") {
+    vercel_env_note = "VERCEL_ENV=development — probe tillatt (ikke production).";
+  } else if (vercel_env === "production") {
+    vercel_env_note = "VERCEL_ENV=production — probe er deaktivert.";
+  } else {
+    vercel_env_note = `Uventet VERCEL_ENV=${vercel_env} — kontakt utvikler.`;
+  }
+  return { vercel_env: vercel_env || "(unset)", preview_enabled, vercel_env_note };
 }

--- a/src/pages/api/agent-search-direct-probe.ts
+++ b/src/pages/api/agent-search-direct-probe.ts
@@ -19,13 +19,22 @@ function json(body: Record<string, unknown>, status: number): Response {
 
 export const GET: APIRoute = async () => {
   if (!isPreviewDiagnosticsEnabled()) {
-    return json(probeDisabledBody(), 404);
+    return json(
+      {
+        ...probeDisabledBody(),
+        error_code: "disabled_in_production",
+        error_source: "app",
+        api_http_status: 404,
+      },
+      404,
+    );
   }
   return json(
     {
       ...probeEnabledBase(),
       ready: true,
       message: "POST for ett :answer-kall med safe metadata.",
+      api_http_status: 200,
     },
     200,
   );
@@ -45,6 +54,7 @@ export const POST: APIRoute = async () => {
         ...probeEnabledBase(),
         status: "error",
         error_code: "configuration_missing",
+        error_source: "config",
         missing_env: env.missing,
         upstream_http_status: null,
         duration_bucket: null,
@@ -53,6 +63,7 @@ export const POST: APIRoute = async () => {
         support_score: null,
         response_state: null,
         google_call_attempted: false,
+        api_http_status: 503,
       },
       503,
     );
@@ -65,6 +76,7 @@ export const POST: APIRoute = async () => {
     {
       ...probeEnabledBase(),
       ...meta,
+      error_source: meta.status === "success" ? null : "google",
       google_call_attempted: true,
       api_http_status: httpStatus,
     },

--- a/src/pages/api/agent-search-direct-probe.ts
+++ b/src/pages/api/agent-search-direct-probe.ts
@@ -1,27 +1,42 @@
-/* CONTRACT: Preview-only single-call Agent Search probe API — safe metadata, no content logging. */
+/* CONTRACT: Preview-only Agent Search probe API — safe metadata, no content logging. */
 import type { APIRoute } from "astro";
-import { runAgentSearchDirectProbeOnce, resolveAgentSearchEnv } from "../../lib/agent-search-direct";
-import {
-  buildProbeEnvelope,
-  probeDisabledBody,
-  probeEnabledBase,
-} from "../../lib/agent-search-probe-envelope";
+import { executeAgentSearchProbeOnce } from "../../lib/agent-search-probe-handler";
+import { probeDisabledBody, probeEnabledBase } from "../../lib/agent-search-probe-envelope";
 import { isPreviewDiagnosticsEnabled } from "../../lib/preview-diagnostics";
 
 export const prerender = false;
 
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Allow": "GET, POST, OPTIONS",
+};
+
 function json(body: Record<string, unknown>, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json; charset=utf-8" },
-  });
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
 }
 
-export const GET: APIRoute = async () => {
+/** CORS preflight + Vercel OPTIONS allowlist compatibility for /api/*. */
+export const OPTIONS: APIRoute = async () => {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      ...JSON_HEADERS,
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Accept",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+};
+
+export const GET: APIRoute = async ({ request }) => {
+  const url = new URL(request.url);
+  const execute = url.searchParams.get("run") === "1";
+
   if (!isPreviewDiagnosticsEnabled()) {
     return json(
       {
         ...probeDisabledBody(),
+        method: execute ? "GET" : "GET",
         error_code: "disabled_in_production",
         error_source: "app",
         api_http_status: 404,
@@ -29,57 +44,39 @@ export const GET: APIRoute = async () => {
       404,
     );
   }
+
+  if (execute) {
+    const result = await executeAgentSearchProbeOnce("GET");
+    return json(result.body, result.status);
+  }
+
   return json(
     {
       ...probeEnabledBase(),
+      method: "GET",
       ready: true,
-      message: "POST for ett :answer-kall med safe metadata.",
+      message: "POST eller GET ?run=1 for ett :answer-kall med safe metadata.",
       api_http_status: 200,
+      probe_execute_url_hint: `${url.pathname}?run=1`,
     },
     200,
   );
 };
 
 export const POST: APIRoute = async () => {
-  const envelope = buildProbeEnvelope();
-
   if (!isPreviewDiagnosticsEnabled()) {
-    return json(probeDisabledBody(), 404);
-  }
-
-  const env = resolveAgentSearchEnv();
-  if (!env.ok) {
     return json(
       {
-        ...probeEnabledBase(),
-        status: "error",
-        error_code: "configuration_missing",
-        error_source: "config",
-        missing_env: env.missing,
-        upstream_http_status: null,
-        duration_bucket: null,
-        has_answer: false,
-        has_citations: false,
-        support_score: null,
-        response_state: null,
-        google_call_attempted: false,
-        api_http_status: 503,
+        ...probeDisabledBody(),
+        method: "POST",
+        error_code: "disabled_in_production",
+        error_source: "app",
+        api_http_status: 404,
       },
-      503,
+      404,
     );
   }
 
-  const meta = await runAgentSearchDirectProbeOnce(env.config);
-  const httpStatus = meta.status === "success" ? 200 : 502;
-
-  return json(
-    {
-      ...probeEnabledBase(),
-      ...meta,
-      error_source: meta.status === "success" ? null : "google",
-      google_call_attempted: true,
-      api_http_status: httpStatus,
-    },
-    httpStatus,
-  );
+  const result = await executeAgentSearchProbeOnce("POST");
+  return json(result.body, result.status);
 };

--- a/src/pages/api/agent-search-direct-probe.ts
+++ b/src/pages/api/agent-search-direct-probe.ts
@@ -1,0 +1,42 @@
+/* CONTRACT: Preview-only single-call Agent Search probe API — safe metadata, no content logging. */
+import type { APIRoute } from "astro";
+import { runAgentSearchDirectProbeOnce, resolveAgentSearchEnv } from "../../lib/agent-search-direct";
+import { isPreviewDiagnosticsEnabled, previewDiagnosticsDisabledReason } from "../../lib/preview-diagnostics";
+
+export const prerender = false;
+
+function json(body: Record<string, unknown>, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}
+
+export const POST: APIRoute = async () => {
+  if (!isPreviewDiagnosticsEnabled()) {
+    return json({ enabled: false, error: "disabled", message: previewDiagnosticsDisabledReason() }, 404);
+  }
+
+  const env = resolveAgentSearchEnv();
+  if (!env.ok) {
+    return json(
+      {
+        enabled: true,
+        status: "error",
+        error_code: "configuration_missing",
+        missing_env: env.missing,
+      },
+      503,
+    );
+  }
+
+  const meta = await runAgentSearchDirectProbeOnce(env.config);
+  return json({ enabled: true, ...meta }, meta.status === "success" ? 200 : 502);
+};
+
+export const GET: APIRoute = async () => {
+  if (!isPreviewDiagnosticsEnabled()) {
+    return json({ enabled: false, error: "disabled", message: previewDiagnosticsDisabledReason() }, 404);
+  }
+  return json({ enabled: true, layer: "google_agent_search_direct" }, 200);
+};

--- a/src/pages/api/agent-search-direct-probe.ts
+++ b/src/pages/api/agent-search-direct-probe.ts
@@ -1,7 +1,12 @@
 /* CONTRACT: Preview-only single-call Agent Search probe API — safe metadata, no content logging. */
 import type { APIRoute } from "astro";
 import { runAgentSearchDirectProbeOnce, resolveAgentSearchEnv } from "../../lib/agent-search-direct";
-import { isPreviewDiagnosticsEnabled, previewDiagnosticsDisabledReason } from "../../lib/preview-diagnostics";
+import {
+  buildProbeEnvelope,
+  probeDisabledBody,
+  probeEnabledBase,
+} from "../../lib/agent-search-probe-envelope";
+import { isPreviewDiagnosticsEnabled } from "../../lib/preview-diagnostics";
 
 export const prerender = false;
 
@@ -12,31 +17,57 @@ function json(body: Record<string, unknown>, status: number): Response {
   });
 }
 
-export const POST: APIRoute = async () => {
+export const GET: APIRoute = async () => {
   if (!isPreviewDiagnosticsEnabled()) {
-    return json({ enabled: false, error: "disabled", message: previewDiagnosticsDisabledReason() }, 404);
+    return json(probeDisabledBody(), 404);
+  }
+  return json(
+    {
+      ...probeEnabledBase(),
+      ready: true,
+      message: "POST for ett :answer-kall med safe metadata.",
+    },
+    200,
+  );
+};
+
+export const POST: APIRoute = async () => {
+  const envelope = buildProbeEnvelope();
+
+  if (!isPreviewDiagnosticsEnabled()) {
+    return json(probeDisabledBody(), 404);
   }
 
   const env = resolveAgentSearchEnv();
   if (!env.ok) {
     return json(
       {
-        enabled: true,
+        ...probeEnabledBase(),
         status: "error",
         error_code: "configuration_missing",
         missing_env: env.missing,
+        upstream_http_status: null,
+        duration_bucket: null,
+        has_answer: false,
+        has_citations: false,
+        support_score: null,
+        response_state: null,
+        google_call_attempted: false,
       },
       503,
     );
   }
 
   const meta = await runAgentSearchDirectProbeOnce(env.config);
-  return json({ enabled: true, ...meta }, meta.status === "success" ? 200 : 502);
-};
+  const httpStatus = meta.status === "success" ? 200 : 502;
 
-export const GET: APIRoute = async () => {
-  if (!isPreviewDiagnosticsEnabled()) {
-    return json({ enabled: false, error: "disabled", message: previewDiagnosticsDisabledReason() }, 404);
-  }
-  return json({ enabled: true, layer: "google_agent_search_direct" }, 200);
+  return json(
+    {
+      ...probeEnabledBase(),
+      ...meta,
+      google_call_attempted: true,
+      api_http_status: httpStatus,
+    },
+    httpStatus,
+  );
 };

--- a/src/pages/vis/system/agent-search-direct-probe/index.astro
+++ b/src/pages/vis/system/agent-search-direct-probe/index.astro
@@ -1,6 +1,7 @@
 ---
 /* CONTRACT: Preview-only Agent Search direct API diagnostics — Thomas tests via Vercel Preview click, no terminal. */
 import VisInternalLayout from "../../../../layouts/VisInternalLayout.astro";
+import { agentSearchProbeApiPath } from "../../../../lib/agent-search-probe-path";
 import {
   isPreviewDiagnosticsEnabled,
   previewDiagnosticsDisabledReason,
@@ -9,7 +10,8 @@ import {
 
 const base = import.meta.env.BASE_URL;
 const enabled = isPreviewDiagnosticsEnabled();
-const apiPath = new URL("api/agent-search-direct-probe", Astro.url).pathname;
+/** Root-absolute — must not be resolved relative to /vis/system/... (that caused /vis/system/api/... 404). */
+const apiPath = agentSearchProbeApiPath(base);
 const probeConfigJson = JSON.stringify({ apiPath });
 const buildPreview = getPreviewDiagnosticsState();
 ---

--- a/src/pages/vis/system/agent-search-direct-probe/index.astro
+++ b/src/pages/vis/system/agent-search-direct-probe/index.astro
@@ -4,11 +4,14 @@ import VisInternalLayout from "../../../../layouts/VisInternalLayout.astro";
 import {
   isPreviewDiagnosticsEnabled,
   previewDiagnosticsDisabledReason,
+  getPreviewDiagnosticsState,
 } from "../../../../lib/preview-diagnostics";
 
 const base = import.meta.env.BASE_URL;
 const enabled = isPreviewDiagnosticsEnabled();
-const apiPath = `${base}api/agent-search-direct-probe`.replace(/\/+/g, "/");
+const apiPath = new URL("api/agent-search-direct-probe", Astro.url).pathname;
+const probeConfigJson = JSON.stringify({ apiPath });
+const buildPreview = getPreviewDiagnosticsState();
 ---
 
 <VisInternalLayout title="Agent Search direct probe" pageContractId="gitbuss" showPageIntro={false}>
@@ -25,6 +28,12 @@ const apiPath = `${base}api/agent-search-direct-probe`.replace(/\/+/g, "/");
       per API-request — ingen prompt eller svar vises.
     </p>
 
+    <p
+      id="probe-bootstrap-error"
+      class="mt-4 hidden max-w-prose rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900"
+      role="alert"
+    />
+
     {
       !enabled ? (
         <div
@@ -35,6 +44,9 @@ const apiPath = `${base}api/agent-search-direct-probe`.replace(/\/+/g, "/");
           <p class="mt-1">{previewDiagnosticsDisabledReason()}</p>
           <p class="mt-2 text-xs text-amber-800">
             Åpne Vercel Preview-deploy for denne branchen og gå til samme URL der.
+          </p>
+          <p class="mt-2 text-xs">
+            Build-time VERCEL_ENV: <code class="font-mono">{buildPreview.vercel_env}</code>
           </p>
         </div>
       ) : (
@@ -50,7 +62,19 @@ const apiPath = `${base}api/agent-search-direct-probe`.replace(/\/+/g, "/");
                 <span class="font-medium">Direct Agent Search :answer:</span> fylles inn etter preview-test nedenfor
               </li>
             </ul>
+            <p class="mt-2 text-xs text-gray-500">
+              Build-time preview: {buildPreview.preview_enabled ? "enabled" : "disabled"} · VERCEL_ENV={buildPreview.vercel_env}
+            </p>
           </section>
+
+          <div
+            id="probe-readiness"
+            class="mt-4 max-w-3xl rounded-md border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700"
+          >
+            <p class="text-gray-500">Laster API readiness…</p>
+          </div>
+
+          <div id="probe-diagnostics" class="mt-4 hidden max-w-3xl rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm" />
 
           <div class="mt-6 flex flex-wrap items-center gap-3">
             <button
@@ -60,7 +84,9 @@ const apiPath = `${base}api/agent-search-direct-probe`.replace(/\/+/g, "/");
             >
               Kjør 5 direct API-kall
             </button>
-            <p id="probe-status" class="text-sm text-gray-500" aria-live="polite"></p>
+            <p id="probe-status" class="text-sm text-gray-500" aria-live="polite">
+              Vent på readiness, deretter start test.
+            </p>
           </div>
 
           <div id="probe-summary" class="mt-4 hidden max-w-3xl rounded-md border border-gray-200 bg-white px-4 py-3 text-sm" />
@@ -71,12 +97,14 @@ const apiPath = `${base}api/agent-search-direct-probe`.replace(/\/+/g, "/");
                 <tr class="border-b border-gray-200 text-xs uppercase tracking-wide text-gray-500">
                   <th class="py-2 pr-4">Call #</th>
                   <th class="py-2 pr-4">Resultat</th>
+                  <th class="py-2 pr-4">API HTTP</th>
                   <th class="py-2 pr-4">Status</th>
                   <th class="py-2 pr-4">Duration</th>
                   <th class="py-2 pr-4">has_answer</th>
                   <th class="py-2 pr-4">has_citations</th>
                   <th class="py-2 pr-4">support_score</th>
                   <th class="py-2 pr-4">error_code</th>
+                  <th class="py-2 pr-4">Notat</th>
                 </tr>
               </thead>
               <tbody id="probe-tbody" class="text-gray-800" />
@@ -94,106 +122,23 @@ const apiPath = `${base}api/agent-search-direct-probe`.replace(/\/+/g, "/");
 
 {
   enabled && (
-    <script define:vars={{ apiPath }}>
-      const RUN_COUNT = 5;
-      const DELAY_MS = 8000;
-      const CHANNEL_BASELINE_PCT = 25;
+    <>
+      <script type="application/json" id="agent-search-probe-config" set:html={probeConfigJson} />
+      <script>
+        import { initAgentSearchDirectProbe } from "../../../../scripts/agent-search-direct-probe-client.ts";
 
-      const runBtn = document.getElementById("probe-run");
-      const statusEl = document.getElementById("probe-status");
-      const summaryEl = document.getElementById("probe-summary");
-      const tableEl = document.getElementById("probe-table");
-      const tbody = document.getElementById("probe-tbody");
-
-      function sleep(ms) {
-        return new Promise((r) => setTimeout(r, ms));
-      }
-
-      function renderSummary(rows) {
-        const total = rows.length;
-        const success = rows.filter((r) => r.status === "success").length;
-        const upstream = rows.filter((r) => r.error_code === "upstream").length;
-        const timeout = rows.filter((r) => r.error_code === "timeout").length;
-        const other = total - success - upstream - timeout;
-        const rate = total ? Math.round((success / total) * 100) : 0;
-        const vsBaseline =
-          rate > CHANNEL_BASELINE_PCT
-            ? "bedre enn channel (25%)"
-            : rate < CHANNEL_BASELINE_PCT
-              ? "verre enn channel (25%)"
-              : "lik channel-baseline (25%)";
-
-        summaryEl.classList.remove("hidden");
-        summaryEl.innerHTML = `
-          <p class="font-medium text-gray-900">Oppsummering (direct :answer)</p>
-          <ul class="mt-2 space-y-1">
-            <li>Total: ${total}</li>
-            <li>Success: ${success}</li>
-            <li>Upstream: ${upstream}</li>
-            <li>Timeout: ${timeout}</li>
-            <li>Andre feil: ${other}</li>
-            <li>Success-rate: ${rate}% — ${vsBaseline}</li>
-          </ul>
-        `;
-      }
-
-      function appendRow(n, data) {
-        const tr = document.createElement("tr");
-        tr.className = "border-b border-gray-100";
-        const resultLabel = data.status === "success" ? "success" : "error";
-        tr.innerHTML = `
-          <td class="py-2 pr-4">${n}</td>
-          <td class="py-2 pr-4">${resultLabel}</td>
-          <td class="py-2 pr-4">${data.status ?? "—"}</td>
-          <td class="py-2 pr-4">${data.duration_bucket ?? "—"}</td>
-          <td class="py-2 pr-4">${data.has_answer ? "ja" : "nei"}</td>
-          <td class="py-2 pr-4">${data.has_citations ? "ja" : "nei"}</td>
-          <td class="py-2 pr-4">${data.support_score ?? "—"}</td>
-          <td class="py-2 pr-4">${data.error_code ?? "—"}</td>
-        `;
-        tbody.appendChild(tr);
-      }
-
-      async function runProbe() {
-        runBtn.disabled = true;
-        tbody.innerHTML = "";
-        summaryEl.classList.add("hidden");
-        tableEl.classList.remove("hidden");
-        const rows = [];
-
-        for (let i = 1; i <= RUN_COUNT; i += 1) {
-          statusEl.textContent = `Kjører kall ${i} av ${RUN_COUNT}…`;
-          try {
-            const res = await fetch(apiPath, { method: "POST" });
-            const data = await res.json().catch(() => ({}));
-            if (!data.enabled) {
-              statusEl.textContent = data.message ?? "Probe deaktivert.";
-              break;
-            }
-            rows.push(data);
-            appendRow(i, data);
-          } catch {
-            rows.push({
-              status: "error",
-              error_code: "upstream",
-              duration_bucket: "—",
-              has_answer: false,
-              has_citations: false,
-              support_score: null,
-            });
-            appendRow(i, rows[rows.length - 1]);
+        const configEl = document.getElementById("agent-search-probe-config");
+        if (!configEl?.textContent) {
+          const err = document.getElementById("probe-bootstrap-error");
+          if (err) {
+            err.textContent = "Probe-klient: mangler #agent-search-probe-config.";
+            err.classList.remove("hidden");
           }
-          if (i < RUN_COUNT) await sleep(DELAY_MS);
+        } else {
+          const { apiPath } = JSON.parse(configEl.textContent) as { apiPath: string };
+          initAgentSearchDirectProbe(apiPath);
         }
-
-        renderSummary(rows);
-        statusEl.textContent = rows.length ? "Ferdig." : "Ingen resultater.";
-        runBtn.disabled = false;
-      }
-
-      runBtn?.addEventListener("click", () => {
-        void runProbe();
-      });
-    </script>
+      </script>
+    </>
   )
 }

--- a/src/pages/vis/system/agent-search-direct-probe/index.astro
+++ b/src/pages/vis/system/agent-search-direct-probe/index.astro
@@ -1,0 +1,199 @@
+---
+/* CONTRACT: Preview-only Agent Search direct API diagnostics — Thomas tests via Vercel Preview click, no terminal. */
+import VisInternalLayout from "../../../../layouts/VisInternalLayout.astro";
+import {
+  isPreviewDiagnosticsEnabled,
+  previewDiagnosticsDisabledReason,
+} from "../../../../lib/preview-diagnostics";
+
+const base = import.meta.env.BASE_URL;
+const enabled = isPreviewDiagnosticsEnabled();
+const apiPath = `${base}api/agent-search-direct-probe`.replace(/\/+/g, "/");
+---
+
+<VisInternalLayout title="Agent Search direct probe" pageContractId="gitbuss" showPageIntro={false}>
+  <main class="px-4 py-6 sm:px-6 sm:py-8">
+    <nav class="text-xs text-gray-500">
+      <a href={`${base}vis/system`} class="underline underline-offset-2">System</a>
+      <span aria-hidden="true"> / </span>
+      <span class="text-gray-800">Agent Search direct probe</span>
+    </nav>
+
+    <h1 class="mt-4 text-lg font-semibold text-gray-900">Agent Search direct API probe</h1>
+    <p class="mt-2 max-w-prose text-sm leading-relaxed text-gray-600">
+      Intern preview-diagnostikk for #198. Ett Google <code class="rounded bg-gray-100 px-1 font-mono text-xs">:answer</code>-kall
+      per API-request — ingen prompt eller svar vises.
+    </p>
+
+    {
+      !enabled ? (
+        <div
+          class="mt-6 max-w-prose rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+          role="status"
+        >
+          <p class="font-medium">Deaktivert i production</p>
+          <p class="mt-1">{previewDiagnosticsDisabledReason()}</p>
+          <p class="mt-2 text-xs text-amber-800">
+            Åpne Vercel Preview-deploy for denne branchen og gå til samme URL der.
+          </p>
+        </div>
+      ) : (
+        <>
+          <section class="mt-4 max-w-3xl rounded-md border border-gray-200 bg-gray-50/80 px-4 py-3 text-sm text-gray-700">
+            <p class="font-medium text-gray-900">Sammenligning mot channel-baseline</p>
+            <ul class="mt-2 list-inside list-disc space-y-1 text-sm">
+              <li>
+                <span class="font-medium">CES channel / runSession:</span> 4/16 success = 25% (2 reliability-serier, guard
+                100/500)
+              </li>
+              <li>
+                <span class="font-medium">Direct Agent Search :answer:</span> fylles inn etter preview-test nedenfor
+              </li>
+            </ul>
+          </section>
+
+          <div class="mt-6 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              id="probe-run"
+              class="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Kjør 5 direct API-kall
+            </button>
+            <p id="probe-status" class="text-sm text-gray-500" aria-live="polite"></p>
+          </div>
+
+          <div id="probe-summary" class="mt-4 hidden max-w-3xl rounded-md border border-gray-200 bg-white px-4 py-3 text-sm" />
+
+          <div class="mt-6 overflow-x-auto">
+            <table id="probe-table" class="hidden min-w-full border-collapse text-left text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 text-xs uppercase tracking-wide text-gray-500">
+                  <th class="py-2 pr-4">Call #</th>
+                  <th class="py-2 pr-4">Resultat</th>
+                  <th class="py-2 pr-4">Status</th>
+                  <th class="py-2 pr-4">Duration</th>
+                  <th class="py-2 pr-4">has_answer</th>
+                  <th class="py-2 pr-4">has_citations</th>
+                  <th class="py-2 pr-4">support_score</th>
+                  <th class="py-2 pr-4">error_code</th>
+                </tr>
+              </thead>
+              <tbody id="probe-tbody" class="text-gray-800" />
+            </table>
+          </div>
+
+          <p class="mt-6 max-w-prose text-xs text-gray-500">
+            5 kall med 8 sek mellomrom. Metadata only — ingen tokens, headers eller svarinnhold.
+          </p>
+        </>
+      )
+    }
+  </main>
+</VisInternalLayout>
+
+{
+  enabled && (
+    <script define:vars={{ apiPath }}>
+      const RUN_COUNT = 5;
+      const DELAY_MS = 8000;
+      const CHANNEL_BASELINE_PCT = 25;
+
+      const runBtn = document.getElementById("probe-run");
+      const statusEl = document.getElementById("probe-status");
+      const summaryEl = document.getElementById("probe-summary");
+      const tableEl = document.getElementById("probe-table");
+      const tbody = document.getElementById("probe-tbody");
+
+      function sleep(ms) {
+        return new Promise((r) => setTimeout(r, ms));
+      }
+
+      function renderSummary(rows) {
+        const total = rows.length;
+        const success = rows.filter((r) => r.status === "success").length;
+        const upstream = rows.filter((r) => r.error_code === "upstream").length;
+        const timeout = rows.filter((r) => r.error_code === "timeout").length;
+        const other = total - success - upstream - timeout;
+        const rate = total ? Math.round((success / total) * 100) : 0;
+        const vsBaseline =
+          rate > CHANNEL_BASELINE_PCT
+            ? "bedre enn channel (25%)"
+            : rate < CHANNEL_BASELINE_PCT
+              ? "verre enn channel (25%)"
+              : "lik channel-baseline (25%)";
+
+        summaryEl.classList.remove("hidden");
+        summaryEl.innerHTML = `
+          <p class="font-medium text-gray-900">Oppsummering (direct :answer)</p>
+          <ul class="mt-2 space-y-1">
+            <li>Total: ${total}</li>
+            <li>Success: ${success}</li>
+            <li>Upstream: ${upstream}</li>
+            <li>Timeout: ${timeout}</li>
+            <li>Andre feil: ${other}</li>
+            <li>Success-rate: ${rate}% — ${vsBaseline}</li>
+          </ul>
+        `;
+      }
+
+      function appendRow(n, data) {
+        const tr = document.createElement("tr");
+        tr.className = "border-b border-gray-100";
+        const resultLabel = data.status === "success" ? "success" : "error";
+        tr.innerHTML = `
+          <td class="py-2 pr-4">${n}</td>
+          <td class="py-2 pr-4">${resultLabel}</td>
+          <td class="py-2 pr-4">${data.status ?? "—"}</td>
+          <td class="py-2 pr-4">${data.duration_bucket ?? "—"}</td>
+          <td class="py-2 pr-4">${data.has_answer ? "ja" : "nei"}</td>
+          <td class="py-2 pr-4">${data.has_citations ? "ja" : "nei"}</td>
+          <td class="py-2 pr-4">${data.support_score ?? "—"}</td>
+          <td class="py-2 pr-4">${data.error_code ?? "—"}</td>
+        `;
+        tbody.appendChild(tr);
+      }
+
+      async function runProbe() {
+        runBtn.disabled = true;
+        tbody.innerHTML = "";
+        summaryEl.classList.add("hidden");
+        tableEl.classList.remove("hidden");
+        const rows = [];
+
+        for (let i = 1; i <= RUN_COUNT; i += 1) {
+          statusEl.textContent = `Kjører kall ${i} av ${RUN_COUNT}…`;
+          try {
+            const res = await fetch(apiPath, { method: "POST" });
+            const data = await res.json().catch(() => ({}));
+            if (!data.enabled) {
+              statusEl.textContent = data.message ?? "Probe deaktivert.";
+              break;
+            }
+            rows.push(data);
+            appendRow(i, data);
+          } catch {
+            rows.push({
+              status: "error",
+              error_code: "upstream",
+              duration_bucket: "—",
+              has_answer: false,
+              has_citations: false,
+              support_score: null,
+            });
+            appendRow(i, rows[rows.length - 1]);
+          }
+          if (i < RUN_COUNT) await sleep(DELAY_MS);
+        }
+
+        renderSummary(rows);
+        statusEl.textContent = rows.length ? "Ferdig." : "Ingen resultater.";
+        runBtn.disabled = false;
+      }
+
+      runBtn?.addEventListener("click", () => {
+        void runProbe();
+      });
+    </script>
+  )
+}

--- a/src/pages/vis/system/agent-search-direct-probe/index.astro
+++ b/src/pages/vis/system/agent-search-direct-probe/index.astro
@@ -114,7 +114,8 @@ const buildPreview = getPreviewDiagnosticsState();
           </div>
 
           <p class="mt-6 max-w-prose text-xs text-gray-500">
-            5 kall med 8 sek mellomrom. Metadata only — ingen tokens, headers eller svarinnhold.
+            5 kall med 8 sek mellomrom via <strong>GET ?run=1</strong> (POST er ofte blokkert av Vercel Deployment Protection på
+            preview). Metadata only.
           </p>
         </>
       )

--- a/src/pages/vis/system/index.astro
+++ b/src/pages/vis/system/index.astro
@@ -103,6 +103,11 @@ const base = import.meta.env.BASE_URL;
           <b>GitHub runtime status</b>
           <p>Generert feed fra GitHub API for @navigator / Daily Sync.</p>
         </a>
+        <a href={`${base}vis/system/agent-search-direct-probe`}>
+          <span>preview · #198</span>
+          <b>Agent Search direct probe</b>
+          <p>Kun Vercel Preview — 5× :answer med safe metadata (ikke production).</p>
+        </a>
       </div>
     </section>
 

--- a/src/scripts/agent-search-direct-probe-client.ts
+++ b/src/scripts/agent-search-direct-probe-client.ts
@@ -224,7 +224,8 @@ function renderReadiness(data: Record<string, unknown>, fetchUrl: string): strin
       <li>VERCEL_ENV: <code class="rounded bg-gray-100 px-1 text-xs">${esc(data.vercel_env)}</code></li>
       <li>Preview enabled: <strong>${data.preview_enabled ? "ja" : "nei"}</strong></li>
       <li>Endpoint host: ${esc(data.endpoint_host)}</li>
-      <li>Env: project=${readiness.has_project_id ? "✓" : "✗"} location=${readiness.has_location ? "✓" : "✗"} engine=${readiness.has_app_id_or_engine_id ? "✓" : "✗"} SA=${readiness.has_service_account ? "✓" : "✗"}</li>
+      <li>Env: project=${readiness.has_project_id ? "✓" : "✗"} location=${readiness.has_location ? "✓" : "✗"} AGENT_SEARCH_ENGINE_ID=${readiness.has_agent_search_engine_id ? "✓" : "✗"} CES_APP_ID (ikke engine)=${readiness.has_ces_app_id ? "satt" : "—"} SA=${readiness.has_service_account ? "✓" : "✗"}</li>
+      ${data.ces_app_id_not_engine ? `<li class="text-xs text-amber-800">CES_APP_ID er CES apps/… — ikke bruk som Discovery Engine engines/…</li>` : ""}
     </ul>
     <p class="mt-2 text-xs text-gray-600">Probe-kjøring bruker <strong>GET ?run=1</strong> (POST er ofte blokkert av Vercel Deployment Protection på preview).</p>
     ${data.vercel_env_note ? `<p class="mt-2 text-xs text-amber-800">${esc(data.vercel_env_note)}</p>` : ""}

--- a/src/scripts/agent-search-direct-probe-client.ts
+++ b/src/scripts/agent-search-direct-probe-client.ts
@@ -308,7 +308,9 @@ function buildRouteNote(data: Record<string, unknown>): string {
   }
   if (data.google_call_attempted === true) {
     if (data.status === "success") return "Google :answer OK (GET ?run=1)";
-    return `Google upstream HTTP ${esc(data.upstream_http_status)} (${esc(data.error_code)})`;
+    const hint = data.google_error_hint ? ` — ${esc(data.google_error_hint)}` : "";
+    const rpc = data.google_rpc_status ? ` ${esc(data.google_rpc_status)}` : "";
+    return `Google HTTP ${esc(data.upstream_http_status)}${rpc} (${esc(data.error_code)})${hint}`;
   }
   return String(data.route_note ?? data.message ?? "—");
 }

--- a/src/scripts/agent-search-direct-probe-client.ts
+++ b/src/scripts/agent-search-direct-probe-client.ts
@@ -1,0 +1,290 @@
+/* CONTRACT: Preview probe UI — binds button, shows per-call metadata, never logs prompt/answer. */
+
+const RUN_COUNT = 5;
+const DELAY_MS = 8000;
+const CHANNEL_BASELINE_PCT = 25;
+
+type ProbeRow = Record<string, unknown>;
+
+type ProbeElements = {
+  runBtn: HTMLButtonElement;
+  statusEl: HTMLElement;
+  summaryEl: HTMLElement;
+  tableEl: HTMLElement;
+  tbody: HTMLElement;
+  readinessEl: HTMLElement;
+  diagEl: HTMLElement;
+};
+
+function resolveApiPath(configuredPath: string): string {
+  const trimmed = configuredPath.trim();
+  if (trimmed.startsWith("http")) return trimmed;
+  const path = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return new URL(path, window.location.origin).href;
+}
+
+function requireElements(): ProbeElements {
+  const ids = [
+    ["probe-run", "runBtn"],
+    ["probe-status", "statusEl"],
+    ["probe-summary", "summaryEl"],
+    ["probe-table", "tableEl"],
+    ["probe-tbody", "tbody"],
+    ["probe-readiness", "readinessEl"],
+    ["probe-diagnostics", "diagEl"],
+  ] as const;
+
+  const out: Partial<ProbeElements> = {};
+  const missing: string[] = [];
+
+  for (const [id, key] of ids) {
+    const el = document.getElementById(id);
+    if (!el) {
+      missing.push(`#${id}`);
+      continue;
+    }
+    if (key === "runBtn" && !(el instanceof HTMLButtonElement)) {
+      missing.push(`#${id} (ikke button)`);
+      continue;
+    }
+    (out as Record<string, HTMLElement>)[key] = el as HTMLElement;
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Probe UI mangler elementer: ${missing.join(", ")}`);
+  }
+
+  return out as ProbeElements;
+}
+
+function esc(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function renderReadiness(data: Record<string, unknown>): string {
+  const readiness = (data.env_readiness ?? {}) as Record<string, boolean>;
+  return `
+    <p class="font-medium text-gray-900">API readiness (GET)</p>
+    <ul class="mt-2 space-y-1 text-sm">
+      <li>API route reached: <strong>${esc(data.api_route_reached ?? data.route_reached ? "yes" : "no")}</strong></li>
+      <li>VERCEL_ENV: <code class="rounded bg-gray-100 px-1 text-xs">${esc(data.vercel_env)}</code></li>
+      <li>Preview enabled: <strong>${data.preview_enabled ? "ja" : "nei"}</strong></li>
+      <li>Endpoint host: ${esc(data.endpoint_host)}</li>
+      <li>Env: project=${readiness.has_project_id ? "✓" : "✗"} location=${readiness.has_location ? "✓" : "✗"} engine=${readiness.has_app_id_or_engine_id ? "✓" : "✗"} SA=${readiness.has_service_account ? "✓" : "✗"}</li>
+    </ul>
+    ${data.vercel_env_note ? `<p class="mt-2 text-xs text-amber-800">${esc(data.vercel_env_note)}</p>` : ""}
+  `;
+}
+
+function renderSummary(rows: ProbeRow[], diagMessages: string[]): void {
+  const { summaryEl, diagEl } = requireElements();
+  const total = rows.length;
+  const success = rows.filter((r) => r.status === "success").length;
+  const upstream = rows.filter((r) => r.error_code === "upstream").length;
+  const timeout = rows.filter((r) => r.error_code === "timeout").length;
+  const config = rows.filter((r) => r.error_code === "configuration_missing").length;
+  const fetchErr = rows.filter((r) => r.error_code === "client_fetch").length;
+  const other = total - success - upstream - timeout - config - fetchErr;
+  const rate = total ? Math.round((success / total) * 100) : 0;
+  const vsBaseline =
+    total === 0
+      ? "ingen kall registrert — se diagnostikk"
+      : rate > CHANNEL_BASELINE_PCT
+        ? "bedre enn channel (25%)"
+        : rate < CHANNEL_BASELINE_PCT
+          ? "verre enn channel (25%)"
+          : "lik channel-baseline (25%)";
+
+  summaryEl.classList.remove("hidden");
+  summaryEl.innerHTML = `
+    <p class="font-medium text-gray-900">Oppsummering (direct :answer)</p>
+    <ul class="mt-2 space-y-1">
+      <li>Total: ${total}</li>
+      <li>Success: ${success}</li>
+      <li>Upstream: ${upstream}</li>
+      <li>Timeout: ${timeout}</li>
+      <li>Config missing: ${config}</li>
+      <li>Fetch/klient: ${fetchErr}</li>
+      <li>Andre feil: ${other}</li>
+      <li>Success-rate: ${total ? `${rate}% — ${vsBaseline}` : "N/A"}</li>
+    </ul>
+    ${
+      total === 0
+        ? `<p class="mt-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">Ingen kall fullført. ${esc(diagMessages.join(" "))}</p>`
+        : ""
+    }
+  `;
+
+  if (diagMessages.length) {
+    diagEl.classList.remove("hidden");
+    diagEl.innerHTML = `<p class="font-medium text-gray-900">Diagnostikk</p><ul class="mt-2 list-disc pl-5 text-sm">${diagMessages.map((m) => `<li>${esc(m)}</li>`).join("")}</ul>`;
+  }
+}
+
+function appendRow(n: number, data: ProbeRow): void {
+  const { tbody } = requireElements();
+  const tr = document.createElement("tr");
+  tr.className = "border-b border-gray-100";
+  const resultLabel = data.status === "success" ? "success" : "error";
+  tr.innerHTML = `
+    <td class="py-2 pr-4">${n}</td>
+    <td class="py-2 pr-4">${esc(resultLabel)}</td>
+    <td class="py-2 pr-4">${esc(data.api_http_status ?? data.client_http_status ?? "—")}</td>
+    <td class="py-2 pr-4">${esc(data.status ?? "—")}</td>
+    <td class="py-2 pr-4">${esc(data.duration_bucket ?? "—")}</td>
+    <td class="py-2 pr-4">${data.has_answer ? "ja" : "nei"}</td>
+    <td class="py-2 pr-4">${data.has_citations ? "ja" : "nei"}</td>
+    <td class="py-2 pr-4">${esc(data.support_score)}</td>
+    <td class="py-2 pr-4">${esc(data.error_code ?? data.client_error ?? "—")}</td>
+    <td class="py-2 pr-4 text-xs">${esc(data.route_note ?? "")}</td>
+  `;
+  tbody.appendChild(tr);
+}
+
+async function fetchReadiness(apiUrl: string): Promise<void> {
+  const { readinessEl, statusEl } = requireElements();
+  statusEl.textContent = "Sjekker API readiness…";
+  try {
+    const res = await fetch(apiUrl, { method: "GET", headers: { Accept: "application/json" } });
+    const text = await res.text();
+    let data: Record<string, unknown> = {};
+    try {
+      data = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      data = {
+        route_reached: false,
+        client_error: "invalid_json",
+        client_http_status: res.status,
+        route_note: `GET svarte ikke JSON (HTTP ${res.status})`,
+      };
+    }
+    data.client_http_status = res.status;
+    readinessEl.innerHTML = renderReadiness(data);
+    statusEl.textContent = res.ok
+      ? "Klar — trykk knappen for 5 kall."
+      : `API readiness HTTP ${res.status} — se panel over.`;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    readinessEl.innerHTML = `<p class="text-sm text-red-800">Kunne ikke nå API (GET): ${esc(message)}</p>`;
+    statusEl.textContent = "API ikke nådd — sjekk preview-deploy og /api/agent-search-direct-probe.";
+  }
+}
+
+async function runProbe(apiUrl: string): Promise<void> {
+  const { runBtn, statusEl, summaryEl, tableEl, tbody, diagEl } = requireElements();
+  const rows: ProbeRow[] = [];
+  const diagMessages: string[] = [];
+
+  runBtn.disabled = true;
+  tbody.innerHTML = "";
+  summaryEl.classList.add("hidden");
+  diagEl.classList.add("hidden");
+  diagEl.innerHTML = "";
+  tableEl.classList.remove("hidden");
+
+  statusEl.textContent = "Starter probe…";
+
+  for (let i = 1; i <= RUN_COUNT; i += 1) {
+    statusEl.textContent = `Kjører ${i}/${RUN_COUNT}…`;
+    let row: ProbeRow = {
+      status: "error",
+      error_code: "client_fetch",
+      client_http_status: null,
+      duration_bucket: "—",
+      has_answer: false,
+      has_citations: false,
+      support_score: null,
+      route_note: "",
+    };
+
+    try {
+      const res = await fetch(apiUrl, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+      });
+      const text = await res.text();
+      row.client_http_status = res.status;
+
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(text) as Record<string, unknown>;
+      } catch {
+        row.error_code = "client_fetch";
+        row.route_note = `POST ikke JSON (HTTP ${res.status}, ${text.slice(0, 80)})`;
+        diagMessages.push(`Kall ${i}: ugyldig JSON fra API.`);
+        rows.push(row);
+        appendRow(i, row);
+        if (i < RUN_COUNT) await sleep(DELAY_MS);
+        continue;
+      }
+
+      row = { ...row, ...data, client_http_status: res.status };
+
+      if (data.preview_enabled === false || data.enabled === false) {
+        row.error_code = data.error_code ?? "disabled";
+        row.route_note = String(data.message ?? "Preview gate: deaktivert");
+        diagMessages.push(`Kall ${i}: ${row.route_note}`);
+      } else if (!res.ok && !data.error_code) {
+        row.error_code = "upstream";
+        row.route_note = `API HTTP ${res.status}`;
+      } else if (data.google_call_attempted === false) {
+        row.route_note = `Google ikke kalt — ${String(data.error_code ?? "config")}`;
+      } else {
+        row.route_note = data.status === "success" ? "Google :answer OK" : `Google ${esc(data.upstream_http_status)}`;
+      }
+
+      rows.push(row);
+      appendRow(i, row);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      row.error_code = "client_fetch";
+      row.route_note = `Fetch feilet: ${message}`;
+      diagMessages.push(`Kall ${i}: ${message}`);
+      rows.push(row);
+      appendRow(i, row);
+    }
+
+    if (i < RUN_COUNT) await sleep(DELAY_MS);
+  }
+
+  renderSummary(rows, diagMessages);
+  statusEl.textContent = rows.length ? `Ferdig — ${rows.length} kall registrert.` : "Ferdig uten registrerte kall.";
+  runBtn.disabled = false;
+}
+
+export function initAgentSearchDirectProbe(configuredApiPath: string): void {
+  const apiUrl = resolveApiPath(configuredApiPath);
+
+  try {
+    const { runBtn, diagEl } = requireElements();
+    diagEl.classList.add("hidden");
+
+    void fetchReadiness(apiUrl);
+
+    runBtn.addEventListener("click", () => {
+      void runProbe(apiUrl).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        const { statusEl, summaryEl, runBtn } = requireElements();
+        runBtn.disabled = false;
+        statusEl.textContent = `Probe feilet: ${message}`;
+        summaryEl.classList.remove("hidden");
+        summaryEl.innerHTML = `<p class="text-sm text-red-800"><strong>Probe avbrutt:</strong> ${esc(message)}</p>`;
+      });
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const fallback = document.getElementById("probe-bootstrap-error");
+    if (fallback) {
+      fallback.textContent = `Klientfeil: ${message}`;
+      fallback.classList.remove("hidden");
+    }
+  }
+}

--- a/src/scripts/agent-search-direct-probe-client.ts
+++ b/src/scripts/agent-search-direct-probe-client.ts
@@ -23,6 +23,74 @@ function resolveApiPath(configuredPath: string): string {
   return new URL(path, window.location.origin).href;
 }
 
+function isOurProbeRoute(data: Record<string, unknown>): boolean {
+  return data.route_reached === true || data.api_route_reached === "yes";
+}
+
+function parseProbeHttpResponse(
+  res: Response,
+  text: string,
+  method: "GET" | "POST",
+): Record<string, unknown> {
+  let data: Record<string, unknown> = {};
+  try {
+    data = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    const wrongPath = res.status === 404;
+    return {
+      route_reached: false,
+      api_route_reached: "no",
+      preview_enabled: false,
+      status: "error",
+      error_code: wrongPath ? "route_not_found" : "route_not_reached",
+      error_source: "app",
+      client_http_status: res.status,
+      route_note:
+        method === "GET"
+          ? `GET ${res.status} — ikke JSON fra probe-API (sjekk at path er /api/agent-search-direct-probe)`
+          : `POST ${res.status} — ikke JSON fra probe-API`,
+      has_answer: false,
+      has_citations: false,
+      support_score: null,
+      duration_bucket: "—",
+    };
+  }
+
+  data.client_http_status = res.status;
+
+  if (!isOurProbeRoute(data)) {
+    const wrongPath = res.status === 404;
+    return {
+      ...data,
+      route_reached: false,
+      api_route_reached: "no",
+      status: "error",
+      error_code: wrongPath ? "route_not_found" : "route_not_reached",
+      error_source: "app",
+      route_note: wrongPath
+        ? "Intern route ikke funnet — feil fetch-path (forventet /api/agent-search-direct-probe)"
+        : "Svar mangler route_reached — ikke fra vår probe-API",
+      has_answer: false,
+      has_citations: false,
+    };
+  }
+
+  if (data.preview_enabled === false && data.error_code !== "disabled_in_production") {
+    data.error_code = "disabled_in_production";
+    data.error_source = "app";
+  }
+
+  if (data.error_code === "configuration_missing") {
+    data.error_source = "config";
+  }
+
+  if (data.google_call_attempted === true && data.status === "error" && !data.error_source) {
+    data.error_source = "google";
+  }
+
+  return data;
+}
+
 function requireElements(): ProbeElements {
   const ids = [
     ["probe-run", "runBtn"],
@@ -69,17 +137,22 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-function renderReadiness(data: Record<string, unknown>): string {
+function renderReadiness(data: Record<string, unknown>, fetchUrl: string): string {
   const readiness = (data.env_readiness ?? {}) as Record<string, boolean>;
+  const routeOk = isOurProbeRoute(data);
   return `
     <p class="font-medium text-gray-900">API readiness (GET)</p>
     <ul class="mt-2 space-y-1 text-sm">
-      <li>API route reached: <strong>${esc(data.api_route_reached ?? data.route_reached ? "yes" : "no")}</strong></li>
+      <li>Fetch URL: <code class="rounded bg-gray-100 px-1 text-xs break-all">${esc(fetchUrl)}</code></li>
+      <li>API route reached: <strong>${routeOk ? "yes" : "no"}</strong></li>
+      <li>HTTP: ${esc(data.client_http_status ?? data.api_http_status)}</li>
       <li>VERCEL_ENV: <code class="rounded bg-gray-100 px-1 text-xs">${esc(data.vercel_env)}</code></li>
       <li>Preview enabled: <strong>${data.preview_enabled ? "ja" : "nei"}</strong></li>
       <li>Endpoint host: ${esc(data.endpoint_host)}</li>
       <li>Env: project=${readiness.has_project_id ? "✓" : "✗"} location=${readiness.has_location ? "✓" : "✗"} engine=${readiness.has_app_id_or_engine_id ? "✓" : "✗"} SA=${readiness.has_service_account ? "✓" : "✗"}</li>
+      ${data.error_code ? `<li>error_code: <code class="text-xs">${esc(data.error_code)}</code></li>` : ""}
     </ul>
+    ${data.route_note ? `<p class="mt-2 text-xs text-amber-800">${esc(data.route_note)}</p>` : ""}
     ${data.vercel_env_note ? `<p class="mt-2 text-xs text-amber-800">${esc(data.vercel_env_note)}</p>` : ""}
   `;
 }
@@ -88,11 +161,14 @@ function renderSummary(rows: ProbeRow[], diagMessages: string[]): void {
   const { summaryEl, diagEl } = requireElements();
   const total = rows.length;
   const success = rows.filter((r) => r.status === "success").length;
-  const upstream = rows.filter((r) => r.error_code === "upstream").length;
-  const timeout = rows.filter((r) => r.error_code === "timeout").length;
+  const routeMiss = rows.filter((r) =>
+    ["route_not_found", "route_not_reached"].includes(String(r.error_code)),
+  ).length;
+  const googleErr = rows.filter((r) => String(r.error_code).startsWith("google_")).length;
   const config = rows.filter((r) => r.error_code === "configuration_missing").length;
+  const timeout = rows.filter((r) => r.error_code === "timeout").length;
   const fetchErr = rows.filter((r) => r.error_code === "client_fetch").length;
-  const other = total - success - upstream - timeout - config - fetchErr;
+  const other = total - success - routeMiss - googleErr - config - timeout - fetchErr;
   const rate = total ? Math.round((success / total) * 100) : 0;
   const vsBaseline =
     total === 0
@@ -109,11 +185,12 @@ function renderSummary(rows: ProbeRow[], diagMessages: string[]): void {
     <ul class="mt-2 space-y-1">
       <li>Total: ${total}</li>
       <li>Success: ${success}</li>
-      <li>Upstream: ${upstream}</li>
-      <li>Timeout: ${timeout}</li>
+      <li>Route ikke treffet: ${routeMiss}</li>
+      <li>Google-feil: ${googleErr}</li>
       <li>Config missing: ${config}</li>
+      <li>Timeout: ${timeout}</li>
       <li>Fetch/klient: ${fetchErr}</li>
-      <li>Andre feil: ${other}</li>
+      <li>Andre: ${other}</li>
       <li>Success-rate: ${total ? `${rate}% — ${vsBaseline}` : "N/A"}</li>
     </ul>
     ${
@@ -143,10 +220,27 @@ function appendRow(n: number, data: ProbeRow): void {
     <td class="py-2 pr-4">${data.has_answer ? "ja" : "nei"}</td>
     <td class="py-2 pr-4">${data.has_citations ? "ja" : "nei"}</td>
     <td class="py-2 pr-4">${esc(data.support_score)}</td>
-    <td class="py-2 pr-4">${esc(data.error_code ?? data.client_error ?? "—")}</td>
+    <td class="py-2 pr-4">${esc(data.error_code ?? "—")}</td>
     <td class="py-2 pr-4 text-xs">${esc(data.route_note ?? "")}</td>
   `;
   tbody.appendChild(tr);
+}
+
+function buildRouteNote(data: Record<string, unknown>, res: Response): string {
+  if (!isOurProbeRoute(data)) {
+    return String(data.route_note ?? "Intern route ikke treffet");
+  }
+  if (data.error_code === "disabled_in_production") {
+    return "Preview gate: production";
+  }
+  if (data.error_code === "configuration_missing") {
+    return `Mangler env: ${Array.isArray(data.missing_env) ? (data.missing_env as string[]).join(", ") : "config"}`;
+  }
+  if (data.google_call_attempted === true) {
+    if (data.status === "success") return "Google :answer OK";
+    return `Google upstream HTTP ${esc(data.upstream_http_status)} (${esc(data.error_code)})`;
+  }
+  return String(data.message ?? `API HTTP ${res.status}`);
 }
 
 async function fetchReadiness(apiUrl: string): Promise<void> {
@@ -155,26 +249,20 @@ async function fetchReadiness(apiUrl: string): Promise<void> {
   try {
     const res = await fetch(apiUrl, { method: "GET", headers: { Accept: "application/json" } });
     const text = await res.text();
-    let data: Record<string, unknown> = {};
-    try {
-      data = JSON.parse(text) as Record<string, unknown>;
-    } catch {
-      data = {
-        route_reached: false,
-        client_error: "invalid_json",
-        client_http_status: res.status,
-        route_note: `GET svarte ikke JSON (HTTP ${res.status})`,
-      };
+    const data = parseProbeHttpResponse(res, text, "GET");
+    readinessEl.innerHTML = renderReadiness(data, apiUrl);
+
+    if (!isOurProbeRoute(data)) {
+      statusEl.textContent = `Feil path eller route — HTTP ${res.status}. Forvent /api/agent-search-direct-probe`;
+      return;
     }
-    data.client_http_status = res.status;
-    readinessEl.innerHTML = renderReadiness(data);
     statusEl.textContent = res.ok
       ? "Klar — trykk knappen for 5 kall."
-      : `API readiness HTTP ${res.status} — se panel over.`;
+      : `API readiness HTTP ${res.status} (${esc(data.error_code)}) — se panel.`;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    readinessEl.innerHTML = `<p class="text-sm text-red-800">Kunne ikke nå API (GET): ${esc(message)}</p>`;
-    statusEl.textContent = "API ikke nådd — sjekk preview-deploy og /api/agent-search-direct-probe.";
+    readinessEl.innerHTML = `<p class="text-sm text-red-800">Kunne ikke nå API (GET): ${esc(message)}</p><p class="mt-1 text-xs">URL: ${esc(apiUrl)}</p>`;
+    statusEl.textContent = "route_not_reached — nettverksfeil mot probe-API.";
   }
 }
 
@@ -194,16 +282,6 @@ async function runProbe(apiUrl: string): Promise<void> {
 
   for (let i = 1; i <= RUN_COUNT; i += 1) {
     statusEl.textContent = `Kjører ${i}/${RUN_COUNT}…`;
-    let row: ProbeRow = {
-      status: "error",
-      error_code: "client_fetch",
-      client_http_status: null,
-      duration_bucket: "—",
-      has_answer: false,
-      has_citations: false,
-      support_score: null,
-      route_note: "",
-    };
 
     try {
       const res = await fetch(apiUrl, {
@@ -211,42 +289,29 @@ async function runProbe(apiUrl: string): Promise<void> {
         headers: { Accept: "application/json" },
       });
       const text = await res.text();
-      row.client_http_status = res.status;
+      const data = parseProbeHttpResponse(res, text, "POST");
+      data.route_note = buildRouteNote(data, res);
+      rows.push(data);
+      appendRow(i, data);
 
-      let data: Record<string, unknown>;
-      try {
-        data = JSON.parse(text) as Record<string, unknown>;
-      } catch {
-        row.error_code = "client_fetch";
-        row.route_note = `POST ikke JSON (HTTP ${res.status}, ${text.slice(0, 80)})`;
-        diagMessages.push(`Kall ${i}: ugyldig JSON fra API.`);
-        rows.push(row);
-        appendRow(i, row);
-        if (i < RUN_COUNT) await sleep(DELAY_MS);
-        continue;
+      if (!isOurProbeRoute(data)) {
+        diagMessages.push(`Kall ${i}: ${data.route_note}`);
+      } else if (data.error_code === "configuration_missing") {
+        diagMessages.push(`Kall ${i}: mangler Vercel env — ${(data.missing_env as string[] | undefined)?.join(", ") ?? ""}`);
       }
-
-      row = { ...row, ...data, client_http_status: res.status };
-
-      if (data.preview_enabled === false || data.enabled === false) {
-        row.error_code = data.error_code ?? "disabled";
-        row.route_note = String(data.message ?? "Preview gate: deaktivert");
-        diagMessages.push(`Kall ${i}: ${row.route_note}`);
-      } else if (!res.ok && !data.error_code) {
-        row.error_code = "upstream";
-        row.route_note = `API HTTP ${res.status}`;
-      } else if (data.google_call_attempted === false) {
-        row.route_note = `Google ikke kalt — ${String(data.error_code ?? "config")}`;
-      } else {
-        row.route_note = data.status === "success" ? "Google :answer OK" : `Google ${esc(data.upstream_http_status)}`;
-      }
-
-      rows.push(row);
-      appendRow(i, row);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      row.error_code = "client_fetch";
-      row.route_note = `Fetch feilet: ${message}`;
+      const row: ProbeRow = {
+        status: "error",
+        error_code: "client_fetch",
+        error_source: "client",
+        client_http_status: null,
+        duration_bucket: "—",
+        has_answer: false,
+        has_citations: false,
+        support_score: null,
+        route_note: `Fetch feilet: ${message}`,
+      };
       diagMessages.push(`Kall ${i}: ${message}`);
       rows.push(row);
       appendRow(i, row);

--- a/src/scripts/agent-search-direct-probe-client.ts
+++ b/src/scripts/agent-search-direct-probe-client.ts
@@ -16,6 +16,9 @@ type ProbeElements = {
   diagEl: HTMLElement;
 };
 
+/** Set after successful readiness GET with route_reached. */
+let readinessRouteOk = false;
+
 function resolveApiPath(configuredPath: string): string {
   const trimmed = configuredPath.trim();
   if (trimmed.startsWith("http")) return trimmed;
@@ -23,59 +26,130 @@ function resolveApiPath(configuredPath: string): string {
   return new URL(path, window.location.origin).href;
 }
 
+function probeRunUrl(apiUrl: string): string {
+  const url = new URL(apiUrl);
+  url.searchParams.set("run", "1");
+  return url.href;
+}
+
 function isOurProbeRoute(data: Record<string, unknown>): boolean {
   return data.route_reached === true || data.api_route_reached === "yes";
+}
+
+function looksLikeVercelProtectionHtml(text: string): boolean {
+  const sample = text.slice(0, 2000).toLowerCase();
+  return (
+    sample.includes("vercel") &&
+    (sample.includes("authentication") ||
+      sample.includes("login") ||
+      sample.includes("deployment protection") ||
+      sample.includes("sso"))
+  );
+}
+
+function classifyNonJsonResponse(
+  res: Response,
+  text: string,
+  method: "GET" | "POST",
+  isExecuteCall: boolean,
+): Record<string, unknown> {
+  const status = res.status;
+
+  if (method === "POST" && isExecuteCall && readinessRouteOk && (status === 401 || status === 403)) {
+    const vercelBlock = looksLikeVercelProtectionHtml(text);
+    return {
+      route_reached: false,
+      api_route_reached: "no",
+      status: "error",
+      error_code: vercelBlock ? "post_blocked_before_handler" : "post_route_not_reached",
+      error_source: "vercel",
+      client_http_status: status,
+      method: "POST",
+      google_call_attempted: false,
+      route_note: vercelBlock
+        ? "POST blokkert før handler (sannsynlig Vercel Deployment Protection) — bruker GET ?run=1"
+        : `POST ${status} uten JSON — ikke fra probe-handler`,
+      has_answer: false,
+      has_citations: false,
+      support_score: null,
+      duration_bucket: "—",
+      response_preview_type: vercelBlock ? "html_vercel_protection" : "non_json",
+    };
+  }
+
+  if (status === 404) {
+    return {
+      route_reached: false,
+      api_route_reached: "no",
+      status: "error",
+      error_code: method === "POST" ? "post_route_not_reached" : "route_not_found",
+      error_source: "app",
+      client_http_status: status,
+      method,
+      google_call_attempted: false,
+      route_note: `${method} 404 — route_not_found`,
+      has_answer: false,
+      has_citations: false,
+      support_score: null,
+      duration_bucket: "—",
+      response_preview_type: "non_json",
+    };
+  }
+
+  return {
+    route_reached: false,
+    api_route_reached: "no",
+    status: "error",
+    error_code: "non_json_response_from_probe_route",
+    error_source: "app",
+    client_http_status: status,
+    method,
+    google_call_attempted: false,
+    route_note: `${method} ${status} — non_json_response_from_probe_route`,
+    has_answer: false,
+    has_citations: false,
+    support_score: null,
+    duration_bucket: "—",
+    response_preview_type: looksLikeVercelProtectionHtml(text) ? "html_vercel_protection" : "non_json",
+  };
 }
 
 function parseProbeHttpResponse(
   res: Response,
   text: string,
   method: "GET" | "POST",
+  isExecuteCall: boolean,
 ): Record<string, unknown> {
-  let data: Record<string, unknown> = {};
+  let data: Record<string, unknown>;
   try {
     data = JSON.parse(text) as Record<string, unknown>;
   } catch {
-    const wrongPath = res.status === 404;
-    return {
-      route_reached: false,
-      api_route_reached: "no",
-      preview_enabled: false,
-      status: "error",
-      error_code: wrongPath ? "route_not_found" : "route_not_reached",
-      error_source: "app",
-      client_http_status: res.status,
-      route_note:
-        method === "GET"
-          ? `GET ${res.status} — ikke JSON fra probe-API (sjekk at path er /api/agent-search-direct-probe)`
-          : `POST ${res.status} — ikke JSON fra probe-API`,
-      has_answer: false,
-      has_citations: false,
-      support_score: null,
-      duration_bucket: "—",
-    };
+    return classifyNonJsonResponse(res, text, method, isExecuteCall);
   }
 
   data.client_http_status = res.status;
+  data.method = data.method ?? method;
 
   if (!isOurProbeRoute(data)) {
-    const wrongPath = res.status === 404;
     return {
       ...data,
       route_reached: false,
       api_route_reached: "no",
       status: "error",
-      error_code: wrongPath ? "route_not_found" : "route_not_reached",
+      error_code:
+        res.status === 404
+          ? method === "POST"
+            ? "post_route_not_reached"
+            : "route_not_found"
+          : "non_json_response_from_probe_route",
       error_source: "app",
-      route_note: wrongPath
-        ? "Intern route ikke funnet — feil fetch-path (forventet /api/agent-search-direct-probe)"
-        : "Svar mangler route_reached — ikke fra vår probe-API",
+      route_note: "Svar mangler route_reached — ikke fra vår probe-API",
       has_answer: false,
       has_citations: false,
     };
   }
 
-  if (data.preview_enabled === false && data.error_code !== "disabled_in_production") {
+  if (data.preview_enabled === false) {
     data.error_code = "disabled_in_production";
     data.error_source = "app";
   }
@@ -84,8 +158,8 @@ function parseProbeHttpResponse(
     data.error_source = "config";
   }
 
-  if (data.google_call_attempted === true && data.status === "error" && !data.error_source) {
-    data.error_source = "google";
+  if (data.google_call_attempted === true && data.status === "error") {
+    data.error_source = data.error_source ?? "google";
   }
 
   return data;
@@ -144,15 +218,15 @@ function renderReadiness(data: Record<string, unknown>, fetchUrl: string): strin
     <p class="font-medium text-gray-900">API readiness (GET)</p>
     <ul class="mt-2 space-y-1 text-sm">
       <li>Fetch URL: <code class="rounded bg-gray-100 px-1 text-xs break-all">${esc(fetchUrl)}</code></li>
+      <li>Execute URL: <code class="rounded bg-gray-100 px-1 text-xs break-all">${esc(probeRunUrl(fetchUrl))}</code></li>
       <li>API route reached: <strong>${routeOk ? "yes" : "no"}</strong></li>
       <li>HTTP: ${esc(data.client_http_status ?? data.api_http_status)}</li>
       <li>VERCEL_ENV: <code class="rounded bg-gray-100 px-1 text-xs">${esc(data.vercel_env)}</code></li>
       <li>Preview enabled: <strong>${data.preview_enabled ? "ja" : "nei"}</strong></li>
       <li>Endpoint host: ${esc(data.endpoint_host)}</li>
       <li>Env: project=${readiness.has_project_id ? "✓" : "✗"} location=${readiness.has_location ? "✓" : "✗"} engine=${readiness.has_app_id_or_engine_id ? "✓" : "✗"} SA=${readiness.has_service_account ? "✓" : "✗"}</li>
-      ${data.error_code ? `<li>error_code: <code class="text-xs">${esc(data.error_code)}</code></li>` : ""}
     </ul>
-    ${data.route_note ? `<p class="mt-2 text-xs text-amber-800">${esc(data.route_note)}</p>` : ""}
+    <p class="mt-2 text-xs text-gray-600">Probe-kjøring bruker <strong>GET ?run=1</strong> (POST er ofte blokkert av Vercel Deployment Protection på preview).</p>
     ${data.vercel_env_note ? `<p class="mt-2 text-xs text-amber-800">${esc(data.vercel_env_note)}</p>` : ""}
   `;
 }
@@ -161,14 +235,12 @@ function renderSummary(rows: ProbeRow[], diagMessages: string[]): void {
   const { summaryEl, diagEl } = requireElements();
   const total = rows.length;
   const success = rows.filter((r) => r.status === "success").length;
-  const routeMiss = rows.filter((r) =>
-    ["route_not_found", "route_not_reached"].includes(String(r.error_code)),
-  ).length;
+  const blocked = rows.filter((r) => r.error_code === "post_blocked_before_handler").length;
   const googleErr = rows.filter((r) => String(r.error_code).startsWith("google_")).length;
   const config = rows.filter((r) => r.error_code === "configuration_missing").length;
   const timeout = rows.filter((r) => r.error_code === "timeout").length;
   const fetchErr = rows.filter((r) => r.error_code === "client_fetch").length;
-  const other = total - success - routeMiss - googleErr - config - timeout - fetchErr;
+  const other = total - success - blocked - googleErr - config - timeout - fetchErr;
   const rate = total ? Math.round((success / total) * 100) : 0;
   const vsBaseline =
     total === 0
@@ -185,19 +257,14 @@ function renderSummary(rows: ProbeRow[], diagMessages: string[]): void {
     <ul class="mt-2 space-y-1">
       <li>Total: ${total}</li>
       <li>Success: ${success}</li>
-      <li>Route ikke treffet: ${routeMiss}</li>
       <li>Google-feil: ${googleErr}</li>
+      <li>POST blokkert (Vercel): ${blocked}</li>
       <li>Config missing: ${config}</li>
       <li>Timeout: ${timeout}</li>
       <li>Fetch/klient: ${fetchErr}</li>
       <li>Andre: ${other}</li>
       <li>Success-rate: ${total ? `${rate}% — ${vsBaseline}` : "N/A"}</li>
     </ul>
-    ${
-      total === 0
-        ? `<p class="mt-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">Ingen kall fullført. ${esc(diagMessages.join(" "))}</p>`
-        : ""
-    }
   `;
 
   if (diagMessages.length) {
@@ -226,9 +293,12 @@ function appendRow(n: number, data: ProbeRow): void {
   tbody.appendChild(tr);
 }
 
-function buildRouteNote(data: Record<string, unknown>, res: Response): string {
+function buildRouteNote(data: Record<string, unknown>): string {
+  if (data.error_code === "post_blocked_before_handler") {
+    return String(data.route_note ?? "POST blokkert — GET ?run=1 brukt");
+  }
   if (!isOurProbeRoute(data)) {
-    return String(data.route_note ?? "Intern route ikke treffet");
+    return String(data.route_note ?? "Route ikke treffet");
   }
   if (data.error_code === "disabled_in_production") {
     return "Preview gate: production";
@@ -237,33 +307,68 @@ function buildRouteNote(data: Record<string, unknown>, res: Response): string {
     return `Mangler env: ${Array.isArray(data.missing_env) ? (data.missing_env as string[]).join(", ") : "config"}`;
   }
   if (data.google_call_attempted === true) {
-    if (data.status === "success") return "Google :answer OK";
+    if (data.status === "success") return "Google :answer OK (GET ?run=1)";
     return `Google upstream HTTP ${esc(data.upstream_http_status)} (${esc(data.error_code)})`;
   }
-  return String(data.message ?? `API HTTP ${res.status}`);
+  return String(data.route_note ?? data.message ?? "—");
+}
+
+async function fetchProbeExecute(url: string, method: "GET" | "POST"): Promise<{ res: Response; text: string }> {
+  const res = await fetch(url, {
+    method,
+    credentials: "include",
+  });
+  const text = await res.text();
+  return { res, text };
 }
 
 async function fetchReadiness(apiUrl: string): Promise<void> {
   const { readinessEl, statusEl } = requireElements();
+  readinessRouteOk = false;
   statusEl.textContent = "Sjekker API readiness…";
   try {
-    const res = await fetch(apiUrl, { method: "GET", headers: { Accept: "application/json" } });
-    const text = await res.text();
-    const data = parseProbeHttpResponse(res, text, "GET");
+    const { res, text } = await fetchProbeExecute(apiUrl, "GET");
+    const data = parseProbeHttpResponse(res, text, "GET", false);
+    readinessRouteOk = isOurProbeRoute(data) && res.ok;
     readinessEl.innerHTML = renderReadiness(data, apiUrl);
 
-    if (!isOurProbeRoute(data)) {
+    if (!readinessRouteOk) {
       statusEl.textContent = `Feil path eller route — HTTP ${res.status}. Forvent /api/agent-search-direct-probe`;
       return;
     }
-    statusEl.textContent = res.ok
-      ? "Klar — trykk knappen for 5 kall."
-      : `API readiness HTTP ${res.status} (${esc(data.error_code)}) — se panel.`;
+    statusEl.textContent = "Klar — trykk knappen for 5 kall (GET ?run=1).";
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    readinessEl.innerHTML = `<p class="text-sm text-red-800">Kunne ikke nå API (GET): ${esc(message)}</p><p class="mt-1 text-xs">URL: ${esc(apiUrl)}</p>`;
-    statusEl.textContent = "route_not_reached — nettverksfeil mot probe-API.";
+    readinessEl.innerHTML = `<p class="text-sm text-red-800">Kunne ikke nå API (GET): ${esc(message)}</p>`;
+    statusEl.textContent = "GET readiness feilet — nettverksfeil.";
   }
+}
+
+async function runSingleProbeCall(apiUrl: string, callIndex: number): Promise<ProbeRow> {
+  const runUrl = probeRunUrl(apiUrl);
+
+  if (readinessRouteOk) {
+    const { res, text } = await fetchProbeExecute(runUrl, "GET");
+    const data = parseProbeHttpResponse(res, text, "GET", true);
+    data.route_note = buildRouteNote(data);
+    data.probe_transport = "GET ?run=1";
+    return data;
+  }
+
+  const { res, text } = await fetchProbeExecute(apiUrl, "POST");
+  let data = parseProbeHttpResponse(res, text, "POST", true);
+
+  if (!isOurProbeRoute(data) && data.error_code === "post_blocked_before_handler") {
+    const fallback = await fetchProbeExecute(runUrl, "GET");
+    data = parseProbeHttpResponse(fallback.res, fallback.text, "GET", true);
+    data.route_note = `POST blokkert (${res.status}) — fallback GET ?run=1`;
+    data.probe_transport = "GET ?run=1 (fallback)";
+    return data;
+  }
+
+  data.route_note = buildRouteNote(data);
+  data.probe_transport = "POST";
+  return data;
 }
 
 async function runProbe(apiUrl: string): Promise<void> {
@@ -278,26 +383,23 @@ async function runProbe(apiUrl: string): Promise<void> {
   diagEl.innerHTML = "";
   tableEl.classList.remove("hidden");
 
-  statusEl.textContent = "Starter probe…";
+  if (!readinessRouteOk) {
+    diagMessages.push("Readiness GET manglet route_reached — kjører likevel.");
+  }
 
   for (let i = 1; i <= RUN_COUNT; i += 1) {
-    statusEl.textContent = `Kjører ${i}/${RUN_COUNT}…`;
-
+    statusEl.textContent = `Kjører ${i}/${RUN_COUNT}… (GET ?run=1)`;
     try {
-      const res = await fetch(apiUrl, {
-        method: "POST",
-        headers: { Accept: "application/json" },
-      });
-      const text = await res.text();
-      const data = parseProbeHttpResponse(res, text, "POST");
-      data.route_note = buildRouteNote(data, res);
+      const data = await runSingleProbeCall(apiUrl, i);
       rows.push(data);
       appendRow(i, data);
 
-      if (!isOurProbeRoute(data)) {
-        diagMessages.push(`Kall ${i}: ${data.route_note}`);
+      if (data.google_call_attempted === true && data.status !== "success") {
+        diagMessages.push(`Kall ${i}: ${data.error_code} (Google HTTP ${data.upstream_http_status})`);
       } else if (data.error_code === "configuration_missing") {
-        diagMessages.push(`Kall ${i}: mangler Vercel env — ${(data.missing_env as string[] | undefined)?.join(", ") ?? ""}`);
+        diagMessages.push(`Kall ${i}: mangler env`);
+      } else if (data.error_code === "post_blocked_before_handler") {
+        diagMessages.push(`Kall ${i}: POST blokkert av Vercel — bruk GET ?run=1`);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -311,6 +413,7 @@ async function runProbe(apiUrl: string): Promise<void> {
         has_citations: false,
         support_score: null,
         route_note: `Fetch feilet: ${message}`,
+        google_call_attempted: false,
       };
       diagMessages.push(`Kall ${i}: ${message}`);
       rows.push(row);
@@ -321,7 +424,7 @@ async function runProbe(apiUrl: string): Promise<void> {
   }
 
   renderSummary(rows, diagMessages);
-  statusEl.textContent = rows.length ? `Ferdig — ${rows.length} kall registrert.` : "Ferdig uten registrerte kall.";
+  statusEl.textContent = rows.length ? `Ferdig — ${rows.length} kall (GET ?run=1).` : "Ferdig uten rader.";
   runBtn.disabled = false;
 }
 
@@ -331,7 +434,6 @@ export function initAgentSearchDirectProbe(configuredApiPath: string): void {
   try {
     const { runBtn, diagEl } = requireElements();
     diagEl.classList.add("hidden");
-
     void fetchReadiness(apiUrl);
 
     runBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary

- Assessment doc for CES channel vs Discovery Engine `:answer` direct API.
- **Preview-only** diagnostics: `/vis/system/agent-search-direct-probe/` + `POST /api/agent-search-direct-probe`.
- Thomas can run 5 spaced direct API calls from the browser on **Vercel Preview** (no terminal, no local SA).
- Disabled when `VERCEL_ENV=production` (404 API + disabled UI message).
- Safe metadata only — no prompt/answer/token logging.

## Test plan (Thomas)

1. Open **Vercel Preview** from this PR (not production).
2. Go to `/vis/system/agent-search-direct-probe/` (or via VIS → System → Agent Search direct probe).
3. Click **«Kjør 5 direct API-kall»** — wait ~40s (5× + 8s spacing).
4. Compare success-rate vs channel baseline **25%** (4/16).
5. Confirm production URL shows **Deaktivert i production** and API returns 404.

## Out of scope

- No production backend switch
- No PostHog / no channel reliability series
- No secrets in repo

Closes #198 (assessment + probe path; backend mode PR follows if stable).

Made with [Cursor](https://cursor.com)