### PR TITLE
feat(#215): VIDDEL_AI_BACKEND v0.1 (default ces_channel)

### DIFF
--- a/src/lib/agent-search-answer.ts
+++ b/src/lib/agent-search-answer.ts
@@ -1,0 +1,280 @@
+/* CONTRACT: Server-only Discovery Engine :answer for /api/chat — no prompt/answer logging. */
+
+import { getGoogleAccessToken } from "./ces-auth";
+import {
+  CES_FETCH_TIMEOUT_MS,
+  CES_MAX_ATTEMPTS,
+  CES_RETRY_DELAY_MS,
+  CesRunSessionError,
+  durationBucket,
+  type CesErrorCode,
+  type DurationBucket,
+} from "./ces-run-session";
+
+const COLLECTION = "default_collection";
+const DEFAULT_ANSWER_SERVING = "default_serving_config";
+
+export type AgentSearchEnvConfig = {
+  projectId: string;
+  location: string;
+  engineId: string;
+  serviceAccountJson: string;
+  servingConfig: string;
+};
+
+export type AgentSearchEnvResult =
+  | { ok: true; config: AgentSearchEnvConfig }
+  | { ok: false; missing: string[] };
+
+export type AgentSearchAnswerInput = {
+  message: string;
+};
+
+export type AgentSearchAnswerResult = {
+  text: string;
+  turnCompleted: boolean;
+  turnIndex: number;
+  meta: AgentSearchAnswerMeta;
+};
+
+export type AgentSearchAnswerMeta = {
+  attemptCount: number;
+  retryUsed: boolean;
+  durationMs: number;
+  durationBucket: DurationBucket;
+  hasCitations: boolean;
+};
+
+type AgentSearchAnswerSessionMode = "omit" | "full";
+
+function readEnv(name: string): string {
+  return (process.env[name] ?? import.meta.env[name] ?? "").trim();
+}
+
+function discoveryHost(location: string): string {
+  const loc = location.trim().toLowerCase();
+  if (loc === "eu") return "https://eu-discoveryengine.googleapis.com";
+  if (loc === "us") return "https://us-discoveryengine.googleapis.com";
+  return "https://discoveryengine.googleapis.com";
+}
+
+export function resolveAgentSearchEnv(): AgentSearchEnvResult {
+  const projectId = readEnv("CES_PROJECT_ID");
+  const location = readEnv("AGENT_SEARCH_LOCATION") || readEnv("CES_LOCATION");
+  const engineId = readEnv("AGENT_SEARCH_ENGINE_ID");
+  const serviceAccountJson = readEnv("GOOGLE_SERVICE_ACCOUNT_JSON");
+  const servingConfig = readEnv("AGENT_SEARCH_SERVING_CONFIG") || DEFAULT_ANSWER_SERVING;
+
+  const missing: string[] = [];
+  if (!projectId) missing.push("CES_PROJECT_ID");
+  if (!location) missing.push("CES_LOCATION or AGENT_SEARCH_LOCATION");
+  if (!engineId) missing.push("AGENT_SEARCH_ENGINE_ID");
+  if (!serviceAccountJson) missing.push("GOOGLE_SERVICE_ACCOUNT_JSON");
+
+  if (missing.length > 0) {
+    return { ok: false, missing };
+  }
+
+  return {
+    ok: true,
+    config: { projectId, location, engineId, serviceAccountJson, servingConfig },
+  };
+}
+
+function resolveAnswerSessionMode(): AgentSearchAnswerSessionMode {
+  const raw = readEnv("AGENT_SEARCH_ANSWER_SESSION").toLowerCase();
+  return raw === "full" ? "full" : "omit";
+}
+
+function buildAnswerSessionResource(config: AgentSearchEnvConfig): string {
+  return `projects/${config.projectId}/locations/${config.location}/collections/${COLLECTION}/engines/${config.engineId}/sessions/-`;
+}
+
+function buildAnswerUrl(host: string, config: AgentSearchEnvConfig): string {
+  const resource = `projects/${config.projectId}/locations/${config.location}/collections/${COLLECTION}/engines/${config.engineId}/servingConfigs/${config.servingConfig}`;
+  return `${host}/v1/${resource}:answer`;
+}
+
+function buildAnswerRequestBody(config: AgentSearchEnvConfig, message: string): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    query: { text: message },
+    groundingSpec: {
+      includeGroundingSupports: true,
+    },
+    answerGenerationSpec: {
+      ignoreAdversarialQuery: true,
+      ignoreNonAnswerSeekingQuery: false,
+      includeCitations: true,
+    },
+  };
+
+  if (resolveAnswerSessionMode() === "full") {
+    body.session = buildAnswerSessionResource(config);
+  }
+
+  return body;
+}
+
+function extractSafeGoogleError(responseText: string): { hint: string | null } {
+  try {
+    const parsed = JSON.parse(responseText) as {
+      error?: { message?: string };
+    };
+    const msg = parsed.error?.message;
+    if (typeof msg !== "string") return { hint: null };
+    const hint = msg.slice(0, 160);
+    return { hint: hint.length < msg.length ? `${hint}…` : hint };
+  } catch {
+    return { hint: null };
+  }
+}
+
+function mapGoogleHttpToCesCode(httpStatus: number, hint: string | null): CesErrorCode {
+  if (httpStatus === 401 || httpStatus === 403) return "auth";
+  if (httpStatus === 408 || httpStatus === 504) return "timeout";
+  if (httpStatus === 502 || httpStatus === 503) return "upstream";
+  if (httpStatus === 400 && hint?.includes("Cannot fetch Engine")) return "upstream";
+  return "upstream";
+}
+
+function extractAnswerText(payload: Record<string, unknown>): string {
+  const answer = (payload.answer ?? payload) as Record<string, unknown>;
+  const text = answer.answerText ?? answer.text ?? "";
+  return typeof text === "string" ? text.trim() : "";
+}
+
+function hasCitations(payload: Record<string, unknown>): boolean {
+  const answer = (payload.answer ?? payload) as Record<string, unknown>;
+  const grounding = answer.groundingMetadata as Record<string, unknown> | undefined;
+  const chunks =
+    grounding?.groundingChunks ?? answer.groundingAttributions ?? answer.citations ?? [];
+  return Array.isArray(chunks) && chunks.length > 0;
+}
+
+function attachAttemptMeta(
+  error: CesRunSessionError,
+  attemptCount: number,
+  retryUsed: boolean,
+  durationMs: number,
+): CesRunSessionError {
+  error.attemptCount = attemptCount;
+  error.retryUsed = retryUsed;
+  error.durationMs = durationMs;
+  error.durationBucket = durationBucket(durationMs);
+  return error;
+}
+
+const RETRYABLE_CODES = new Set<CesErrorCode>(["upstream", "empty_response"]);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runAgentSearchAnswerOnce(
+  config: AgentSearchEnvConfig,
+  input: AgentSearchAnswerInput,
+  accessToken: string,
+): Promise<{ text: string; hasCitations: boolean }> {
+  const host = discoveryHost(config.location);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), CES_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(buildAnswerUrl(host, config), {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(buildAnswerRequestBody(config, input.message)),
+    });
+
+    const responseText = await response.text().catch(() => "");
+
+    if (!response.ok) {
+      const { hint } = extractSafeGoogleError(responseText);
+      const code = mapGoogleHttpToCesCode(response.status, hint);
+      throw new CesRunSessionError(`agent_search_upstream_${response.status}`, code, 502, response.status);
+    }
+
+    let payload: Record<string, unknown> = {};
+    if (responseText) {
+      payload = (JSON.parse(responseText) as Record<string, unknown>) ?? {};
+    }
+
+    const text = extractAnswerText(payload);
+    if (!text) {
+      throw new CesRunSessionError("empty_agent_search_response", "empty_response", 502, 200);
+    }
+
+    return { text, hasCitations: hasCitations(payload) };
+  } catch (error) {
+    if (error instanceof CesRunSessionError) {
+      throw error;
+    }
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new CesRunSessionError("agent_search_fetch_timeout", "timeout", 504, null);
+    }
+    throw new CesRunSessionError("agent_search_network_error", "upstream", 502, null);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/** Discovery Engine :answer for /api/chat — retries once on transient errors; never logs message or answer. */
+export async function runAgentSearchAnswer(
+  config: AgentSearchEnvConfig,
+  input: AgentSearchAnswerInput,
+): Promise<AgentSearchAnswerResult> {
+  const started = performance.now();
+
+  let accessToken: string;
+  try {
+    accessToken = await getGoogleAccessToken(config.serviceAccountJson);
+  } catch {
+    const durationMs = Math.round(performance.now() - started);
+    throw attachAttemptMeta(
+      new CesRunSessionError("google_auth_failed", "auth", 503, null),
+      1,
+      false,
+      durationMs,
+    );
+  }
+
+  let lastError: CesRunSessionError | undefined;
+  let attemptsMade = 0;
+
+  for (let attempt = 1; attempt <= CES_MAX_ATTEMPTS; attempt += 1) {
+    attemptsMade = attempt;
+    try {
+      const result = await runAgentSearchAnswerOnce(config, input, accessToken);
+      const durationMs = Math.round(performance.now() - started);
+      return {
+        text: result.text,
+        turnCompleted: true,
+        turnIndex: 0,
+        meta: {
+          attemptCount: attempt,
+          retryUsed: attempt > 1,
+          durationMs,
+          durationBucket: durationBucket(durationMs),
+          hasCitations: result.hasCitations,
+        },
+      };
+    } catch (error) {
+      if (!(error instanceof CesRunSessionError)) {
+        throw error;
+      }
+      lastError = error;
+      const canRetry = attempt < CES_MAX_ATTEMPTS && RETRYABLE_CODES.has(error.code);
+      if (!canRetry) {
+        break;
+      }
+      await sleep(CES_RETRY_DELAY_MS);
+    }
+  }
+
+  const durationMs = Math.round(performance.now() - started);
+  throw attachAttemptMeta(lastError!, attemptsMade, attemptsMade > 1, durationMs);
+}

--- a/src/lib/chat-usage-metrics.ts
+++ b/src/lib/chat-usage-metrics.ts
@@ -72,6 +72,7 @@ export type ChatOpsDriftMeta = {
   duration_bucket?: string | null;
   retry_used?: boolean;
   attempt_count?: number;
+  backend_mode?: string | null;
 };
 
 /** Ops reliability tests — separate log stream and counters; never logs content, sessionId or IP. */
@@ -85,6 +86,7 @@ export function recordChatOpsDriftSignal(signal: ChatDriftSignal, meta?: ChatOps
       duration_bucket: meta?.duration_bucket ?? null,
       retry_used: meta?.retry_used ?? false,
       attempt_count: meta?.attempt_count ?? 1,
+      backend_mode: meta?.backend_mode ?? null,
     });
 
     const redis = getMetricsRedis();

--- a/src/lib/viddel-ai-backend.ts
+++ b/src/lib/viddel-ai-backend.ts
@@ -1,0 +1,23 @@
+/* CONTRACT: Resolve VIDDEL_AI_BACKEND for /api/chat — default ces_channel, no client exposure. */
+
+export type ViddelAiBackend = "ces_channel" | "google_agent_search_direct";
+
+const VALID_BACKENDS: ReadonlySet<string> = new Set([
+  "ces_channel",
+  "google_agent_search_direct",
+]);
+
+function readEnv(name: string): string {
+  return (process.env[name] ?? import.meta.env[name] ?? "").trim();
+}
+
+/** Server-only backend mode for POST /api/chat. Invalid/unset → ces_channel. */
+export function resolveViddelAiBackend(): ViddelAiBackend {
+  const raw = readEnv("VIDDEL_AI_BACKEND").toLowerCase();
+  if (!raw) return "ces_channel";
+  if (VALID_BACKENDS.has(raw)) {
+    return raw as ViddelAiBackend;
+  }
+  console.warn("[api/chat] backend_mode_invalid", { backend_mode: raw });
+  return "ces_channel";
+}

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,5 +1,6 @@
-/* CONTRACT: Server proxy for CES runSession — validates input, guards, never exposes credentials or diagnosticInfo. */
+/* CONTRACT: Server proxy for Viddel chat — guards, optional CES or Agent Search backend, no content logging. */
 import type { APIRoute } from "astro";
+import { runAgentSearchAnswer, resolveAgentSearchEnv } from "../../lib/agent-search-answer";
 import {
   CHAT_GUARD_MESSAGES,
   CHAT_MAX_MESSAGE_LENGTH,
@@ -15,6 +16,7 @@ import {
 } from "../../lib/chat-usage-metrics";
 import { resolveCesEnv } from "../../lib/ces-env";
 import { CesRunSessionError, runCesSession } from "../../lib/ces-run-session";
+import { resolveViddelAiBackend, type ViddelAiBackend } from "../../lib/viddel-ai-backend";
 
 export const prerender = false;
 
@@ -23,6 +25,13 @@ const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-_]{4,62}$/;
 type ChatRequestBody = {
   message?: unknown;
   sessionId?: unknown;
+};
+
+type ChatSuccessMeta = {
+  duration_bucket: string;
+  retry_used: boolean;
+  attempt_count: number;
+  has_citations?: boolean;
 };
 
 function jsonResponse(body: Record<string, unknown>, status: number): Response {
@@ -41,6 +50,7 @@ function trackDrift(
     duration_bucket?: string | null;
     retry_used?: boolean;
     attempt_count?: number;
+    backend_mode?: ViddelAiBackend;
   },
 ): void {
   if (opsTest) {
@@ -50,6 +60,7 @@ function trackDrift(
       duration_bucket: meta?.duration_bucket ?? null,
       retry_used: meta?.retry_used ?? false,
       attempt_count: meta?.attempt_count ?? 1,
+      backend_mode: meta?.backend_mode ?? null,
     });
     return;
   }
@@ -62,15 +73,85 @@ function respond(
   status: number,
   signal?: ChatDriftSignal,
   errorCode?: string,
+  backendMode?: ViddelAiBackend,
 ): Response {
   if (signal) {
-    trackDrift(opsTest, signal, errorCode ? { error_code: errorCode } : undefined);
+    trackDrift(opsTest, signal, errorCode ? { error_code: errorCode, backend_mode: backendMode } : { backend_mode: backendMode });
   }
   return jsonResponse(body, status);
 }
 
+function configurationMissingResponse(opsTest: boolean, backendMode: ViddelAiBackend): Response {
+  return respond(
+    opsTest,
+    {
+      error: "configuration_missing",
+      message: "Viddel er ikke tilgjengelig akkurat nå.",
+    },
+    503,
+    "configuration_missing",
+    "configuration_missing",
+    backendMode,
+  );
+}
+
+function handleBackendError(
+  opsTest: boolean,
+  error: CesRunSessionError,
+  sessionId: string,
+  backendMode: ViddelAiBackend,
+): Response {
+  trackDrift(opsTest, "error", {
+    error_code: error.code,
+    upstream_http_status: error.upstreamHttpStatus,
+    duration_bucket: error.durationBucket,
+    retry_used: error.retryUsed,
+    attempt_count: error.attemptCount,
+    backend_mode: backendMode,
+  });
+  if (!opsTest) {
+    console.error("[api/chat] backend_failed", {
+      backend_mode: backendMode,
+      error_code: error.code,
+      upstream_http_status: error.upstreamHttpStatus,
+      duration_bucket: error.durationBucket,
+      retry_used: error.retryUsed,
+      attempt_count: error.attemptCount,
+      session_id_length: sessionId.length,
+    });
+  }
+  return jsonResponse(
+    {
+      error: error.code,
+      message:
+        error.code === "auth"
+          ? "Viddel er ikke tilgjengelig akkurat nå."
+          : CHAT_GUARD_MESSAGES.invalidRequest,
+    },
+    error.status,
+  );
+}
+
+function logSuccess(
+  opsTest: boolean,
+  backendMode: ViddelAiBackend,
+  meta: ChatSuccessMeta,
+): void {
+  if (opsTest) return;
+  console.info("[api/chat] backend_ok", {
+    backend_mode: backendMode,
+    error_code: null,
+    upstream_http_status: null,
+    duration_bucket: meta.duration_bucket,
+    retry_used: meta.retry_used,
+    attempt_count: meta.attempt_count,
+    has_citations: meta.has_citations ?? null,
+  });
+}
+
 export const POST: APIRoute = async ({ request }) => {
   const opsTest = isOpsReliabilityRequest(request);
+  const backendMode = resolveViddelAiBackend();
 
   let body: ChatRequestBody;
   try {
@@ -82,6 +163,7 @@ export const POST: APIRoute = async ({ request }) => {
       400,
       "error",
       "invalid_json",
+      backendMode,
     );
   }
 
@@ -95,6 +177,7 @@ export const POST: APIRoute = async ({ request }) => {
       400,
       "error",
       "invalid_message",
+      backendMode,
     );
   }
 
@@ -105,6 +188,7 @@ export const POST: APIRoute = async ({ request }) => {
       400,
       "message_too_long",
       "message_too_long",
+      backendMode,
     );
   }
 
@@ -115,6 +199,7 @@ export const POST: APIRoute = async ({ request }) => {
       400,
       "error",
       "invalid_session",
+      backendMode,
     );
   }
 
@@ -126,6 +211,7 @@ export const POST: APIRoute = async ({ request }) => {
       403,
       "error",
       "forbidden_origin",
+      backendMode,
     );
   }
 
@@ -138,41 +224,66 @@ export const POST: APIRoute = async ({ request }) => {
       rateLimit.status,
       signal,
       rateLimit.error,
+      backendMode,
     );
   }
 
-  trackDrift(opsTest, "request");
+  trackDrift(opsTest, "request", { backend_mode: backendMode });
+
+  if (backendMode === "google_agent_search_direct") {
+    const agentEnv = resolveAgentSearchEnv();
+    if (!agentEnv.ok) {
+      return configurationMissingResponse(opsTest, backendMode);
+    }
+
+    try {
+      const result = await runAgentSearchAnswer(agentEnv.config, { message });
+      const meta: ChatSuccessMeta = {
+        duration_bucket: result.meta.durationBucket,
+        retry_used: result.meta.retryUsed,
+        attempt_count: result.meta.attemptCount,
+        has_citations: result.meta.hasCitations,
+      };
+      trackDrift(opsTest, "success", { ...meta, backend_mode: backendMode });
+      logSuccess(opsTest, backendMode, meta);
+      return jsonResponse(
+        {
+          text: result.text,
+          turnCompleted: result.turnCompleted,
+          turnIndex: result.turnIndex,
+        },
+        200,
+      );
+    } catch (error) {
+      if (error instanceof CesRunSessionError) {
+        return handleBackendError(opsTest, error, sessionId, backendMode);
+      }
+      console.error("[api/chat] unexpected_error", { backend_mode: backendMode });
+      return respond(
+        opsTest,
+        { error: "internal_error", message: CHAT_GUARD_MESSAGES.invalidRequest },
+        500,
+        "error",
+        "internal_error",
+        backendMode,
+      );
+    }
+  }
 
   const env = resolveCesEnv();
   if (!env.ok) {
-    return respond(
-      opsTest,
-      {
-        error: "configuration_missing",
-        message: "Viddel er ikke tilgjengelig akkurat nå.",
-      },
-      503,
-      "configuration_missing",
-      "configuration_missing",
-    );
+    return configurationMissingResponse(opsTest, backendMode);
   }
 
   try {
     const result = await runCesSession(env.config, { message, sessionId });
-    trackDrift(opsTest, "success", {
+    const meta: ChatSuccessMeta = {
       duration_bucket: result.meta.durationBucket,
       retry_used: result.meta.retryUsed,
       attempt_count: result.meta.attemptCount,
-    });
-    if (!opsTest) {
-      console.info("[api/chat] ces_run_session_ok", {
-        error_code: null,
-        upstream_http_status: null,
-        duration_bucket: result.meta.durationBucket,
-        retry_used: result.meta.retryUsed,
-        attempt_count: result.meta.attemptCount,
-      });
-    }
+    };
+    trackDrift(opsTest, "success", { ...meta, backend_mode: backendMode });
+    logSuccess(opsTest, backendMode, meta);
     return jsonResponse(
       {
         text: result.text,
@@ -183,42 +294,17 @@ export const POST: APIRoute = async ({ request }) => {
     );
   } catch (error) {
     if (error instanceof CesRunSessionError) {
-      trackDrift(opsTest, "error", {
-        error_code: error.code,
-        upstream_http_status: error.upstreamHttpStatus,
-        duration_bucket: error.durationBucket,
-        retry_used: error.retryUsed,
-        attempt_count: error.attemptCount,
-      });
-      if (!opsTest) {
-        console.error("[api/chat] ces_run_session_failed", {
-          error_code: error.code,
-          upstream_http_status: error.upstreamHttpStatus,
-          duration_bucket: error.durationBucket,
-          retry_used: error.retryUsed,
-          attempt_count: error.attemptCount,
-          session_id_length: sessionId.length,
-        });
-      }
-      return jsonResponse(
-        {
-          error: error.code,
-          message:
-            error.code === "auth"
-              ? "Viddel er ikke tilgjengelig akkurat nå."
-              : CHAT_GUARD_MESSAGES.invalidRequest,
-        },
-        error.status,
-      );
+      return handleBackendError(opsTest, error, sessionId, backendMode);
     }
 
-    console.error("[api/chat] unexpected_error");
+    console.error("[api/chat] unexpected_error", { backend_mode: backendMode });
     return respond(
       opsTest,
       { error: "internal_error", message: CHAT_GUARD_MESSAGES.invalidRequest },
       500,
       "error",
       "internal_error",
+      backendMode,
     );
   }
 };


### PR DESCRIPTION
## Summary

Implements optional backend mode for `POST /api/chat` per [VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md](docs/project/VIDDEL_AI_BACKEND_MODE_ASSESSMENT_v0_1.md).

- **`VIDDEL_AI_BACKEND=ces_channel`** (default when unset/invalid)
- **`VIDDEL_AI_BACKEND=google_agent_search_direct`** — Discovery Engine `:answer` via `src/lib/agent-search-answer.ts`
- Frontend contract unchanged: `{ text, turnCompleted, turnIndex }`
- No probe UI, no PostHog, no production env change in this PR

Closes #215

## Env (direct mode)

Requires `AGENT_SEARCH_ENGINE_ID` (+ existing `CES_PROJECT_ID`, `CES_LOCATION`, `GOOGLE_SERVICE_ACCOUNT_JSON`). See [known-good doc](docs/project/GOOGLE_AGENT_SEARCH_DIRECT_KNOWN_GOOD_v0_1.md).

## Safety

- No prompt/answer logging
- `[api/chat]` logs metadata only (`backend_mode`, `error_code`, `duration_bucket`, `has_citations` boolean)
- Citations not exposed in client JSON v0.1

## Rollback

Unset `VIDDEL_AI_BACKEND` or set `ces_channel` in Vercel → redeploy.

## Test plan

- [ ] `npm run build` (CI)
- [ ] Preview: default (no env) → CES path unchanged on `/no/chat`
- [ ] Preview: `VIDDEL_AI_BACKEND=google_agent_search_direct` + known-good env → `/api/chat` returns 200 + text
- [ ] Preview reliability: ≥20 calls, ≥80% success before any Production env change
- [ ] Production: **do not** set direct mode until QA sign-off

## Out of scope

- Production backend switch
- Probe routes from #213
- Guard limit changes

Made with [Cursor](https://cursor.com)