### PR TITLE
feat(#215): direct /api/chat reliability tooling

### DIFF
--- a/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_CHAT_RELIABILITY_v0_1.md
+++ b/docs/project/GOOGLE_AGENT_SEARCH_DIRECT_CHAT_RELIABILITY_v0_1.md
@@ -1,0 +1,69 @@
+# Direct backend `/api/chat` reliability v0.1
+
+Related: [#198](https://github.com/THUNDERPLUNDER/vox-web/issues/198), [#215](https://github.com/THUNDERPLUNDER/vox-web/issues/215)
+
+## Target
+
+| Item | Value |
+|------|--------|
+| Endpoint | `POST /api/chat` |
+| Env (Preview) | `VIDDEL_AI_BACKEND=google_agent_search_direct` |
+| Calls | ≥20 |
+| Success rate | ≥80% |
+| Contract | `{ text, turnCompleted, turnIndex }` only |
+| Logging | Metadata only — no prompt/answer |
+
+## Automated run (Thomas / ops)
+
+```bash
+# .env.local (never commit):
+# VIDDEL_OPS_TEST_TOKEN=<Preview value from Vercel>
+# VERCEL_AUTOMATION_BYPASS_SECRET=<Vercel Protection Bypass for Automation>
+
+npm run chat:reliability -- \
+  --preview \
+  --count=20 \
+  --delay-ms=8000 \
+  --expect-backend=google_agent_search_direct \
+  --env-file=.env.local \
+  --label=direct-preview-api-chat-v01
+```
+
+Output: `tmp/chat-reliability/run-*.json` (gitignored, metadata only).
+
+### Prerequisites
+
+1. Preview env: `VIDDEL_AI_BACKEND=google_agent_search_direct` + `AGENT_SEARCH_ENGINE_ID` + SA + IAM.
+2. Preview env: `VIDDEL_OPS_TEST_TOKEN` (same value used in script header).
+3. Vercel **Protection Bypass for Automation** if Deployment Protection blocks unauthenticated `POST /api/chat` (401 HTML).
+
+### Ops meta headers (token required)
+
+When `x-viddel-ops-test-token` matches, responses include safe headers (no content):
+
+- `x-viddel-ops-meta-backend-mode`
+- `x-viddel-ops-meta-error-code`
+- `x-viddel-ops-meta-upstream-http-status`
+- `x-viddel-ops-meta-duration-bucket`
+- `x-viddel-ops-meta-retry-used`
+- `x-viddel-ops-meta-attempt-count`
+- `x-viddel-ops-meta-has-citations`
+
+## Deployment Protection blocker
+
+Unauthenticated `curl` / CI without bypass → **401** Vercel Authentication HTML (not `/api/chat`).
+
+**Do not** disable protection globally for this test. Use bypass secret or run from authenticated operator machine.
+
+## Pass / fail
+
+| Pass | Fail |
+|------|------|
+| ≥80% `result: success` | &lt;80% success |
+| All `backendMode` = `google_agent_search_direct` | Any `ces_channel` |
+| All successes `responseContractOk: true` | Extra JSON fields to client |
+| No prompt/answer in output file | Content leaked in logs |
+
+## Follow-up (not reliability blocker)
+
+Long answers with raw Markdown (`**`, bullets) → issue: **Direct backend response formatting v0.1**.

--- a/scripts/chat-reliability-assessment.mjs
+++ b/scripts/chat-reliability-assessment.mjs
@@ -10,9 +10,18 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const OPS_TEST_HEADER = "x-viddel-ops-test-token";
 const DEFAULT_BASE = "https://vox.raddum.no";
+const DEFAULT_PREVIEW_BASE =
+  "https://vox-web-git-main-raddum-5965s-projects.vercel.app";
 /** Default spacing — production limits are server-side (VIDDEL_CHAT_* in Vercel). */
 const DEFAULT_COUNT = 8;
 const DEFAULT_DELAY_MS = 8_000;
+const OPS_META_BACKEND = "x-viddel-ops-meta-backend-mode";
+const OPS_META_ERROR = "x-viddel-ops-meta-error-code";
+const OPS_META_UPSTREAM = "x-viddel-ops-meta-upstream-http-status";
+const OPS_META_DURATION = "x-viddel-ops-meta-duration-bucket";
+const OPS_META_RETRY = "x-viddel-ops-meta-retry-used";
+const OPS_META_ATTEMPTS = "x-viddel-ops-meta-attempt-count";
+const OPS_META_CITATIONS = "x-viddel-ops-meta-has-citations";
 const DEFAULT_BURST_LIMIT = 10;
 const DEFAULT_DAILY_LIMIT = 50;
 
@@ -70,15 +79,20 @@ function parseArgs(argv) {
     delayMs: DEFAULT_DELAY_MS,
     sessionPerRequest: true,
     envFile: "",
+    expectBackend: "",
+    label: "",
   };
   for (const arg of argv) {
     if (arg.startsWith("--base=")) args.base = arg.slice(7).replace(/\/$/, "");
+    else if (arg === "--preview") args.base = DEFAULT_PREVIEW_BASE;
     else if (arg.startsWith("--count=")) args.count = Number(arg.slice(8));
     else if (arg.startsWith("--out=")) args.out = arg.slice(6);
     else if (arg === "--direct") args.direct = true;
     else if (arg === "--shared-session") args.sessionPerRequest = false;
     else if (arg.startsWith("--delay-ms=")) args.delayMs = Number(arg.slice(11));
     else if (arg.startsWith("--env-file=")) args.envFile = arg.slice(11);
+    else if (arg.startsWith("--expect-backend=")) args.expectBackend = arg.slice(17).trim();
+    else if (arg.startsWith("--label=")) args.label = arg.slice(8).trim();
   }
   return args;
 }
@@ -124,7 +138,8 @@ function durationBucket(ms) {
 function errorCategory(errorCode, httpStatus) {
   if (errorCode === "rate_limited" || httpStatus === 429) return "rate_limit";
   if (errorCode === "timeout" || httpStatus === 504) return "timeout";
-  if (errorCode === "upstream" || errorCode === "empty_response") return "ces_upstream";
+  if (errorCode === "upstream" || errorCode === "empty_response") return "upstream";
+  if (httpStatus === 401 && !errorCode) return "deployment_protection";
   if (
     errorCode === "invalid_message" ||
     errorCode === "invalid_session" ||
@@ -151,7 +166,19 @@ function buildPlan(count) {
   return plan;
 }
 
-async function callProxy(base, sessionId, message, opsToken) {
+function checkResponseContract(payload) {
+  if (typeof payload.text !== "string" || !payload.text.trim()) return false;
+  if (typeof payload.turnCompleted !== "boolean") return false;
+  if (typeof payload.turnIndex !== "number" || !Number.isFinite(payload.turnIndex)) return false;
+  const extra = Object.keys(payload).filter((k) => !["text", "turnCompleted", "turnIndex"].includes(k));
+  return extra.length === 0;
+}
+
+function readOpsHeader(response, name) {
+  return response.headers.get(name)?.trim() ?? null;
+}
+
+async function callProxy(base, sessionId, message, opsToken, protectionBypass) {
   const started = performance.now();
   const headers = {
     "Content-Type": "application/json",
@@ -161,23 +188,49 @@ async function callProxy(base, sessionId, message, opsToken) {
   if (opsToken) {
     headers[OPS_TEST_HEADER] = opsToken;
   }
+  if (protectionBypass) {
+    headers["x-vercel-protection-bypass"] = protectionBypass;
+  }
   const response = await fetch(`${base}/api/chat`, {
     method: "POST",
     headers,
     body: JSON.stringify({ message, sessionId }),
   });
   const durationMs = Math.round(performance.now() - started);
-  const payload = await response.json().catch(() => ({}));
-  const errorCode = typeof payload.error === "string" ? payload.error : null;
+  const contentType = response.headers.get("content-type") ?? "";
+  const payload =
+    contentType.includes("application/json") ? await response.json().catch(() => ({})) : {};
+  const deploymentBlocked =
+    response.status === 401 && !contentType.includes("application/json");
+  const errorCode = deploymentBlocked
+    ? "deployment_protection"
+    : typeof payload.error === "string"
+      ? payload.error
+      : null;
   const hasText = typeof payload.text === "string" && payload.text.trim().length > 0;
-  const category = hasText ? "success" : errorCategory(errorCode, response.status);
+  const responseContractOk = hasText && checkResponseContract(payload);
+  const category = deploymentBlocked
+    ? "deployment_protection"
+    : hasText
+      ? "success"
+      : errorCategory(errorCode, response.status);
+  const serverDuration = readOpsHeader(response, OPS_META_DURATION);
+  const backendMode = readOpsHeader(response, OPS_META_BACKEND);
   return {
     httpStatus: response.status,
     errorCode,
     category,
     success: response.ok && hasText,
     durationMs,
-    durationBucket: durationBucket(durationMs),
+    durationBucket: serverDuration ?? durationBucket(durationMs),
+    backendMode,
+    upstreamHttpStatus: readOpsHeader(response, OPS_META_UPSTREAM),
+    retryUsed: readOpsHeader(response, OPS_META_RETRY) === "1",
+    attemptCount: Number.parseInt(readOpsHeader(response, OPS_META_ATTEMPTS) ?? "1", 10) || 1,
+    hasCitations: readOpsHeader(response, OPS_META_CITATIONS) === "1",
+    responseContractOk,
+    deploymentBlocked,
+    opsMetaErrorCode: readOpsHeader(response, OPS_META_ERROR),
   };
 }
 
@@ -272,20 +325,23 @@ async function callDirectCes(env, sessionId, message) {
   };
 }
 
-function summarize(results, opsConfig, publicLimitContext) {
+function summarize(results, opsConfig, publicLimitContext, expectBackend) {
   const total = results.length;
   const byCategory = {
     success: 0,
+    upstream: 0,
     ces_upstream: 0,
     rate_limit: 0,
     timeout: 0,
     app_error: 0,
+    deployment_protection: 0,
     other: 0,
   };
   let beforeRateLimitTotal = 0;
   let beforeRateLimitSuccess = 0;
   for (const row of results) {
-    byCategory[row.category] = (byCategory[row.category] ?? 0) + 1;
+    const key = row.category === "ces_upstream" ? "upstream" : row.category;
+    byCategory[key] = (byCategory[key] ?? 0) + 1;
   }
   for (const row of results) {
     if (row.category === "rate_limit") break;
@@ -297,11 +353,25 @@ function summarize(results, opsConfig, publicLimitContext) {
     buckets[r.durationBucket] = (buckets[r.durationBucket] ?? 0) + 1;
   }
   const success = byCategory.success;
+  const backendModeCounts = {};
+  let contractOk = 0;
+  let backendMismatch = 0;
+  for (const r of results) {
+    if (r.backendMode) {
+      backendModeCounts[r.backendMode] = (backendModeCounts[r.backendMode] ?? 0) + 1;
+    }
+    if (r.responseContractOk) contractOk += 1;
+    if (expectBackend && r.backendMode && r.backendMode !== expectBackend) backendMismatch += 1;
+  }
+  const passThreshold = 80;
+  const successRatePct = total ? Number(((success / total) * 100).toFixed(1)) : 0;
   return {
     total,
     success,
     error: total - success,
-    successRate: total ? Number(((success / total) * 100).toFixed(1)) : 0,
+    successRate: successRatePct,
+    passThreshold,
+    passed: successRatePct >= passThreshold && backendMismatch === 0,
     successBeforeRateLimit: beforeRateLimitSuccess,
     callsBeforeRateLimit: beforeRateLimitTotal,
     successRateBeforeRateLimit: beforeRateLimitTotal
@@ -309,9 +379,13 @@ function summarize(results, opsConfig, publicLimitContext) {
       : 0,
     byCategory,
     durationBuckets: buckets,
+    backendModeCounts,
+    responseContractOkCount: contractOk,
+    backendMismatchCount: backendMismatch,
+    expectBackend: expectBackend || null,
     opsMode: opsConfig,
     publicLimitContext,
-    retryUsedNote: "Server-side retry_used — see [chat-drift] in Vercel Runtime Logs",
+    retryUsedNote: "retry_used/attempt_count from ops meta headers when token configured",
     guardNote: opsConfig.publicGuardBypassed
       ? "Ops token bypassed public IP limits (optional path — not required for pre-pilot test)."
       : `Public guard active — server limits from Vercel env (default ${DEFAULT_BURST_LIMIT}/10m, ${DEFAULT_DAILY_LIMIT}/day).`,
@@ -322,9 +396,15 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   const fileEnv = args.envFile ? loadEnvFile(args.envFile) : {};
   const opsToken = (process.env.VIDDEL_OPS_TEST_TOKEN ?? fileEnv.VIDDEL_OPS_TEST_TOKEN ?? "").trim();
+  const protectionBypass = (
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET ??
+    fileEnv.VERCEL_AUTOMATION_BYPASS_SECRET ??
+    ""
+  ).trim();
   const opsConfig = {
     tokenConfiguredLocally: Boolean(opsToken),
     publicGuardBypassed: Boolean(opsToken),
+    protectionBypassConfigured: Boolean(protectionBypass),
     header: OPS_TEST_HEADER,
   };
   const publicLimitContext = buildPublicLimitContext(fileEnv);
@@ -334,8 +414,13 @@ async function main() {
   const results = [];
 
   console.log(
-    `chat-reliability: ${args.count} calls, ${args.delayMs}ms spacing, sessionPerRequest=${args.sessionPerRequest}`,
+    `chat-reliability: ${args.count} calls, ${args.delayMs}ms spacing, sessionPerRequest=${args.sessionPerRequest}, base=${args.base}`,
   );
+  if (args.label) console.log(`label: ${args.label}`);
+  if (args.expectBackend) console.log(`expectBackend: ${args.expectBackend}`);
+  if (opsConfig.protectionBypassConfigured) {
+    console.log("vercelProtectionBypass: configured (x-vercel-protection-bypass)");
+  }
   console.log(
     `publicGuard: active (server limits — default ${DEFAULT_BURST_LIMIT}/10m ${DEFAULT_DAILY_LIMIT}/day; set VIDDEL_CHAT_* in Vercel + redeploy for pre-pilot)`,
   );
@@ -347,18 +432,32 @@ async function main() {
     const requestSessionId = args.sessionPerRequest
       ? `viddel-rel-${Date.now().toString(36)}-${item.n}`
       : sessionId;
-    const proxy = await callProxy(args.base, requestSessionId, item.message, opsToken || undefined);
+    const proxy = await callProxy(
+      args.base,
+      requestSessionId,
+      item.message,
+      opsToken || undefined,
+      protectionBypass || undefined,
+    );
     const row = {
-      request: item.n,
+      call: item.n,
       inputType: item.inputType,
-      channel: "proxy",
+      channel: "api_chat",
       opsTest: opsConfig.tokenConfiguredLocally,
       httpStatus: proxy.httpStatus,
-      errorCode: proxy.errorCode,
+      result: proxy.success ? "success" : "error",
+      errorCode: proxy.errorCode ?? proxy.opsMetaErrorCode,
       category: proxy.category,
       finalSuccess: proxy.success,
       durationMs: proxy.durationMs,
       durationBucket: proxy.durationBucket,
+      backendMode: proxy.backendMode,
+      upstreamHttpStatus: proxy.upstreamHttpStatus,
+      retryUsed: proxy.retryUsed,
+      attemptCount: proxy.attemptCount,
+      hasCitations: proxy.hasCitations,
+      responseContractOk: proxy.responseContractOk,
+      deploymentBlocked: proxy.deploymentBlocked,
     };
 
     if (args.direct) {
@@ -382,22 +481,24 @@ async function main() {
 
     results.push(row);
     process.stdout.write(
-      `#${row.request} ${row.inputType} ${row.category} http=${row.httpStatus} code=${row.errorCode ?? "none"} ${row.durationBucket}\n`,
+      `#${row.call} ${row.result} http=${row.httpStatus} backend=${row.backendMode ?? "n/a"} code=${row.errorCode ?? "none"} ${row.durationBucket} contract=${row.responseContractOk ? "ok" : "fail"}\n`,
     );
     if (args.delayMs > 0 && item.n < plan.length) {
       await new Promise((r) => setTimeout(r, args.delayMs));
     }
   }
 
-  const summary = summarize(results, opsConfig, publicLimitContext);
+  const summary = summarize(results, opsConfig, publicLimitContext, args.expectBackend);
   const cesEnv = readCesEnv();
   const report = {
     generatedAt: new Date().toISOString(),
+    label: args.label || null,
     base: args.base,
     config: {
       count: args.count,
       delayMs: args.delayMs,
       sessionPerRequest: args.sessionPerRequest,
+      expectBackend: args.expectBackend || null,
       opsTest: opsConfig,
       publicLimitContext,
     },

--- a/src/lib/chat-ops-meta.ts
+++ b/src/lib/chat-ops-meta.ts
@@ -1,0 +1,47 @@
+/* CONTRACT: Ops-only response headers for /api/chat reliability — metadata only, never content. */
+
+import type { ViddelAiBackend } from "./viddel-ai-backend";
+
+export const OPS_META_HEADER_BACKEND = "x-viddel-ops-meta-backend-mode";
+export const OPS_META_HEADER_ERROR_CODE = "x-viddel-ops-meta-error-code";
+export const OPS_META_HEADER_UPSTREAM_HTTP = "x-viddel-ops-meta-upstream-http-status";
+export const OPS_META_HEADER_DURATION_BUCKET = "x-viddel-ops-meta-duration-bucket";
+export const OPS_META_HEADER_RETRY_USED = "x-viddel-ops-meta-retry-used";
+export const OPS_META_HEADER_ATTEMPT_COUNT = "x-viddel-ops-meta-attempt-count";
+export const OPS_META_HEADER_HAS_CITATIONS = "x-viddel-ops-meta-has-citations";
+
+export type OpsChatResponseMeta = {
+  backend_mode: ViddelAiBackend;
+  error_code?: string | null;
+  upstream_http_status?: number | null;
+  duration_bucket?: string | null;
+  retry_used?: boolean;
+  attempt_count?: number;
+  has_citations?: boolean | null;
+};
+
+/** Safe headers for ops reliability script — only when x-viddel-ops-test-token matches. */
+export function buildOpsChatMetaHeaders(meta: OpsChatResponseMeta): Record<string, string> {
+  const headers: Record<string, string> = {
+    [OPS_META_HEADER_BACKEND]: meta.backend_mode,
+  };
+  if (meta.error_code != null && meta.error_code !== "") {
+    headers[OPS_META_HEADER_ERROR_CODE] = meta.error_code;
+  }
+  if (meta.upstream_http_status != null) {
+    headers[OPS_META_HEADER_UPSTREAM_HTTP] = String(meta.upstream_http_status);
+  }
+  if (meta.duration_bucket) {
+    headers[OPS_META_HEADER_DURATION_BUCKET] = meta.duration_bucket;
+  }
+  if (meta.retry_used != null) {
+    headers[OPS_META_HEADER_RETRY_USED] = meta.retry_used ? "1" : "0";
+  }
+  if (meta.attempt_count != null) {
+    headers[OPS_META_HEADER_ATTEMPT_COUNT] = String(meta.attempt_count);
+  }
+  if (meta.has_citations != null) {
+    headers[OPS_META_HEADER_HAS_CITATIONS] = meta.has_citations ? "1" : "0";
+  }
+  return headers;
+}

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -16,6 +16,7 @@ import {
 } from "../../lib/chat-usage-metrics";
 import { resolveCesEnv } from "../../lib/ces-env";
 import { CesRunSessionError, runCesSession } from "../../lib/ces-run-session";
+import { buildOpsChatMetaHeaders, type OpsChatResponseMeta } from "../../lib/chat-ops-meta";
 import { resolveViddelAiBackend, type ViddelAiBackend } from "../../lib/viddel-ai-backend";
 
 export const prerender = false;
@@ -34,11 +35,19 @@ type ChatSuccessMeta = {
   has_citations?: boolean;
 };
 
-function jsonResponse(body: Record<string, unknown>, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json; charset=utf-8" },
-  });
+function chatResponse(
+  body: Record<string, unknown>,
+  status: number,
+  opsTest: boolean,
+  opsMeta?: OpsChatResponseMeta,
+): Response {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json; charset=utf-8",
+  };
+  if (opsTest && opsMeta) {
+    Object.assign(headers, buildOpsChatMetaHeaders(opsMeta));
+  }
+  return new Response(JSON.stringify(body), { status, headers });
 }
 
 function trackDrift(
@@ -78,7 +87,7 @@ function respond(
   if (signal) {
     trackDrift(opsTest, signal, errorCode ? { error_code: errorCode, backend_mode: backendMode } : { backend_mode: backendMode });
   }
-  return jsonResponse(body, status);
+  return chatResponse(body, status, opsTest, backendMode ? { backend_mode: backendMode, error_code: errorCode ?? null } : undefined);
 }
 
 function configurationMissingResponse(opsTest: boolean, backendMode: ViddelAiBackend): Response {
@@ -93,6 +102,23 @@ function configurationMissingResponse(opsTest: boolean, backendMode: ViddelAiBac
     "configuration_missing",
     backendMode,
   );
+}
+
+function successResponse(
+  opsTest: boolean,
+  backendMode: ViddelAiBackend,
+  body: { text: string; turnCompleted: boolean; turnIndex: number },
+  meta: ChatSuccessMeta,
+): Response {
+  return chatResponse(body, 200, opsTest, {
+    backend_mode: backendMode,
+    error_code: null,
+    duration_bucket: meta.duration_bucket,
+    retry_used: meta.retry_used,
+    attempt_count: meta.attempt_count,
+    has_citations: meta.has_citations ?? null,
+    upstream_http_status: null,
+  });
 }
 
 function handleBackendError(
@@ -120,7 +146,7 @@ function handleBackendError(
       session_id_length: sessionId.length,
     });
   }
-  return jsonResponse(
+  return chatResponse(
     {
       error: error.code,
       message:
@@ -129,6 +155,15 @@ function handleBackendError(
           : CHAT_GUARD_MESSAGES.invalidRequest,
     },
     error.status,
+    opsTest,
+    {
+      backend_mode: backendMode,
+      error_code: error.code,
+      upstream_http_status: error.upstreamHttpStatus,
+      duration_bucket: error.durationBucket,
+      retry_used: error.retryUsed,
+      attempt_count: error.attemptCount,
+    },
   );
 }
 
@@ -246,14 +281,7 @@ export const POST: APIRoute = async ({ request }) => {
       };
       trackDrift(opsTest, "success", { ...meta, backend_mode: backendMode });
       logSuccess(opsTest, backendMode, meta);
-      return jsonResponse(
-        {
-          text: result.text,
-          turnCompleted: result.turnCompleted,
-          turnIndex: result.turnIndex,
-        },
-        200,
-      );
+      return successResponse(opsTest, backendMode, result, meta);
     } catch (error) {
       if (error instanceof CesRunSessionError) {
         return handleBackendError(opsTest, error, sessionId, backendMode);
@@ -284,14 +312,7 @@ export const POST: APIRoute = async ({ request }) => {
     };
     trackDrift(opsTest, "success", { ...meta, backend_mode: backendMode });
     logSuccess(opsTest, backendMode, meta);
-    return jsonResponse(
-      {
-        text: result.text,
-        turnCompleted: result.turnCompleted,
-        turnIndex: result.turnIndex,
-      },
-      200,
-    );
+    return successResponse(opsTest, backendMode, result, meta);
   } catch (error) {
     if (error instanceof CesRunSessionError) {
       return handleBackendError(opsTest, error, sessionId, backendMode);


### PR DESCRIPTION
## Summary

- Extends `scripts/chat-reliability-assessment.mjs` for Preview direct backend tests (`--preview`, `--expect-backend`, Vercel bypass secret).
- Adds ops-only response headers on `/api/chat` when `VIDDEL_OPS_TEST_TOKEN` matches (metadata only).
- Documents 20-call procedure in `GOOGLE_AGENT_SEARCH_DIRECT_CHAT_RELIABILITY_v0_1.md`.

Does not change Production env or default backend.

## Test plan

- [ ] `npm run build`
- [ ] Thomas runs 20-call series with ops token + bypass (see doc)

Made with [Cursor](https://cursor.com)