### PR TITLE
Direct backend response formatting v0.1 (#217)

### DIFF
--- a/src/lib/agent-search-answer.ts
+++ b/src/lib/agent-search-answer.ts
@@ -2,6 +2,10 @@
 
 import { getGoogleAccessToken } from "./ces-auth";
 import {
+  VIDDEL_RESPONSE_CONTRACT_VERSION,
+  VIDDEL_RESPONSE_PREAMBLE,
+} from "./viddel-response-contract";
+import {
   CES_FETCH_TIMEOUT_MS,
   CES_MAX_ATTEMPTS,
   CES_RETRY_DELAY_MS,
@@ -43,6 +47,7 @@ export type AgentSearchAnswerMeta = {
   durationMs: number;
   durationBucket: DurationBucket;
   hasCitations: boolean;
+  responseContractVersion: string;
 };
 
 type AgentSearchAnswerSessionMode = "omit" | "full";
@@ -105,6 +110,9 @@ function buildAnswerRequestBody(config: AgentSearchEnvConfig, message: string): 
       ignoreAdversarialQuery: true,
       ignoreNonAnswerSeekingQuery: false,
       includeCitations: true,
+      promptSpec: {
+        preamble: VIDDEL_RESPONSE_PREAMBLE,
+      },
     },
   };
 
@@ -260,6 +268,7 @@ export async function runAgentSearchAnswer(
           durationMs,
           durationBucket: durationBucket(durationMs),
           hasCitations: result.hasCitations,
+          responseContractVersion: VIDDEL_RESPONSE_CONTRACT_VERSION,
         },
       };
     } catch (error) {

--- a/src/lib/render-assistant-markdown.ts
+++ b/src/lib/render-assistant-markdown.ts
@@ -1,0 +1,81 @@
+/* CONTRACT: Safe DOM renderer for assistant Markdown v0.1 — no innerHTML on raw AI text. */
+
+function appendInlineMarkdown(parent: HTMLElement, content: string): void {
+  const parts = content.split(/(\*\*[^*]+\*\*)/g);
+  for (const part of parts) {
+    if (!part) continue;
+    const boldMatch = part.match(/^\*\*(.+)\*\*$/);
+    if (boldMatch) {
+      const strong = document.createElement("strong");
+      strong.textContent = boldMatch[1];
+      parent.append(strong);
+      continue;
+    }
+    parent.append(document.createTextNode(part));
+  }
+}
+
+/** Renders a subset of Markdown into container using explicit DOM nodes only. */
+export function renderAssistantMarkdownInto(container: HTMLElement, text: string): void {
+  container.replaceChildren();
+
+  const normalized = String(text || "").replace(/\r\n/g, "\n").trim();
+  if (!normalized) return;
+
+  const lines = normalized.split("\n");
+  let listType: "ul" | "ol" | "" = "";
+  let listEl: HTMLUListElement | HTMLOListElement | null = null;
+
+  const closeList = () => {
+    if (listEl) {
+      container.append(listEl);
+    }
+    listType = "";
+    listEl = null;
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      closeList();
+      continue;
+    }
+
+    const bullet = line.match(/^[-*]\s+(.+)$/);
+    const numbered = line.match(/^(\d+)[.)]\s+(.+)$/);
+
+    if (bullet) {
+      if (listType !== "ul") {
+        closeList();
+        listType = "ul";
+        listEl = document.createElement("ul");
+      }
+      const li = document.createElement("li");
+      appendInlineMarkdown(li, bullet[1]);
+      listEl!.append(li);
+      continue;
+    }
+
+    if (numbered) {
+      if (listType !== "ol") {
+        closeList();
+        listType = "ol";
+        listEl = document.createElement("ol");
+      }
+      const li = document.createElement("li");
+      if (numbered[1] !== String((listEl!.children.length || 0) + 1)) {
+        li.setAttribute("value", numbered[1]);
+      }
+      appendInlineMarkdown(li, numbered[2]);
+      listEl!.append(li);
+      continue;
+    }
+
+    closeList();
+    const paragraph = document.createElement("p");
+    appendInlineMarkdown(paragraph, line);
+    container.append(paragraph);
+  }
+
+  closeList();
+}

--- a/src/lib/viddel-response-contract.ts
+++ b/src/lib/viddel-response-contract.ts
@@ -1,0 +1,40 @@
+/* CONTRACT: Viddel response contract v0.1 — preamble for Google Agent Search direct :answer. */
+
+export const VIDDEL_RESPONSE_CONTRACT_VERSION = "v0.1";
+
+export const VIDDEL_RESPONSE_PREAMBLE = `Du svarer som Viddel, på norsk.
+
+Svar kort, konkret og voksent.
+Gå ut fra at brukeren er alminnelig godt opplyst.
+
+Svarmønster:
+- Start med en kort vurdering.
+- Gi ett relevant neste steg først.
+- Bruk maks 3–5 punkter når du lister steg.
+- Still maks ett oppfølgingsspørsmål.
+- Ikke dump manualtekst eller lange kildeutdrag.
+- Ikke skriv lange forklaringer med mindre brukeren ber om forklaring.
+
+Språkregler:
+- Ikke bruk ordene: trygg, trygt, tryggeste, rolig, vanlig.
+- Bruk heller formuleringer som "kjent problem", "mange opplever", "for å utelukke det enkle først", "neste steg kan være".
+- Ikke bruk kundeservice-tone.
+- Ikke skriv som om brukeren er uopplyst.
+- Når et enkelt feilsøkingssteg er nødvendig, forklar at det er for å utelukke før vi går videre.
+
+Oppfølgingsspørsmål:
+- Når merke eller modell er relevant, spør: "Vet du hvilket merke eller modell du har?"
+- Legg gjerne til at det går fint om brukeren ikke vet det.
+
+Audiograf:
+- Ikke nevn audiograf som standard sikkerhetsrefleks.
+- Nevn audiograf når det faktisk er neste relevante steg, for eksempel ved justering, fysisk passform, vedvarende problem, smerte, plutselig endret hørsel eller noe som bør vurderes videre.
+- Når audiograf er relevant, tilby å hjelpe brukeren å lage en kort beskrivelse eller huskeliste.
+
+Usikkerhet:
+- Hvis du ikke er sikker nok, skriv: "Her er jeg ikke sikker nok til å være presis, men du kan prøve ..."
+- Hvis det ikke fungerer, tilby å hjelpe brukeren å formulere problemet videre.
+
+Kilder:
+- Bruk kildene som grunnlag for svaret.
+- Ikke la kildene dominere svaret.`;

--- a/src/pages/no/chat.astro
+++ b/src/pages/no/chat.astro
@@ -36,8 +36,8 @@ const aiHeadingId = "viddel-standalone-chat-ai";
             beskriver hva du prøver å få til.
           </p>
           <p class="viddel-chat-standalone__safety">
-            Viddel kan gi praktiske forslag og hjelpe deg å finne neste steg. Ved medisinske spørsmål eller vedvarende
-            problemer bør du kontakte audiograf eller annet helsepersonell.
+            Viddel kan gi praktiske forslag og hjelpe deg å finne neste steg. Hvis saken bør tas videre, kan Viddel
+            hjelpe deg å lage en kort beskrivelse til audiograf.
           </p>
         </header>
 
@@ -135,7 +135,9 @@ const aiHeadingId = "viddel-standalone-chat-ai";
     }
   </style>
 
-  <script is:inline>
+  <script>
+    import { renderAssistantMarkdownInto } from "../../lib/render-assistant-markdown";
+
     (() => {
       const root = document.querySelector("[data-viddel-chat]");
       const shell = document.querySelector("[data-viddel-chat-shell]");
@@ -243,7 +245,7 @@ const aiHeadingId = "viddel-standalone-chat-ai";
         eyebrow.textContent = "Viddel";
         const body = document.createElement("div");
         body.className = "inline-chat-shell__message-text";
-        body.textContent = text;
+        renderAssistantMarkdownInto(body, text);
         assistant.append(eyebrow, body);
         activeTurn.append(assistant);
         assistant.scrollIntoView({ behavior: "smooth", block: "nearest" });

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -84,6 +84,34 @@ body.vox-shell--standalone-chat #ces-widget {
   scroll-margin-bottom: min(1.55rem, var(--inline-chat-bottom-reserve, 72px));
 }
 
+.inline-chat-shell__message-text p {
+  margin: 0 0 0.75rem;
+}
+
+.inline-chat-shell__message-text p:last-child,
+.inline-chat-shell__message-text ul:last-child,
+.inline-chat-shell__message-text ol:last-child {
+  margin-bottom: 0;
+}
+
+.inline-chat-shell__message-text ul,
+.inline-chat-shell__message-text ol {
+  margin: 0 0 0.75rem 1.15rem;
+  padding: 0;
+}
+
+.inline-chat-shell__message-text ul {
+  list-style: disc;
+}
+
+.inline-chat-shell__message-text ol {
+  list-style: decimal;
+}
+
+.inline-chat-shell__message-text li + li {
+  margin-top: 0.25rem;
+}
+
 .inline-chat-shell[data-inline-chat-mode="progressive"] .inline-chat-shell__compose-stack {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Adds Viddel response contract v0.1 preamble to Google Agent Search direct `:answer` requests.
- Renders assistant replies in `/no/chat` with safe DOM-based Markdown (bold, lists, paragraphs).
- Tones down over-cautious safety copy without changing backend mode or public API contract.

## Test plan
- [ ] Preview deploy on exact host (not `--preview` alias)
- [ ] `/no/chat`: `**bold**` and lists render correctly
- [ ] QA questions from #217: shorter answers, no forbidden words, audiograf only when relevant
- [ ] `npm run build` passes


Made with [Cursor](https://cursor.com)