### PR TITLE
VIS knowledge status panel v0.1 (#230)

### DIFF
--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -66,7 +66,7 @@ export type ClosedSprint = {
 };
 
 export const mvpCurrentState = {
-  updatedAt: "2026-05-29",
+  updatedAt: "2026-06-05",
   currentSprint: {
     id: "2026-w21",
     label: "2026-W21",
@@ -158,6 +158,13 @@ export const mvpCurrentState = {
       visFrontpage: false,
       frontpageDescription: "Operativ sprintflate for 2026-W21.",
     },
+    {
+      id: "knowledge-status",
+      label: "Knowledge status",
+      route: "/vis/system/knowledge-status-v01/",
+      role: "Source trust, review-behov og manifest-gate — sample inventory v0.1",
+      visFrontpage: false,
+    },
   ] satisfies CanonicalReference[],
   nextRisks: [
     {
@@ -197,6 +204,12 @@ export const mvpCurrentState = {
     },
   ] satisfies NextRisk[],
   recentChanges: [
+    {
+      date: "2026-06-05",
+      summary: "VIS knowledge status panel v0.1 — source trust og manifest-gate lesbart i VIS (#230)",
+      issue: "#230",
+      commit: "—",
+    },
     {
       date: "2026-05-30",
       summary: "Backstage guardrail — operating rules, Return Ticket-felt, build-time verify (#184)",

--- a/src/data/vis-knowledge-status-v01.ts
+++ b/src/data/vis-knowledge-status-v01.ts
@@ -1,0 +1,209 @@
+/* CONTRACT: VIS read model for source inventory / knowledge status v0.1 (#230). */
+
+import knowledgeStatusSample from "../../data/source-inventory/knowledge-status.sample.json";
+import sourceRegistrySample from "../../data/source-inventory/source-registry.generated.sample.json";
+import manifestPlaceholder from "../../data/source-inventory/datastore-ready-manifest.sample.json";
+import manifestValid from "../../data/source-inventory/datastore-ready-manifest.valid.sample.json";
+import { validateDatastoreManifest } from "../lib/source-registry.ts";
+import type { ReviewNeed, SourceRegistryEntry } from "./source-registry/source-types.ts";
+
+export const visKnowledgeStatusMeta = {
+  version: "v0.1",
+  pageRoute: "/vis/system/knowledge-status-v01",
+  dataSource: "data/source-inventory/*.sample.json",
+  updatedAt: knowledgeStatusSample.generatedAt.slice(0, 10),
+  classifierVersion: sourceRegistrySample.classifierVersion,
+  snapshotSource: sourceRegistrySample.snapshotSource,
+} as const;
+
+export const productionManifestRule =
+  "Production Agent Search kan bare bruke manifest-godkjente datastore_ready assets. Rå Drive-mapper, manualer, transkripsjoner og researchnotater skal ikke importeres direkte i production." as const;
+
+export const knowledgeFlowSteps = [
+  "Raw source",
+  "machine classified",
+  "reviewed insight",
+  "canonical guidance",
+  "datastore_ready manifest",
+  "production Agent Search",
+] as const;
+
+export type StatusCount = {
+  id: string;
+  label: string;
+  value: number;
+  hint?: string;
+};
+
+export type ReviewNeedSummary = {
+  need: ReviewNeed;
+  label: string;
+  count: number;
+  examples: { id: string; title: string }[];
+};
+
+export type ManifestGateSummary = {
+  id: string;
+  label: string;
+  filePath: string;
+  status: "ok" | "blocked";
+  importableEntries: number;
+  issueCount: number;
+  note: string;
+};
+
+const REVIEW_NEED_LABELS: Record<ReviewNeed, string> = {
+  none: "Ingen review",
+  needs_metadata: "Trenger metadata",
+  needs_source_check: "Trenger kilde-sjekk",
+  needs_freshness_check: "Trenger ferskhets-sjekk",
+  needs_human_review: "Trenger menneskelig review",
+  needs_canonical_rewrite: "Trenger canonical omskriving",
+};
+
+function countByReviewNeed(entries: SourceRegistryEntry[]): ReviewNeedSummary[] {
+  const order: ReviewNeed[] = [
+    "needs_human_review",
+    "needs_canonical_rewrite",
+    "needs_freshness_check",
+    "needs_source_check",
+    "needs_metadata",
+    "none",
+  ];
+
+  return order
+    .map((need) => {
+      const matched = entries.filter((e) => e.reviewNeed === need);
+      return {
+        need,
+        label: REVIEW_NEED_LABELS[need],
+        count: matched.length,
+        examples: matched.slice(0, 3).map((e) => ({ id: e.id, title: e.title })),
+      };
+    })
+    .filter((row) => row.count > 0);
+}
+
+function manifestSummary(
+  id: string,
+  label: string,
+  filePath: string,
+  manifest: typeof manifestValid,
+  note: string,
+): ManifestGateSummary {
+  const issues = validateDatastoreManifest(manifest);
+  return {
+    id,
+    label,
+    filePath,
+    status: issues.length === 0 ? "ok" : "blocked",
+    importableEntries: manifest.entries?.length ?? 0,
+    issueCount: issues.length,
+    note,
+  };
+}
+
+export function getVisKnowledgeStatusModel() {
+  const entries = sourceRegistrySample.entries as SourceRegistryEntry[];
+  const reviewNeeds = countByReviewNeed(entries);
+
+  const statusCounts: StatusCount[] = [
+    { id: "totalSources", label: "Totalt kilder", value: knowledgeStatusSample.totalSources },
+    { id: "rawOriginal", label: "Raw originals", value: knowledgeStatusSample.rawOriginal },
+    {
+      id: "machineClassified",
+      label: "Machine classified",
+      value: knowledgeStatusSample.machineClassified,
+    },
+    {
+      id: "needsReview",
+      label: "Trenger review",
+      value: knowledgeStatusSample.needsReview,
+      hint: "Alle sample-kilder har minst ett review-flagg i v0.1.",
+    },
+    {
+      id: "provisionalInsight",
+      label: "Provisional insight",
+      value: knowledgeStatusSample.provisionalInsight,
+    },
+    {
+      id: "reviewedInsight",
+      label: "Reviewed insight",
+      value: knowledgeStatusSample.reviewedInsight,
+    },
+    {
+      id: "canonicalGuidance",
+      label: "Canonical guidance",
+      value: knowledgeStatusSample.canonicalGuidance,
+    },
+    {
+      id: "datastoreReady",
+      label: "Datastore-ready",
+      value: knowledgeStatusSample.datastoreReady,
+      hint: "Eneste tillatte status for production-import via manifest.",
+    },
+    { id: "deprecated", label: "Deprecated", value: knowledgeStatusSample.deprecated },
+    {
+      id: "staleOrOutdated",
+      label: "Stale / outdated",
+      value: knowledgeStatusSample.staleOrOutdated,
+    },
+  ];
+
+  const manifestGates: ManifestGateSummary[] = [
+    manifestSummary(
+      "valid-sample",
+      "Valid manifest (demo)",
+      "data/source-inventory/datastore-ready-manifest.valid.sample.json",
+      manifestValid,
+      "Passerer manifest-gate — eksempel på godkjent import-rad, ikke deployet.",
+    ),
+    manifestSummary(
+      "placeholder-sample",
+      "Placeholder manifest (blokkert)",
+      "data/source-inventory/datastore-ready-manifest.sample.json",
+      manifestPlaceholder,
+      "Bevisst ugyldig — viser hva som blokkeres før production-import.",
+    ),
+  ];
+
+  const docLinks = [
+    {
+      label: "Datastore/source architecture v0.1",
+      path: "docs/project/VIDDEL_DATASTORE_SOURCE_ARCHITECTURE_v0_1.md",
+    },
+    {
+      label: "Source inventory automation v0.1",
+      path: "docs/project/VIDDEL_SOURCE_INVENTORY_AUTOMATION_v0_1.md",
+    },
+    {
+      label: "Datastore-ready manifest v0.1",
+      path: "docs/project/VIDDEL_DATASTORE_READY_MANIFEST_v0_1.md",
+    },
+    {
+      label: "Generated registry sample",
+      path: "data/source-inventory/source-registry.generated.sample.json",
+    },
+    {
+      label: "Knowledge status sample",
+      path: "data/source-inventory/knowledge-status.sample.json",
+    },
+    {
+      label: "Manifest placeholder sample",
+      path: "data/source-inventory/datastore-ready-manifest.sample.json",
+    },
+    {
+      label: "Manifest valid sample",
+      path: "data/source-inventory/datastore-ready-manifest.valid.sample.json",
+    },
+  ];
+
+  return {
+    meta: visKnowledgeStatusMeta,
+    statusCounts,
+    reviewNeeds,
+    manifestGates,
+    docLinks,
+    registryEntryCount: entries.length,
+  };
+}

--- a/src/data/vis-navigation-v01.ts
+++ b/src/data/vis-navigation-v01.ts
@@ -203,6 +203,19 @@ export const visPageContracts: Record<string, VisPageContract> = {
     lastReviewed: "2026-06-01",
     ownerRole: "Thomas",
   },
+  "knowledge-status": {
+    id: "knowledge-status",
+    title: "Knowledge status",
+    type: "runtime-data",
+    status: "active",
+    purpose: "Lesbar oversikt over source trust, review-behov og manifest-gate — uten JSON/scripts.",
+    primaryTask: "forstå-system",
+    audience: ["Thomas", "Vibeke", "@navigator"],
+    canonicalSource: "data/source-inventory/knowledge-status.sample.json",
+    lastReviewed: "2026-06-05",
+    ownerRole: "Thomas",
+    nextAction: "Sjekk datastore-ready og review-flagg før manifest-godkjenning.",
+  },
   "raw-wireframes": {
     id: "raw-wireframes",
     title: "Raw wireframes",
@@ -320,6 +333,12 @@ export const visNavSections: VisNavSection[] = [
         href: "/vis/system/ia-inventory-v01",
         pageContractId: "ia-inventory",
       },
+      {
+        id: "knowledge-status",
+        label: "Knowledge status",
+        href: "/vis/system/knowledge-status-v01",
+        pageContractId: "knowledge-status",
+      },
     ],
   },
   {
@@ -368,7 +387,7 @@ export const visNavSections: VisNavSection[] = [
 
 export const visNavigationMeta = {
   version: "v0.1",
-  updatedAt: "2026-06-01",
+  updatedAt: "2026-06-05",
   dataSource: "src/data/vis-navigation-v01.ts",
 } as const;
 

--- a/src/pages/vis/system/index.astro
+++ b/src/pages/vis/system/index.astro
@@ -103,6 +103,11 @@ const base = import.meta.env.BASE_URL;
           <b>GitHub runtime status</b>
           <p>Generert feed fra GitHub API for @navigator / Daily Sync.</p>
         </a>
+        <a href={`${base}vis/system/knowledge-status-v01`}>
+          <span>runtime · source trust</span>
+          <b>Knowledge status v0.1</b>
+          <p>Sample source inventory, review-behov og manifest-gate for verified insight.</p>
+        </a>
       </div>
     </section>
 

--- a/src/pages/vis/system/knowledge-status-v01.astro
+++ b/src/pages/vis/system/knowledge-status-v01.astro
@@ -1,0 +1,198 @@
+---
+/* CONTRACT: VIS knowledge status panel v0.1 — lesbar oversikt over source trust og manifest-gate (#230). */
+import VisInternalLayout from "../../../layouts/VisInternalLayout.astro";
+import {
+  getVisKnowledgeStatusModel,
+  knowledgeFlowSteps,
+  productionManifestRule,
+} from "../../../data/vis-knowledge-status-v01.ts";
+
+const base = import.meta.env.BASE_URL;
+const model = getVisKnowledgeStatusModel();
+---
+
+<VisInternalLayout title="Knowledge status v0.1" pageContractId="knowledge-status">
+  <main class="px-4 py-6 sm:px-6 sm:py-8">
+    <nav class="text-xs text-gray-500">
+      <a href={`${base}vis`} class="underline underline-offset-2">VIS</a>
+      <span aria-hidden="true"> / </span>
+      <a href={`${base}vis/system`} class="underline underline-offset-2">System</a>
+      <span aria-hidden="true"> / </span>
+      <span class="text-gray-800">Knowledge status</span>
+    </nav>
+
+    <header class="mt-4 max-w-3xl">
+      <p class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">VIS · source trust</p>
+      <h1 class="mt-1 text-xl font-semibold tracking-tight text-gray-900 sm:text-2xl">
+        Kunnskapsstatus v0.1
+      </h1>
+      <p class="mt-3 text-sm leading-relaxed text-gray-600">
+        Lesbar statusflate for verified insight / datastore-klar kunnskap. Basert på sample og generated
+        source inventory fra #228 — ikke full live Drive-inventory.
+      </p>
+      <p class="mt-2 text-xs text-gray-500">
+        Generert {model.meta.updatedAt} · classifier {model.meta.classifierVersion} · snapshot{" "}
+        <code class="rounded bg-gray-100 px-1 font-mono">{model.meta.snapshotSource}</code>
+      </p>
+    </header>
+
+    <section class="mt-6 rounded-md border border-gray-300 bg-white p-4" aria-labelledby="ks-counts">
+      <h2 id="ks-counts" class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Kunnskapsstatus
+      </h2>
+      <p class="mt-1 text-xs text-gray-500">
+        Tall fra <code class="font-mono">knowledge-status.sample.json</code> ({model.registryEntryCount}{" "}
+        registry-rader).
+      </p>
+      <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {
+          model.statusCounts.map((row) => (
+            <article
+              class:list={[
+                "rounded border px-3 py-2.5",
+                row.id === "datastoreReady"
+                  ? "border-emerald-300 bg-emerald-50/60"
+                  : row.id === "needsReview"
+                    ? "border-amber-300 bg-amber-50/50"
+                    : "border-gray-200 bg-gray-50/50",
+              ]}
+            >
+              <p class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">{row.label}</p>
+              <p class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">{row.value}</p>
+              {row.hint ? <p class="mt-1 text-[11px] leading-relaxed text-gray-600">{row.hint}</p> : null}
+            </article>
+          ))
+        }
+      </div>
+    </section>
+
+    <section class="mt-6 rounded-md border border-gray-300 bg-white p-4" aria-labelledby="ks-gate">
+      <h2 id="ks-gate" class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Manifest-gate
+      </h2>
+      <blockquote class="mt-3 max-w-3xl border-l-4 border-gray-300 pl-3 text-sm leading-relaxed text-gray-700">
+        {productionManifestRule}
+      </blockquote>
+      <div class="mt-4 grid gap-3 sm:grid-cols-2">
+        {
+          model.manifestGates.map((gate) => (
+            <article
+              class:list={[
+                "rounded border px-3 py-3",
+                gate.status === "ok"
+                  ? "border-emerald-300 bg-emerald-50/40"
+                  : "border-red-300 bg-red-50/40",
+              ]}
+            >
+              <div class="flex flex-wrap items-center gap-2">
+                <span
+                  class:list={[
+                    "rounded px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide",
+                    gate.status === "ok"
+                      ? "bg-emerald-100 text-emerald-800"
+                      : "bg-red-100 text-red-800",
+                  ]}
+                >
+                  {gate.status === "ok" ? "OK / demo" : "Blokkert / eksempel"}
+                </span>
+                <h3 class="text-sm font-semibold text-gray-900">{gate.label}</h3>
+              </div>
+              <p class="mt-2 font-mono text-[11px] text-gray-600">{gate.filePath}</p>
+              <p class="mt-2 text-xs text-gray-600">
+                {gate.importableEntries} manifest-rader · {gate.issueCount} valideringsfeil
+              </p>
+              <p class="mt-1 text-xs leading-relaxed text-gray-600">{gate.note}</p>
+            </article>
+          ))
+        }
+      </div>
+    </section>
+
+    <section class="mt-6 rounded-md border border-gray-300 bg-white p-4" aria-labelledby="ks-review">
+      <h2 id="ks-review" class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Hva trenger review?
+      </h2>
+      <p class="mt-1 text-xs text-gray-500">
+        Oppsummering fra registry sample — ikke full browser.
+      </p>
+      {
+        model.reviewNeeds.length ? (
+          <ul class="mt-4 space-y-3">
+            {model.reviewNeeds.map((row) => (
+              <li class="rounded border border-gray-200 bg-gray-50/60 px-3 py-2.5">
+                <div class="flex flex-wrap items-baseline justify-between gap-2">
+                  <span class="text-sm font-medium text-gray-900">{row.label}</span>
+                  <span class="text-sm font-semibold tabular-nums text-gray-700">{row.count}</span>
+                </div>
+                {row.examples.length ? (
+                  <ul class="mt-2 space-y-1 text-xs text-gray-600">
+                    {row.examples.map((ex) => (
+                      <li>
+                        <span class="font-mono text-[10px] text-gray-500">{ex.id}</span>
+                        {" — "}
+                        {ex.title}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p class="mt-3 text-sm text-gray-600">Ingen review-flagg i sample-data.</p>
+        )
+      }
+    </section>
+
+    <section class="mt-6 rounded-md border border-gray-300 bg-white p-4" aria-labelledby="ks-flow">
+      <h2 id="ks-flow" class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Hvordan flyten fungerer
+      </h2>
+      <ol class="mt-4 flex flex-wrap items-center gap-2 text-xs text-gray-700">
+        {
+          knowledgeFlowSteps.map((step, index) => (
+            <>
+              <li class="rounded border border-gray-200 bg-gray-50 px-2.5 py-1.5 font-medium">{step}</li>
+              {index < knowledgeFlowSteps.length - 1 ? (
+                <span class="text-gray-400" aria-hidden="true">→</span>
+              ) : null}
+            </>
+          ))
+        }
+      </ol>
+    </section>
+
+    <section class="mt-6 rounded-md border border-gray-300 bg-white p-4" aria-labelledby="ks-links">
+      <h2 id="ks-links" class="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Filer og docs
+      </h2>
+      <ul class="mt-3 space-y-1.5 text-sm text-gray-700">
+        {
+          model.docLinks.map((link) => (
+            <li>
+              <code class="rounded bg-gray-100 px-1 font-mono text-xs">{link.path}</code>
+              <span class="text-gray-500"> — </span>
+              {link.label}
+            </li>
+          ))
+        }
+      </ul>
+      <p class="mt-3 text-xs text-gray-500">
+        Regenerer sample: <code class="font-mono">npm run source:inventory</code> · Valider manifest:{" "}
+        <code class="font-mono">npm run source:manifest:check</code>
+      </p>
+    </section>
+
+    <section class="mt-6 rounded-md border border-dashed border-gray-300 bg-gray-50/70 p-4" aria-labelledby="ks-not">
+      <h2 id="ks-not" class="text-sm font-semibold uppercase tracking-wide text-gray-600">
+        Hva dette ikke er
+      </h2>
+      <ul class="mt-2 list-inside list-disc space-y-1 text-sm text-gray-600">
+        <li>Ikke live Drive-dashboard</li>
+        <li>Ikke datastore-import</li>
+        <li>Ikke fullt review-system eller registry-browser</li>
+        <li>Ikke production-endring — kun VIS-orientering</li>
+      </ul>
+    </section>
+  </main>
+</VisInternalLayout>


### PR DESCRIPTION
## Summary
- Adds `/vis/system/knowledge-status-v01` — readable status surface for source trust, review needs and manifest gate
- Small adapter `src/data/vis-knowledge-status-v01.ts` reads existing #228 sample JSON (no live Drive)
- Updates VIS navigation/page contract and `mvp-current-state` canonical reference (not frontpage)

## Test plan
- [x] `npm run build`
- [ ] Open `/vis/system/knowledge-status-v01` — status cards show sample counts (10 total, 0 datastore-ready)
- [ ] Manifest section shows valid sample OK + placeholder blocked
- [ ] Review section lists needs_human_review / needs_canonical_rewrite examples
- [ ] Page reachable from VIS tremeny → «Forstå system og innhold» → Knowledge status
- [ ] No production/backend/env changes


Made with [Cursor](https://cursor.com)