### PR TITLE
Docs: Codex operating setup v0.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,30 @@ The product should feel warm, premium, technically strong, and useful in everyda
 - GitHub issues/PRs as task bus
 
 ## Working role
-Codex is an implementation agent.
+Codex and Cursor are implementation agents.
 Use GitHub and the repository as source of truth for code, project docs, issues, branches and PRs.
 Do not assume access to ChatGPT project memory. Read repo context before coding.
 
+Codex is the default executor for routine repo work:
+- docs
+- data/source inventory
+- scripts
+- validators
+- small Astro/VIS pages
+- structured GitHub issue work
+- PR work with clear acceptance criteria
+
+Cursor is reserve/specialist for:
+- visual debugging
+- CSS/layout fine tuning
+- live dev-server iteration
+- local IDE-heavy file navigation
+- cases where Codex gets stuck
+
 ## Before coding
-For non-trivial tasks, first inspect relevant project docs and files.
+Every task starts from a GitHub issue or a clear prompt. If the task is ambiguous, clarify scope before changing files.
+
+For non-trivial tasks, first do safe-read: inspect relevant project docs and files before editing.
 Prefer reading:
 - README.md
 - docs/project/OPERATING_RULES.md
@@ -38,10 +56,14 @@ For ambiguous or larger tasks:
 - Keep changes small and reviewable.
 - Prefer existing components, tokens, CSS patterns and Astro structure.
 - Preserve IA, routes and content model unless explicitly asked.
+- Use existing VIS structure, page contracts and navigation patterns.
 - Do not introduce new dependencies without approval.
 - Do not rewrite working areas unnecessarily.
 - Avoid broad refactors unless the task explicitly asks for it.
 - Do not make visual redesigns without a clear brief.
+- Do not change backend, env, datastore, import routines or PostHog without an explicit decision.
+- Do not log prompts, AI answers or private conversation content.
+- Do not claim something exists in production before it is deployed and verified on the exact production URL.
 - Commit messages, branch names, code and filenames may be in English.
 - User-facing summaries and QA should be in Norwegian.
 
@@ -55,7 +77,7 @@ Full doc: `docs/project/OPERATING_RULES.md`
 
 **Source of truth:** `/designsystem/` = design patterns · `src/data/mvp-current-state.ts` = operativ MVP-status · `/vis/sprints/...` = historikk.
 
-**Return Ticket extras (when relevant):** Designsystem impact · Current-state / VIS impact · Applied surfaces · Follow-up. If N/A: `Current-state update: Ikke nødvendig — ingen endring i MVP-status, designmønstre eller applied surfaces.`
+**Return Ticket extras:** VIS/current-state impact · Backstage impact · Navigation/page-contract impact · Follow-up if deferred. If N/A, say so explicitly.
 
 ## Verification
 Run relevant checks before finishing.
@@ -64,18 +86,29 @@ Default check:
 
 If a check cannot be run, explain why.
 
-## Return ticket
-End every task with a Norwegian return ticket:
+For UI/page changes, also provide the exact Preview URL when relevant. Do not describe a Preview or production state as verified unless the exact URL has been opened and checked.
 
-- Status
-- Hva ble gjort
-- Filer endret
-- Tester kjørt
-- Hva Thomas bør verifisere
-- Eventuelle risikoer eller åpne punkter
-- Designsystem impact (when relevant)
-- Current-state / VIS frontpage impact (when relevant)
-- Applied surfaces impacted (when relevant)
+## Return ticket
+End every completed issue task with a Norwegian Return Ticket on the issue. Use this template:
+
+```text
+Status:
+Hva ble gjort:
+Filer endret:
+Tester kjørt:
+Commit:
+Push-status:
+PR:
+Preview/deploy:
+Hva Thomas bør verifisere:
+Risiko / åpne punkter:
+VIS/current-state impact:
+Backstage impact:
+Navigation/page-contract impact:
+Follow-up issue if deferred:
+```
+
+The Return Ticket must include commit hash, push status, PR link, tests run and exact Preview/deploy URL when relevant.
 
 ## Agent Workflow v0.1
 Dette er operativ minimumsflyt for Codex og Cursor i dette repoet.
@@ -92,6 +125,8 @@ Dette er operativ minimumsflyt for Codex og Cursor i dette repoet.
    - Hold endringer små, avgrensede og reviewbare.
    - Unngå brede refaktorer og sideeffekter uten eksplisitt bestilling.
    - Ikke endre strategi, roadmap eller arkitektur uten eksplisitt mandat.
+   - Ikke endre backend/env/datastore/PostHog uten eksplisitt beslutning.
+   - Ikke logg prompt eller AI-svar.
 
 4. **Les før endring**
    - Les relevante filer i berørt filscope før du gjør endringer.
@@ -100,6 +135,8 @@ Dette er operativ minimumsflyt for Codex og Cursor i dette repoet.
 5. **Verifisering før ferdigmelding**
    - Kjør relevante repo-sjekker for endringen.
    - Minimum: `npm run build` (eller forklar konkret hvorfor den ikke kan kjøres).
+   - Ved Preview/deploy: oppgi exact URL og hva som faktisk er verifisert.
+   - Ikke si at noe finnes i production før production URL er deployet og verifisert.
 
 6. **Feilhåndtering ved funn etterpå**
    - Forklar kort hvorfor feilen ikke ble fanget tidligere.
@@ -107,3 +144,14 @@ Dette er operativ minimumsflyt for Codex og Cursor i dette repoet.
 
 7. **Avslutning**
    - Avslutt med Return Ticket ved ferdig arbeid.
+   - Commit ferdig arbeid.
+   - Push branch.
+   - Opprett PR, med mindre Thomas eksplisitt har bedt om noe annet.
+   - Oppgi commit hash, push-status og PR-lenke.
+   - Legg Return Ticket på issue når ferdig.
+
+8. **Obligatorisk impact-sjekk**
+   - VIS/current-state impact: vurder om `src/data/mvp-current-state.ts`, VIS frontpage eller VIS Runtime Feed må oppdateres. Hvis ikke: skriv `VIS/current-state impact: none`.
+   - Backstage impact: vurder om `/backstage/` påvirkes av system/API/guard/env/monitoring/production-endringer.
+   - Navigation/page-contract impact: vurder om routes, IA, sidekontrakter eller navigasjon påvirkes.
+   - Hvis en nødvendig oppdatering utsettes, opprett eller lenk follow-up issue.

--- a/docs/project/06_RETURN_TICKET.md
+++ b/docs/project/06_RETURN_TICKET.md
@@ -6,53 +6,48 @@ Gi en kort, fast retur fra utførelse tilbake til strategi, arkiv og prosjektsta
 ## Når brukes den
 Bruk Return Ticket når:
 - Cursor har implementert noe
+- Codex har implementert noe
 - en GitHub-oppgave er flyttet vesentlig
 - et viktig design-, innholds- eller arbeidsgrep er landet
 - resultatet påvirker arbeidsarkitektur, roadmap, VIS eller prosjektstatus
 
-## Mal v1
+## Mal v1.1
 
-Oppgave
-- 
+```text
+Status:
+Hva ble gjort:
+Filer endret:
+Tester kjørt:
+Commit:
+Push-status:
+PR:
+Preview/deploy:
+Hva Thomas bør verifisere:
+Risiko / åpne punkter:
+VIS/current-state impact:
+Backstage impact:
+Navigation/page-contract impact:
+Follow-up issue if deferred:
+```
 
-Hva ble gjort
-- 
+## Operative presiseringer
 
-Hva ble faktisk landet
-- 
+`Commit` skal inneholde commit hash. `Push-status` skal si om branchen er pushet. `PR` skal lenke til PR, med mindre Thomas eksplisitt har bedt om noe annet.
 
-Avvik fra plan
-- 
+`Preview/deploy` skal inneholde exact Preview URL når relevant. Ikke skriv at noe finnes i production før exact production URL er deployet og verifisert.
 
-Designsystem impact
-- 
+`VIS/current-state impact` skal si om `src/data/mvp-current-state.ts`, VIS frontpage eller VIS Runtime Feed må oppdateres. Hvis ikke relevant: `VIS/current-state impact: none`.
 
-Current-state / VIS frontpage impact
-- (Hvis ikke relevant: «Current-state update: Ikke nødvendig — ingen endring i MVP-status, designmønstre eller applied surfaces.»)
+`Backstage impact` skal si om systemflyt, API, guard, env-vars, monitoring eller production-status påvirkes.
 
-Backstage impact
-- `Oppdatert: ...` / `Ikke relevant: ingen endring i systemflyt, API, guard, env-vars, monitoring eller production-status.` / `Må følges opp: ...`
+`Navigation/page-contract impact` skal si om routes, IA, sidekontrakter eller navigasjon påvirkes.
 
-VIS runtime update
-- Oppdatert: ja / nei
-- Hva skjer nå? (én menneskelig setning)
-- Hvorfor gjør vi det?
-- Område
-- Status / fremdrift
-- Neste beslutning
-- Sist ferdigstilt
-- Siste retur
-- Lenker (primary + secondary)
+Ved større eller VIS-relevante endringer kan Return Ticket også utvides med:
+- Designsystem impact
+- Applied surfaces impacted
+- VIS runtime update
 
 **Presisering:** Intern shorthand er ikke nok. Return Ticket skal gi nok språk til at VIS kan forstås dagen etter, også uten muntlig kontekst.
-
-Hvis ikke relevant: `VIS runtime update: Ikke nødvendig — ingen endring i hva Cursor/rigger jobber med akkurat nå.`
-
-Applied surfaces impacted
-- 
-
-Follow-up needed
-- 
 
 Hva må oppdateres
 - [ ] VIS (`src/data/mvp-current-state.ts` ved MVP-statusendring)

--- a/docs/project/07_GITHUB_TASK_FLOW.md
+++ b/docs/project/07_GITHUB_TASK_FLOW.md
@@ -90,7 +90,7 @@ Kort bør vise:
 
 ### 3. Board — Execution
 Formål:
-Operativ flyt for @rigger og Cursor.
+Operativ flyt for @rigger, Codex og Cursor.
 
 Oppsett:
 - layout: Board
@@ -128,10 +128,11 @@ Oppsett:
 - sikrer riktig statusflyt
 - sikrer at handoff og Return Ticket henger sammen med kortet
 
-### Cursor
-- utfører kun på grunnlag av konkret Task / issue
-- leverer commit, push, commit hash, push-status og verifikasjon
-- returnerer med Return Ticket
+### Codex / Cursor
+- utfører kun på grunnlag av konkret Task / issue eller tydelig prompt
+- leverer commit, push, commit hash, push-status, PR og verifikasjon
+- oppgir exact Preview/deploy URL når relevant
+- returnerer med Return Ticket på issue
 
 ### Thomas og Vibeke
 - følger primært Roadmap — Tracks og Board — Workstreams

--- a/docs/project/CODEX_OPERATING_SETUP_v0_1.md
+++ b/docs/project/CODEX_OPERATING_SETUP_v0_1.md
@@ -1,0 +1,78 @@
+# Codex Operating Setup v0.1
+
+Kort onboarding for å bruke Codex som standard executor i Viddel Lab / vox-web.
+
+## Når bruke Codex
+
+Bruk Codex først for rutinearbeid som har tydelig issue, akseptkriterier og lav runtime-risiko:
+
+- docs
+- data/source inventory
+- scripts
+- validators
+- små Astro/VIS-sider
+- strukturert GitHub issue-arbeid
+- PR-arbeid med klare akseptkriterier
+
+## Når bruke Cursor
+
+Bruk Cursor som reserve eller spesialist når arbeidet krever:
+
+- visuell debugging
+- CSS/layout-finjustering
+- live dev-server-iterasjon
+- lokal IDE-tung filnavigering
+- situasjoner der Codex står fast
+
+## Standard arbeidsflyt
+
+1. Start fra GitHub issue eller tydelig prompt.
+2. Gjør safe-read av relevante repo-filer før endring.
+3. Hold scope lite og reviewbart.
+4. Bruk eksisterende mønstre, tokens, routes og VIS-struktur.
+5. Ikke endre backend, env, datastore, import-rutiner eller PostHog uten eksplisitt beslutning.
+6. Ikke logg prompt, AI-svar eller privat samtaleinnhold.
+7. Kjør relevante tester, minimum `npm run build` hvis repo-endringer er gjort.
+8. Commit, push branch og opprett PR.
+9. Legg Return Ticket på issue.
+
+## Return Ticket-mal
+
+```text
+Status:
+Hva ble gjort:
+Filer endret:
+Tester kjørt:
+Commit:
+Push-status:
+PR:
+Preview/deploy:
+Hva Thomas bør verifisere:
+Risiko / åpne punkter:
+VIS/current-state impact:
+Backstage impact:
+Navigation/page-contract impact:
+Follow-up issue if deferred:
+```
+
+## Preview og deploy-verifisering
+
+Oppgi exact Preview URL når en PR har relevant visuell eller sidebasert effekt.
+
+Ikke skriv at noe finnes i production før det faktisk er deployet og verifisert på exact production URL. Hvis Preview ikke er relevant for en docs/data/script-endring, skriv det eksplisitt i Return Ticket.
+
+## Første Codex-pilot
+
+Anbefalt første praktiske pilot er #232: `Expand source inventory coverage across Drive source pools v0.1`.
+
+Formålet er å teste Codex på en strukturert docs/data/script-oppgave uten production-runtime-risiko. Ikke start #232 som del av Codex operating setup v0.1.
+
+## Uten eksplisitt beslutning skal Codex ikke
+
+- gjøre runtime-endringer
+- endre backend/env
+- importere datastore-data
+- gjøre Drive-endringer
+- endre PostHog
+- logge prompt eller AI-svar
+- redesigne VIS

--- a/docs/project/OPERATING_RULES.md
+++ b/docs/project/OPERATING_RULES.md
@@ -87,12 +87,18 @@ Validering: `npm run verify:vis-runtime-feed` (kjøres automatisk før `npm run 
 
 Alle relevante Return Tickets skal inneholde:
 
-1. **Designsystem impact** — mønstre brukt / nye / `/designsystem/` oppdatert?
-2. **Current-state / VIS frontpage impact** — skal `mvp-current-state.ts` oppdateres?
-3. **Backstage impact** — skal `/backstage/` oppdateres? (Se under.)
-4. **VIS runtime update** — skal `vis-runtime-feed.ts` oppdateres? (Se under.)
-5. **Applied surfaces impacted** — hvilke routes?
-6. **Follow-up needed** — åpne risiko eller neste steg?
+1. **Status** — ferdig / delvis / blokkert.
+2. **Hva ble gjort** — kort faktisk leveranse.
+3. **Filer endret** — relevante filer.
+4. **Tester kjørt** — inkludert `npm run build`, eller konkret hvorfor ikke.
+5. **Commit** — commit hash.
+6. **Push-status** — om branch er pushet.
+7. **PR** — PR-lenke, med mindre annet er eksplisitt avtalt.
+8. **Preview/deploy** — exact Preview/deploy URL når relevant.
+9. **VIS/current-state impact** — skal `mvp-current-state.ts`, VIS frontpage eller VIS Runtime Feed oppdateres?
+10. **Backstage impact** — skal `/backstage/` oppdateres? (Se under.)
+11. **Navigation/page-contract impact** — påvirkes routes, IA, page contract eller navigasjon?
+12. **Follow-up issue if deferred** — opprett/lenk issue hvis nødvendig oppdatering utsettes.
 
 **Backstage impact** — forventet innhold:
 
@@ -104,9 +110,9 @@ Hvis ikke relevant, skriv eksplisitt:
 
 > Backstage impact: Ikke relevant — ingen endring i systemflyt, API, guard, env-vars, monitoring eller production-status.
 
-Hvis current-state ikke endres:
+Hvis VIS/current-state ikke endres:
 
-> Current-state update: Ikke nødvendig — ingen endring i MVP-status, designmønstre eller applied surfaces.
+> VIS/current-state impact: none
 
 **VIS runtime update** — forventet format:
 
@@ -129,7 +135,8 @@ Intern shorthand er **ikke nok**. Return Ticket skal gi nok språk til at VIS ka
 4. Vurder Backstage (`/backstage/`) ved endringer i API, guard, env-vars eller production.
 5. Vurder VIS Runtime Feed (`vis-runtime-feed.ts`) ved viktig Return Ticket — skriv for Thomas/Vibeke.
 6. Hold endringer små; `npm run build` før ferdig.
-7. Return Ticket på relevant issue.
+7. Commit ferdig arbeid, push branch og opprett PR.
+8. Return Ticket på relevant issue.
 
 ## Filer
 
@@ -137,5 +144,6 @@ Intern shorthand er **ikke nok**. Return Ticket skal gi nok språk til at VIS ka
 - VIS Runtime Feed: `src/data/vis-runtime-feed.ts`, `src/lib/vis-runtime-feed-guard.ts`
 - Backstage: `src/data/backstage-v01.ts`, `src/lib/backstage-guard.ts`
 - Agent entry: `AGENTS.md`
+- Codex onboarding: `docs/project/CODEX_OPERATING_SETUP_v0_1.md`
 - Cursor: `.cursor/rules/viddel-operating-rules.mdc`
 - Return Ticket-mal: `docs/project/06_RETURN_TICKET.md`


### PR DESCRIPTION
## Summary
- tighten AGENTS.md for shared Codex/Cursor operating routine
- add short Codex onboarding doc and first-pilot guidance for #232
- align Return Ticket, operating rules and GitHub task-flow with commit/push/PR/impact requirements

## Tests
- npm run build

## Scope
- docs/agent-rules only
- no runtime changes
- no backend/env changes
- no datastore import
- no Drive changes
- no PostHog
- no prompt/answer logging

Closes #233