### PR TITLE
Align Lab image QA with Viddel chat shell

### DIFF
--- a/src/pages/lab/image-qa.astro
+++ b/src/pages/lab/image-qa.astro
@@ -109,7 +109,8 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
           id="image-qa-run"
           type="button"
           disabled
-          class="w-full rounded-[var(--radius-sm)] bg-[rgb(var(--accent))] px-4 py-3 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-45"
+          aria-disabled="true"
+          class="w-full rounded-[var(--radius-sm)] px-4 py-3 text-sm font-semibold transition enabled:bg-[rgb(var(--accent))] enabled:text-white enabled:shadow-sm disabled:cursor-not-allowed disabled:border disabled:border-[rgb(var(--stroke)/0.3)] disabled:bg-[rgb(var(--surface-subtle))] disabled:text-[rgb(var(--muted))]"
         >
           Analyser bilde
         </button>
@@ -169,8 +170,11 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
       const chatMetaEl = document.getElementById("image-qa-chat-meta");
       const chatTextEl = document.getElementById("image-qa-chat-text");
 
-      /** @type {{ base64: string; mimeType: string; previewUrl: string } | null} */
-      let selected = null;
+      const MAX_BYTES = 5 * 1024 * 1024;
+      const ALLOWED_MIME = new Set(["image/jpeg", "image/png", "image/webp", "image/bmp"]);
+
+      /** @type {{ file: File; previewUrl: string } | null} */
+      let selectedFile = null;
 
       function setStatus(text) {
         statusEl.textContent = text;
@@ -182,12 +186,65 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
         errorEl.classList.toggle("hidden", !text);
       }
 
+      function setRunButtonEnabled(enabled) {
+        runBtn.disabled = !enabled;
+        runBtn.setAttribute("aria-disabled", enabled ? "false" : "true");
+      }
+
+      function resolveMimeType(file) {
+        const raw = (file.type || "").trim().toLowerCase();
+        if (raw.startsWith("image/")) return raw;
+        const name = file.name.toLowerCase();
+        if (name.endsWith(".png")) return "image/png";
+        if (name.endsWith(".webp")) return "image/webp";
+        if (name.endsWith(".bmp")) return "image/bmp";
+        if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
+        // Mobilkamera gir ofte tom type — anta JPEG når fil kommer fra image/* picker.
+        return "image/jpeg";
+      }
+
+      function validateImageFile(file) {
+        if (!file || file.size <= 0) {
+          return { ok: false, message: "Ingen fil valgt." };
+        }
+        if (file.size > MAX_BYTES) {
+          return { ok: false, message: "Bildet er for stort (maks 5 MB)." };
+        }
+        const mimeType = resolveMimeType(file);
+        if (!ALLOWED_MIME.has(mimeType)) {
+          return { ok: false, message: "Velg et bilde (JPEG, PNG, WebP eller BMP)." };
+        }
+        return { ok: true, mimeType };
+      }
+
       function clearPreview() {
-        if (selected?.previewUrl) URL.revokeObjectURL(selected.previewUrl);
-        selected = null;
+        if (selectedFile?.previewUrl) URL.revokeObjectURL(selectedFile.previewUrl);
+        selectedFile = null;
         preview.removeAttribute("src");
         previewWrap.classList.add("hidden");
-        runBtn.disabled = true;
+        setRunButtonEnabled(false);
+      }
+
+      /** @returns {Promise<{ base64: string; mimeType: string }>} */
+      function fileToBase64Payload(file) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const dataUrl = typeof reader.result === "string" ? reader.result : "";
+            const comma = dataUrl.indexOf(",");
+            if (comma === -1) {
+              reject(new Error("Kunne ikke konvertere bildet til base64."));
+              return;
+            }
+            resolve({
+              base64: dataUrl.slice(comma + 1),
+              mimeType: resolveMimeType(file),
+            });
+          };
+          reader.onerror = () => reject(new Error("Kunne ikke lese bildet for opplasting."));
+          reader.onabort = () => reject(new Error("Lesing av bildet ble avbrutt."));
+          reader.readAsDataURL(file);
+        });
       }
 
       fileInput?.addEventListener("change", () => {
@@ -195,59 +252,59 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
         clearPreview();
         const file = fileInput.files?.[0];
         if (!file) return;
-        if (!file.type.startsWith("image/")) {
-          setError("Velg et bilde (JPEG, PNG, WebP).");
+
+        const validation = validateImageFile(file);
+        if (!validation.ok) {
+          setError(validation.message);
           fileInput.value = "";
           return;
         }
-        if (file.size > 5 * 1024 * 1024) {
-          setError("Bildet er for stort (maks 5 MB).");
-          fileInput.value = "";
-          return;
-        }
+
         const previewUrl = URL.createObjectURL(file);
         preview.src = previewUrl;
         previewWrap.classList.remove("hidden");
-        const reader = new FileReader();
-        reader.onload = () => {
-          const dataUrl = typeof reader.result === "string" ? reader.result : "";
-          const comma = dataUrl.indexOf(",");
-          if (comma === -1) {
-            setError("Kunne ikke lese bildet.");
-            return;
-          }
-          selected = {
-            base64: dataUrl.slice(comma + 1),
-            mimeType: file.type || "image/jpeg",
-            previewUrl,
-          };
-          runBtn.disabled = false;
-        };
-        reader.onerror = () => setError("Kunne ikke lese bildet.");
-        reader.readAsDataURL(file);
+        selectedFile = { file, previewUrl };
+        setRunButtonEnabled(true);
       });
 
       runBtn?.addEventListener("click", async () => {
-        if (!selected) return;
+        if (!selectedFile) return;
         setError("");
-        setStatus("Kjører vision…");
+        setStatus("Forbereder bilde…");
         resultsEl.classList.add("hidden");
         chatWrap.classList.add("hidden");
         warningsWrap.classList.add("hidden");
-        runBtn.disabled = true;
+        setRunButtonEnabled(false);
 
         const scenario = document.getElementById("image-qa-scenario")?.value ?? "A";
         const userProblem = document.getElementById("image-qa-problem")?.value?.trim() ?? "";
         const callChat = document.getElementById("image-qa-call-chat")?.checked ?? false;
 
         try {
+          let imageBase64;
+          let mimeType;
+          try {
+            const payload = await fileToBase64Payload(selectedFile.file);
+            imageBase64 = payload.base64;
+            mimeType = payload.mimeType;
+          } catch (conversionError) {
+            throw conversionError instanceof Error
+              ? conversionError
+              : new Error("Kunne ikke konvertere bildet.");
+          }
+
+          if (!imageBase64) {
+            throw new Error("Kunne ikke konvertere bildet til base64.");
+          }
+
+          setStatus("Kjører vision…");
           const visionRes = await fetch("/api/lab/image-vision", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             credentials: "same-origin",
             body: JSON.stringify({
-              imageBase64: selected.base64,
-              mimeType: selected.mimeType,
+              imageBase64,
+              mimeType,
               userProblem,
               scenario,
             }),
@@ -303,7 +360,7 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
           setError(err instanceof Error ? err.message : "Ukjent feil");
           setStatus("");
         } finally {
-          runBtn.disabled = !selected;
+          setRunButtonEnabled(Boolean(selectedFile));
         }
       });
     </script>

--- a/src/pages/lab/image-qa.astro
+++ b/src/pages/lab/image-qa.astro
@@ -1,7 +1,10 @@
 ---
-/* CONTRACT: Lab mobile camera QA — image→vision→RAG (#236/#237). Gated by Lab login; no image storage. */
-import "../../styles/global.css";
+/* CONTRACT: Lab image QA on Viddel AI shell — composer + attachment + vision flow (#240). Not /no/chat. */
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import { hasValidLabSession, isLabRouteAvailable } from "../../lib/lab-auth-v01.ts";
+import "../../styles/r1-dialog-article.css";
+import "../../styles/viddel-standalone-chat.css";
+import "../../styles/lab-image-qa.css";
 
 export const prerender = false;
 
@@ -14,184 +17,309 @@ if (!hasValidLabSession(Astro.request)) {
 }
 
 Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
+
+const aiHeadingId = "viddel-lab-image-qa-ai";
 ---
 
-<!doctype html>
-<html lang="no">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <meta name="robots" content="noindex,nofollow" />
-    <title>Viddel Lab · Bilde-QA</title>
-  </head>
-  <body class="min-h-dvh bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))] antialiased">
-    <main class="mx-auto flex max-w-lg flex-col gap-4 px-4 py-5 pb-[max(1.25rem,env(safe-area-inset-bottom))]">
-      <header class="flex items-start justify-between gap-3">
-        <div class="space-y-1">
-          <p class="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">Viddel Lab</p>
-          <h1 class="font-display text-2xl font-semibold tracking-tight">Bilde-QA</h1>
-          <p class="text-sm leading-relaxed text-[rgb(var(--muted))]">
-            Ta bilde av høreapparatutstyr (lader, dome/filter, appskjerm, statuslys). Ingen lagring.
+<BaseLayout
+  title="Viddel Lab · Bilde-QA"
+  currentPath="/lab/image-qa"
+  headerBrand="viddel"
+  shellVariant="standalone-chat"
+  showHeaderDevtoolsToggle={false}
+>
+  <meta slot="head" name="robots" content="noindex,nofollow" />
+
+  <main class="viddel-chat-standalone" data-viddel-lab-image-qa>
+    <div class="r1-editorial-container">
+      <div data-r1-editorial class="viddel-chat-standalone__editorial">
+        <header class="viddel-chat-standalone__intro" data-viddel-lab-intro aria-labelledby="viddel-lab-image-qa-title">
+          <h1 id="viddel-lab-image-qa-title" class="viddel-chat-standalone__intro-title">Spør Viddel</h1>
+          <p class="viddel-chat-standalone__intro-lede">
+            Ta bilde av høreapparatutstyr og beskriv situasjonen. Viddel analyserer utstyret og svarer som i chat — med
+            bildevedlegg i composer.
           </p>
-        </div>
-        <button
-          id="lab-logout"
-          type="button"
-          class="shrink-0 rounded-[var(--radius-sm)] border border-[rgb(var(--stroke)/0.25)] px-3 py-2 text-xs font-medium"
-        >
-          Logg ut
-        </button>
-      </header>
+          <p class="viddel-chat-standalone__safety">
+            Kun test med høreapparatutstyr. Ikke ta bilde av øre, hud, ansikt eller personer. Ingen bildelagring.
+          </p>
+          <div class="lab-image-qa__intro-actions">
+            <span class="lab-image-qa__lab-badge">Viddel Lab</span>
+            <button type="button" id="lab-logout" class="lab-image-qa__logout">Logg ut</button>
+          </div>
+        </header>
 
-      <div
-        class="rounded-[var(--radius-md)] border border-amber-400/70 bg-amber-50 px-4 py-3 text-sm leading-relaxed text-amber-950"
-        role="note"
-      >
-        <strong class="font-semibold">Kun test med høreapparatutstyr.</strong>
-        Ikke ta bilde av øre, hud, ansikt eller personer.
-      </div>
-
-      <label
-        for="image-qa-file"
-        id="image-qa-drop"
-        class="flex min-h-44 cursor-pointer flex-col items-center justify-center gap-2 rounded-[var(--radius-md)] border-2 border-dashed border-[rgb(var(--stroke)/0.35)] bg-[rgb(var(--surface-elevated))] px-4 py-6 text-center transition hover:border-[rgb(var(--accent)/0.45)]"
-      >
-        <span class="text-sm font-medium">Trykk for kamera / bilde</span>
-        <span class="text-xs text-[rgb(var(--muted))]">JPEG, PNG, WebP · maks 5 MB</span>
-        <input
-          id="image-qa-file"
-          type="file"
-          accept="image/*"
-          capture="environment"
-          class="sr-only"
-        />
-      </label>
-
-      <div id="image-qa-preview-wrap" class="hidden overflow-hidden rounded-[var(--radius-md)] border border-[rgb(var(--stroke)/0.2)] bg-[rgb(var(--surface-elevated))]">
-        <img id="image-qa-preview" alt="Forhåndsvisning av valgt utstyr-bilde" class="max-h-64 w-full object-contain" />
-      </div>
-
-      <div class="space-y-3 rounded-[var(--radius-md)] border border-[rgb(var(--stroke)/0.2)] bg-[rgb(var(--surface-elevated))] p-4">
-        <div>
-          <label for="image-qa-scenario" class="mb-1 block text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">
-            Scenario
-          </label>
-          <select
-            id="image-qa-scenario"
-            class="w-full rounded-[var(--radius-sm)] border border-[rgb(var(--stroke)/0.25)] bg-[rgb(var(--surface-subtle))] px-3 py-2.5 text-sm"
+        <section class="r1-ai-bridge px-0.5 py-1">
+          <section
+            class="inline-chat-shell"
+            aria-labelledby={aiHeadingId}
+            data-viddel-lab-shell
+            data-inline-chat-mode="progressive"
+            data-inline-chat-conversation="idle"
+            data-inline-chat-state="idle"
           >
-            <option value="A">A — ladeboks / statuslys</option>
-            <option value="B">B — dome / voksfilter</option>
-            <option value="C">C — appskjerm / Bluetooth</option>
-            <option value="D">D — uklart bilde</option>
-            <option value="E">E — etikett / modell</option>
-          </select>
-        </div>
+            <header class="inline-chat-shell__header" data-inline-chat-header>
+              <h2 id={aiHeadingId} class="inline-chat-shell__title">Bilde + spørsmål</h2>
+            </header>
 
-        <div>
-          <label for="image-qa-problem" class="mb-1 block text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">
-            Brukerproblem (valgfritt)
-          </label>
-          <textarea
-            id="image-qa-problem"
-            rows="3"
-            placeholder="F.eks. Hva betyr det gule lyset?"
-            class="w-full resize-y rounded-[var(--radius-sm)] border border-[rgb(var(--stroke)/0.25)] bg-[rgb(var(--surface-subtle))] px-3 py-2.5 text-sm"
-          ></textarea>
-        </div>
+            <p class="inline-chat-shell__status inline-chat-shell__status--dock hidden" data-viddel-lab-loading role="status">
+              Viddel analyserer …
+            </p>
 
-        <label class="flex items-start gap-2 text-sm">
-          <input id="image-qa-call-chat" type="checkbox" class="mt-1" checked />
-          <span>Kjør også <code class="text-xs">/api/chat</code> med <code class="text-xs">rag_query_text</code></span>
-        </label>
+            <div class="inline-chat-shell__dialog-thread mt-3 hidden" data-viddel-lab-dialog>
+              <div class="inline-chat-shell__transcript-divider">
+                <span class="inline-chat-shell__transcript-divider-line" aria-hidden="true"></span>
+                <span class="inline-chat-shell__transcript-divider-label" id="viddel-lab-dialog-label">
+                  Dialog med Viddel
+                </span>
+              </div>
+              <div
+                class="inline-chat-shell__transcript"
+                data-viddel-lab-transcript
+                role="log"
+                aria-live="polite"
+                aria-relevant="additions text"
+              >
+              </div>
 
-        <button
-          id="image-qa-run"
-          type="button"
-          disabled
-          aria-disabled="true"
-          class="w-full rounded-[var(--radius-sm)] px-4 py-3 text-sm font-semibold transition enabled:bg-[rgb(var(--accent))] enabled:text-white enabled:shadow-sm disabled:cursor-not-allowed disabled:border disabled:border-[rgb(var(--stroke)/0.3)] disabled:bg-[rgb(var(--surface-subtle))] disabled:text-[rgb(var(--muted))]"
-        >
-          Analyser bilde
-        </button>
+              <details class="lab-image-qa__debug hidden" data-viddel-lab-debug>
+                <summary>Vision / QA-data</summary>
+                <div class="lab-image-qa__debug-body">
+                  <div class="lab-image-qa__debug-block">
+                    <span class="lab-image-qa__field-label">Confidence</span>
+                    <p data-viddel-lab-debug-confidence>—</p>
+                  </div>
+                  <div class="lab-image-qa__debug-block">
+                    <span class="lab-image-qa__field-label">rag_query_text</span>
+                    <pre class="lab-image-qa__debug-pre" data-viddel-lab-debug-rag>—</pre>
+                  </div>
+                  <ul class="lab-image-qa__warnings hidden" data-viddel-lab-debug-warnings></ul>
+                  <div class="lab-image-qa__debug-block">
+                    <span class="lab-image-qa__field-label">Vision JSON</span>
+                    <pre class="lab-image-qa__debug-pre" data-viddel-lab-debug-json>—</pre>
+                  </div>
+                  <div class="lab-image-qa__debug-block hidden" data-viddel-lab-debug-chat-wrap>
+                    <span class="lab-image-qa__field-label">/api/chat</span>
+                    <p data-viddel-lab-debug-chat-meta></p>
+                    <pre class="lab-image-qa__debug-pre" data-viddel-lab-debug-chat-text></pre>
+                  </div>
+                </div>
+              </details>
+            </div>
+
+            <details class="lab-image-qa__settings mt-3" data-viddel-lab-settings>
+              <summary>Lab-innstillinger</summary>
+              <div class="lab-image-qa__settings-body">
+                <div>
+                  <label class="lab-image-qa__field-label" for="image-qa-scenario">Scenario</label>
+                  <select id="image-qa-scenario" class="lab-image-qa__select" data-viddel-lab-scenario>
+                    <option value="A">A — ladeboks / statuslys</option>
+                    <option value="B">B — dome / voksfilter</option>
+                    <option value="C">C — appskjerm / Bluetooth</option>
+                    <option value="D">D — uklart bilde</option>
+                    <option value="E">E — etikett / modell</option>
+                  </select>
+                </div>
+                <label class="lab-image-qa__checkbox-row">
+                  <input id="image-qa-call-chat" type="checkbox" data-viddel-lab-call-chat checked />
+                  <span>Kjør også <code>/api/chat</code> med <code>rag_query_text</code></span>
+                </label>
+              </div>
+            </details>
+
+            <div class="inline-chat-shell__compose-stack mt-3" data-viddel-lab-compose-stack>
+              <p class="viddel-chat-standalone__error hidden" data-viddel-lab-error role="alert"></p>
+              <form class="inline-chat-shell__compose lab-image-qa__compose" data-viddel-lab-form>
+                <input
+                  id="image-qa-file"
+                  type="file"
+                  accept="image/*"
+                  capture="environment"
+                  class="sr-only"
+                  data-viddel-lab-file
+                />
+                <button
+                  type="button"
+                  class="lab-image-qa__attach"
+                  data-viddel-lab-attach
+                  aria-label="Legg ved bilde av utstyr"
+                >
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" aria-hidden="true">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M4 7a3 3 0 0 1 3-3h4.5a2.5 2.5 0 0 1 2.12 1.18L15 7h2a3 3 0 0 1 3 3v7a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7Z"
+                    ></path>
+                    <circle cx="12" cy="13" r="3.25"></circle>
+                  </svg>
+                </button>
+                <div class="inline-chat-shell__compose-input-wrap lab-image-qa__compose-input-wrap">
+                  <div class="lab-image-qa__attachment hidden" data-viddel-lab-attachment>
+                    <img class="lab-image-qa__thumb" data-viddel-lab-thumb alt="Valgt utstyr-bilde" />
+                    <button type="button" class="lab-image-qa__remove-attachment" data-viddel-lab-remove aria-label="Fjern bilde">
+                      ×
+                    </button>
+                  </div>
+                  <label class="sr-only" for="viddel-lab-input">Beskriv situasjonen eller spørsmålet ditt</label>
+                  <textarea
+                    id="viddel-lab-input"
+                    data-viddel-lab-input
+                    class="inline-chat-shell__compose-input"
+                    rows="1"
+                    placeholder="Beskriv situasjonen eller spørsmålet ditt …"
+                  ></textarea>
+                </div>
+                <button
+                  type="submit"
+                  class="inline-chat-shell__compose-send"
+                  data-viddel-lab-send
+                  aria-label="Send med bilde"
+                  disabled
+                >
+                  <span aria-hidden="true">↑</span>
+                </button>
+              </form>
+            </div>
+          </section>
+        </section>
       </div>
+    </div>
+  </main>
 
-      <p id="image-qa-status" class="hidden text-sm text-[rgb(var(--muted))]" role="status"></p>
-      <p id="image-qa-error" class="hidden text-sm text-red-700" role="alert"></p>
+  <style is:global>
+    body.vox-shell--standalone-chat {
+      display: flex;
+      flex-direction: column;
+      min-height: 100dvh;
+    }
 
-      <section id="image-qa-results" class="hidden space-y-4">
-        <div class="rounded-[var(--radius-md)] border border-[rgb(var(--stroke)/0.2)] bg-[rgb(var(--surface-elevated))] p-4">
-          <h2 class="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">Confidence</h2>
-          <p id="image-qa-confidence" class="mt-1 text-lg font-semibold"></p>
-        </div>
+    @media (max-width: 639px) {
+      body.vox-shell--standalone-chat {
+        height: 100dvh;
+      }
 
-        <div class="rounded-[var(--radius-md)] border border-[rgb(var(--stroke)/0.2)] bg-[rgb(var(--surface-elevated))] p-4">
-          <h2 class="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">rag_query_text</h2>
-          <p id="image-qa-rag" class="mt-2 whitespace-pre-wrap text-sm leading-relaxed"></p>
-        </div>
+      body.vox-shell--standalone-chat .vox-shell-standalone-chat__stage {
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+    }
+  </style>
 
-        <div id="image-qa-warnings-wrap" class="hidden rounded-[var(--radius-md)] border border-amber-300/60 bg-amber-50 p-4 text-amber-950">
-          <h2 class="text-xs font-medium uppercase tracking-wide">Advarsler / corpus-gap</h2>
-          <ul id="image-qa-warnings" class="mt-2 list-disc space-y-1 pl-4 text-sm"></ul>
-        </div>
+  <script>
+    import { renderAssistantMarkdownInto } from "../../lib/render-assistant-markdown";
 
-        <div class="rounded-[var(--radius-md)] border border-[rgb(var(--stroke)/0.2)] bg-[rgb(var(--surface-elevated))] p-4">
-          <h2 class="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">Vision JSON</h2>
-          <pre id="image-qa-json" class="mt-2 max-h-72 overflow-auto text-xs leading-relaxed"></pre>
-        </div>
+    (() => {
+      const root = document.querySelector("[data-viddel-lab-image-qa]");
+      const shell = document.querySelector("[data-viddel-lab-shell]");
+      const intro = document.querySelector("[data-viddel-lab-intro]");
+      const header = shell?.querySelector("[data-inline-chat-header]");
+      const dialog = document.querySelector("[data-viddel-lab-dialog]");
+      const transcript = document.querySelector("[data-viddel-lab-transcript]");
+      const composeStack = document.querySelector("[data-viddel-lab-compose-stack]");
+      const loadingEl = document.querySelector("[data-viddel-lab-loading]");
+      const errorEl = document.querySelector("[data-viddel-lab-error]");
+      const form = document.querySelector("[data-viddel-lab-form]");
+      const input = document.querySelector("[data-viddel-lab-input]");
+      const sendBtn = document.querySelector("[data-viddel-lab-send]");
+      const fileInput = document.querySelector("[data-viddel-lab-file]");
+      const attachBtn = document.querySelector("[data-viddel-lab-attach]");
+      const attachmentWrap = document.querySelector("[data-viddel-lab-attachment]");
+      const thumbEl = document.querySelector("[data-viddel-lab-thumb]");
+      const removeBtn = document.querySelector("[data-viddel-lab-remove]");
+      const scenarioEl = document.querySelector("[data-viddel-lab-scenario]");
+      const callChatEl = document.querySelector("[data-viddel-lab-call-chat]");
+      const debugEl = document.querySelector("[data-viddel-lab-debug]");
+      const debugConfidence = document.querySelector("[data-viddel-lab-debug-confidence]");
+      const debugRag = document.querySelector("[data-viddel-lab-debug-rag]");
+      const debugWarnings = document.querySelector("[data-viddel-lab-debug-warnings]");
+      const debugJson = document.querySelector("[data-viddel-lab-debug-json]");
+      const debugChatWrap = document.querySelector("[data-viddel-lab-debug-chat-wrap]");
+      const debugChatMeta = document.querySelector("[data-viddel-lab-debug-chat-meta]");
+      const debugChatText = document.querySelector("[data-viddel-lab-debug-chat-text]");
+      const logoutBtn = document.getElementById("lab-logout");
 
-        <div id="image-qa-chat-wrap" class="hidden rounded-[var(--radius-md)] border border-[rgb(var(--stroke)/0.2)] bg-[rgb(var(--surface-elevated))] p-4">
-          <h2 class="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">/api/chat</h2>
-          <p id="image-qa-chat-meta" class="mt-1 text-xs text-[rgb(var(--muted))]"></p>
-          <p id="image-qa-chat-text" class="mt-3 whitespace-pre-wrap text-sm leading-relaxed"></p>
-        </div>
-      </section>
-    </main>
-
-    <script>
-      document.getElementById("lab-logout")?.addEventListener("click", async () => {
-        await fetch("/api/lab/logout", { method: "POST", credentials: "same-origin" });
-        window.location.href = "/lab/login";
-      });
-
-      const fileInput = document.getElementById("image-qa-file");
-      const previewWrap = document.getElementById("image-qa-preview-wrap");
-      const preview = document.getElementById("image-qa-preview");
-      const runBtn = document.getElementById("image-qa-run");
-      const statusEl = document.getElementById("image-qa-status");
-      const errorEl = document.getElementById("image-qa-error");
-      const resultsEl = document.getElementById("image-qa-results");
-      const confidenceEl = document.getElementById("image-qa-confidence");
-      const ragEl = document.getElementById("image-qa-rag");
-      const jsonEl = document.getElementById("image-qa-json");
-      const warningsWrap = document.getElementById("image-qa-warnings-wrap");
-      const warningsEl = document.getElementById("image-qa-warnings");
-      const chatWrap = document.getElementById("image-qa-chat-wrap");
-      const chatMetaEl = document.getElementById("image-qa-chat-meta");
-      const chatTextEl = document.getElementById("image-qa-chat-text");
+      if (
+        !root ||
+        !shell ||
+        !intro ||
+        !header ||
+        !dialog ||
+        !transcript ||
+        !composeStack ||
+        !loadingEl ||
+        !errorEl ||
+        !form ||
+        !input ||
+        !sendBtn ||
+        !fileInput ||
+        !attachBtn ||
+        !attachmentWrap ||
+        !thumbEl ||
+        !removeBtn ||
+        !scenarioEl ||
+        !callChatEl ||
+        !debugEl
+      ) {
+        return;
+      }
 
       const MAX_BYTES = 5 * 1024 * 1024;
       const ALLOWED_MIME = new Set(["image/jpeg", "image/png", "image/webp", "image/bmp"]);
 
       /** @type {{ file: File; previewUrl: string } | null} */
       let selectedFile = null;
+      let isSending = false;
+      let hasConversation = false;
+      let activeTurn = null;
 
-      function setStatus(text) {
-        statusEl.textContent = text;
-        statusEl.classList.toggle("hidden", !text);
-      }
+      const syncComposeReserve = () => {
+        const h = composeStack.getBoundingClientRect().height;
+        const reserve = `${Math.ceil(h + 12)}px`;
+        shell.style.setProperty("--inline-chat-bottom-reserve", reserve);
+        document.body.style.setProperty("--viddel-chat-compose-reserve", reserve);
+      };
 
-      function setError(text) {
-        errorEl.textContent = text;
-        errorEl.classList.toggle("hidden", !text);
-      }
+      const setSendEnabled = (enabled) => {
+        sendBtn.disabled = !enabled;
+      };
 
-      function setRunButtonEnabled(enabled) {
-        runBtn.disabled = !enabled;
-        runBtn.setAttribute("aria-disabled", enabled ? "false" : "true");
-      }
+      const showError = (message) => {
+        errorEl.textContent = message;
+        errorEl.classList.remove("hidden");
+        syncComposeReserve();
+      };
 
-      function resolveMimeType(file) {
+      const clearError = () => {
+        errorEl.textContent = "";
+        errorEl.classList.add("hidden");
+        syncComposeReserve();
+      };
+
+      const setLoading = (active) => {
+        loadingEl.classList.toggle("hidden", !active);
+        syncComposeReserve();
+      };
+
+      const resizeInput = () => {
+        input.style.height = "auto";
+        input.style.height = `${input.scrollHeight}px`;
+        syncComposeReserve();
+      };
+
+      const activateConversation = () => {
+        if (hasConversation) return;
+        hasConversation = true;
+        intro.classList.add("hidden");
+        header.classList.add("hidden");
+        header.setAttribute("aria-hidden", "true");
+        dialog.classList.remove("hidden");
+        shell.setAttribute("data-inline-chat-conversation", "active");
+        shell.setAttribute("data-inline-chat-state", "active");
+        shell.setAttribute("aria-labelledby", "viddel-lab-dialog-label");
+        document.body.setAttribute("data-viddel-chat-active", "true");
+        syncComposeReserve();
+      };
+
+      const resolveMimeType = (file) => {
         const raw = (file.type || "").trim().toLowerCase();
         if (raw.startsWith("image/")) return raw;
         const name = file.name.toLowerCase();
@@ -199,35 +327,49 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
         if (name.endsWith(".webp")) return "image/webp";
         if (name.endsWith(".bmp")) return "image/bmp";
         if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
-        // Mobilkamera gir ofte tom type — anta JPEG når fil kommer fra image/* picker.
         return "image/jpeg";
-      }
+      };
 
-      function validateImageFile(file) {
-        if (!file || file.size <= 0) {
-          return { ok: false, message: "Ingen fil valgt." };
-        }
-        if (file.size > MAX_BYTES) {
-          return { ok: false, message: "Bildet er for stort (maks 5 MB)." };
-        }
+      const validateImageFile = (file) => {
+        if (!file || file.size <= 0) return { ok: false, message: "Ingen fil valgt." };
+        if (file.size > MAX_BYTES) return { ok: false, message: "Bildet er for stort (maks 5 MB)." };
         const mimeType = resolveMimeType(file);
         if (!ALLOWED_MIME.has(mimeType)) {
           return { ok: false, message: "Velg et bilde (JPEG, PNG, WebP eller BMP)." };
         }
         return { ok: true, mimeType };
-      }
+      };
 
-      function clearPreview() {
+      const clearAttachment = () => {
         if (selectedFile?.previewUrl) URL.revokeObjectURL(selectedFile.previewUrl);
         selectedFile = null;
-        preview.removeAttribute("src");
-        previewWrap.classList.add("hidden");
-        setRunButtonEnabled(false);
-      }
+        fileInput.value = "";
+        thumbEl.removeAttribute("src");
+        attachmentWrap.classList.add("hidden");
+        setSendEnabled(false);
+        syncComposeReserve();
+      };
+
+      const setAttachment = (file) => {
+        clearAttachment();
+        const validation = validateImageFile(file);
+        if (!validation.ok) {
+          showError(validation.message);
+          return;
+        }
+        clearError();
+        const previewUrl = URL.createObjectURL(file);
+        thumbEl.src = previewUrl;
+        attachmentWrap.classList.remove("hidden");
+        selectedFile = { file, previewUrl };
+        setSendEnabled(true);
+        resizeInput();
+        input.focus();
+      };
 
       /** @returns {Promise<{ base64: string; mimeType: string }>} */
-      function fileToBase64Payload(file) {
-        return new Promise((resolve, reject) => {
+      const fileToBase64Payload = (file) =>
+        new Promise((resolve, reject) => {
           const reader = new FileReader();
           reader.onload = () => {
             const dataUrl = typeof reader.result === "string" ? reader.result : "";
@@ -236,80 +378,115 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
               reject(new Error("Kunne ikke konvertere bildet til base64."));
               return;
             }
-            resolve({
-              base64: dataUrl.slice(comma + 1),
-              mimeType: resolveMimeType(file),
-            });
+            resolve({ base64: dataUrl.slice(comma + 1), mimeType: resolveMimeType(file) });
           };
           reader.onerror = () => reject(new Error("Kunne ikke lese bildet for opplasting."));
           reader.onabort = () => reject(new Error("Lesing av bildet ble avbrutt."));
           reader.readAsDataURL(file);
         });
-      }
 
-      fileInput?.addEventListener("change", () => {
-        setError("");
-        clearPreview();
-        const file = fileInput.files?.[0];
-        if (!file) return;
+      const appendUserMessage = (text, previewUrl) => {
+        const turn = document.createElement("div");
+        turn.className = "inline-chat-shell__turn";
+        const message = document.createElement("div");
+        message.className = "inline-chat-shell__message inline-chat-shell__message--user";
+        const body = document.createElement("p");
+        body.className = "inline-chat-shell__message-text";
+        body.textContent = text || "Bilde av utstyr";
+        message.append(body);
+        if (previewUrl) {
+          const img = document.createElement("img");
+          img.className = "lab-image-qa__message-thumb";
+          img.src = previewUrl;
+          img.alt = "Vedlagt utstyr-bilde";
+          message.append(img);
+        }
+        turn.append(message);
+        transcript.append(turn);
+        activeTurn = turn;
+        turn.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      };
 
-        const validation = validateImageFile(file);
-        if (!validation.ok) {
-          setError(validation.message);
-          fileInput.value = "";
-          return;
+      const appendAssistantMessage = (text) => {
+        if (!activeTurn) return;
+        const assistant = document.createElement("div");
+        assistant.className = "inline-chat-shell__message inline-chat-shell__message--assistant";
+        const eyebrow = document.createElement("p");
+        eyebrow.className = "inline-chat-shell__message-eyebrow";
+        eyebrow.textContent = "Viddel";
+        const body = document.createElement("div");
+        body.className = "inline-chat-shell__message-text";
+        renderAssistantMarkdownInto(body, text);
+        assistant.append(eyebrow, body);
+        activeTurn.append(assistant);
+        assistant.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      };
+
+      const updateDebug = (visionPayload, chatPayload, chatStatus) => {
+        const vision = visionPayload?.vision ?? {};
+        debugConfidence.textContent = vision.confidence ?? "—";
+        debugRag.textContent = vision.rag_query_text ?? "—";
+        debugJson.textContent = JSON.stringify(visionPayload, null, 2);
+
+        const warnings = Array.isArray(visionPayload?.warnings) ? visionPayload.warnings : [];
+        debugWarnings.replaceChildren(
+          ...warnings.map((w) => {
+            const li = document.createElement("li");
+            li.textContent = w;
+            return li;
+          }),
+        );
+        debugWarnings.classList.toggle("hidden", warnings.length === 0);
+
+        if (chatPayload && typeof chatStatus === "number") {
+          debugChatWrap.classList.remove("hidden");
+          debugChatMeta.textContent = `HTTP ${chatStatus}${chatPayload.error ? ` · ${chatPayload.error}` : ""}`;
+          debugChatText.textContent =
+            typeof chatPayload.text === "string" && chatPayload.text
+              ? chatPayload.text
+              : chatPayload.message || "Ingen tekst i svar.";
+        } else {
+          debugChatWrap.classList.add("hidden");
         }
 
-        const previewUrl = URL.createObjectURL(file);
-        preview.src = previewUrl;
-        previewWrap.classList.remove("hidden");
-        selectedFile = { file, previewUrl };
-        setRunButtonEnabled(true);
-      });
+        debugEl.classList.remove("hidden");
+      };
 
-      runBtn?.addEventListener("click", async () => {
-        if (!selectedFile) return;
-        setError("");
-        setStatus("Forbereder bilde…");
-        resultsEl.classList.add("hidden");
-        chatWrap.classList.add("hidden");
-        warningsWrap.classList.add("hidden");
-        setRunButtonEnabled(false);
+      const submitWithAttachment = async () => {
+        if (!selectedFile || isSending) return;
 
-        const scenario = document.getElementById("image-qa-scenario")?.value ?? "A";
-        const userProblem = document.getElementById("image-qa-problem")?.value?.trim() ?? "";
-        const callChat = document.getElementById("image-qa-call-chat")?.checked ?? false;
+        const userProblem = input.value.trim();
+        const scenario = scenarioEl.value || "A";
+        const callChat = callChatEl.checked;
+        const previewForMessage = selectedFile.previewUrl;
+
+        clearError();
+        activateConversation();
+        appendUserMessage(userProblem, previewForMessage);
+
+        isSending = true;
+        setSendEnabled(false);
+        input.disabled = true;
+        attachBtn.disabled = true;
+        removeBtn.disabled = true;
+        setLoading(true);
 
         try {
-          let imageBase64;
-          let mimeType;
-          try {
-            const payload = await fileToBase64Payload(selectedFile.file);
-            imageBase64 = payload.base64;
-            mimeType = payload.mimeType;
-          } catch (conversionError) {
-            throw conversionError instanceof Error
-              ? conversionError
-              : new Error("Kunne ikke konvertere bildet.");
-          }
+          const { base64, mimeType } = await fileToBase64Payload(selectedFile.file);
 
-          if (!imageBase64) {
-            throw new Error("Kunne ikke konvertere bildet til base64.");
-          }
-
-          setStatus("Kjører vision…");
           const visionRes = await fetch("/api/lab/image-vision", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             credentials: "same-origin",
             body: JSON.stringify({
-              imageBase64,
+              imageBase64: base64,
               mimeType,
               userProblem,
               scenario,
             }),
           });
           const visionPayload = await visionRes.json().catch(() => ({}));
+
           if (visionRes.status === 401) {
             window.location.href = "/lab/login?return=/lab/image-qa";
             return;
@@ -318,51 +495,98 @@ Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
             throw new Error(visionPayload.message || visionPayload.error || `Vision HTTP ${visionRes.status}`);
           }
 
-          const vision = visionPayload.vision ?? {};
-          confidenceEl.textContent = vision.confidence ?? "—";
-          ragEl.textContent = vision.rag_query_text ?? "—";
-          jsonEl.textContent = JSON.stringify(visionPayload, null, 2);
+          let assistantText =
+            visionPayload.vision?.rag_query_text?.trim() ||
+            "Jeg analyserte bildet, men fant ikke en tydelig tekstspørring.";
 
-          const warnings = Array.isArray(visionPayload.warnings) ? visionPayload.warnings : [];
-          if (warnings.length) {
-            warningsEl.replaceChildren(
-              ...warnings.map((w) => {
-                const li = document.createElement("li");
-                li.textContent = w;
-                return li;
-              }),
-            );
-            warningsWrap.classList.remove("hidden");
-          }
+          let chatPayload = null;
+          let chatStatus = null;
 
-          resultsEl.classList.remove("hidden");
-          setStatus(`Vision ferdig (${visionPayload.durationMs ?? "?"} ms, ${visionPayload.model ?? "?"})`);
-
-          if (callChat && vision.rag_query_text) {
-            setStatus("Kjører /api/chat…");
-            const sessionId = `image-qa-${Date.now().toString(36)}`;
+          if (callChat && visionPayload.vision?.rag_query_text) {
             const chatRes = await fetch("/api/chat", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               credentials: "same-origin",
-              body: JSON.stringify({ message: vision.rag_query_text, sessionId }),
+              body: JSON.stringify({
+                message: visionPayload.vision.rag_query_text,
+                sessionId: `image-qa-${Date.now().toString(36)}`,
+              }),
             });
-            const chatPayload = await chatRes.json().catch(() => ({}));
-            chatWrap.classList.remove("hidden");
-            chatMetaEl.textContent = `HTTP ${chatRes.status}${chatPayload.error ? ` · ${chatPayload.error}` : ""}`;
-            chatTextEl.textContent =
-              typeof chatPayload.text === "string" && chatPayload.text
-                ? chatPayload.text
-                : chatPayload.message || "Ingen tekst i svar.";
-            setStatus(`Ferdig — vision + chat (${chatRes.status})`);
+            chatPayload = await chatRes.json().catch(() => ({}));
+            chatStatus = chatRes.status;
+            if (chatRes.ok && typeof chatPayload.text === "string" && chatPayload.text.trim()) {
+              assistantText = chatPayload.text.trim();
+            } else if (chatPayload?.message) {
+              assistantText = `${assistantText}\n\n(${chatPayload.message})`;
+            }
           }
+
+          appendAssistantMessage(assistantText);
+          updateDebug(visionPayload, chatPayload, chatStatus);
+          clearAttachment();
+          input.value = "";
+          resizeInput();
         } catch (err) {
-          setError(err instanceof Error ? err.message : "Ukjent feil");
-          setStatus("");
+          showError(err instanceof Error ? err.message : "Ukjent feil");
         } finally {
-          setRunButtonEnabled(Boolean(selectedFile));
+          isSending = false;
+          input.disabled = false;
+          attachBtn.disabled = false;
+          removeBtn.disabled = false;
+          setSendEnabled(Boolean(selectedFile));
+          setLoading(false);
+          syncComposeReserve();
+        }
+      };
+
+      logoutBtn?.addEventListener("click", async () => {
+        await fetch("/api/lab/logout", { method: "POST", credentials: "same-origin" });
+        window.location.href = "/lab/login";
+      });
+
+      attachBtn.addEventListener("click", () => fileInput.click());
+
+      fileInput.addEventListener("change", () => {
+        const file = fileInput.files?.[0];
+        if (!file) return;
+        setAttachment(file);
+      });
+
+      removeBtn.addEventListener("click", () => {
+        clearError();
+        clearAttachment();
+      });
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        if (!selectedFile) {
+          showError("Legg ved et bilde av utstyr før du sender.");
+          return;
+        }
+        submitWithAttachment();
+      });
+
+      input.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          if (!selectedFile) {
+            showError("Legg ved et bilde av utstyr før du sender.");
+            return;
+          }
+          submitWithAttachment();
         }
       });
-    </script>
-  </body>
-</html>
+
+      input.addEventListener("input", resizeInput);
+
+      if ("ResizeObserver" in window) {
+        const observer = new ResizeObserver(syncComposeReserve);
+        observer.observe(composeStack);
+      }
+
+      window.addEventListener("resize", syncComposeReserve, { passive: true });
+      syncComposeReserve();
+      input.focus();
+    })();
+  </script>
+</BaseLayout>

--- a/src/styles/lab-image-qa.css
+++ b/src/styles/lab-image-qa.css
@@ -1,0 +1,210 @@
+/* CONTRACT: Lab image-QA composer extensions — attachment + thumbnail in inline-chat-shell (#240). Lab-only; /no/chat unchanged. */
+
+.lab-image-qa__intro-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.lab-image-qa__lab-badge {
+  color: rgb(var(--reading-ink-secondary));
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.lab-image-qa__logout {
+  background: transparent;
+  border: 1px solid rgb(var(--border) / 0.45);
+  border-radius: 999px;
+  color: rgb(var(--reading-ink-secondary));
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 550;
+  padding: 0.35rem 0.75rem;
+}
+
+.lab-image-qa__logout:focus-visible {
+  outline: 2px solid rgb(var(--reading-accent-iris) / 0.42);
+  outline-offset: 2px;
+}
+
+.lab-image-qa__compose {
+  align-items: flex-end;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.lab-image-qa__attach {
+  align-items: center;
+  background: rgb(var(--surface-subtle) / 0.9);
+  border: 1px solid rgb(var(--border) / 0.45);
+  border-radius: 999px;
+  color: rgb(var(--reading-ink-secondary));
+  cursor: pointer;
+  display: inline-flex;
+  flex-shrink: 0;
+  height: 2.35rem;
+  justify-content: center;
+  min-height: 2.35rem;
+  width: 2.35rem;
+}
+
+.lab-image-qa__attach:focus-visible {
+  outline: 2px solid rgb(var(--reading-accent-iris) / 0.42);
+  outline-offset: 2px;
+}
+
+.lab-image-qa__attach svg {
+  display: block;
+  height: 1.15rem;
+  width: 1.15rem;
+}
+
+.lab-image-qa__compose-input-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.lab-image-qa__attachment {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.45rem;
+  max-width: 100%;
+}
+
+.lab-image-qa__attachment.hidden {
+  display: none;
+}
+
+.lab-image-qa__thumb {
+  border: 1px solid rgb(var(--border) / 0.45);
+  border-radius: 0.55rem;
+  display: block;
+  flex-shrink: 0;
+  height: 3rem;
+  object-fit: cover;
+  width: 3rem;
+}
+
+.lab-image-qa__remove-attachment {
+  background: rgb(var(--surface-subtle));
+  border: 1px solid rgb(var(--border) / 0.45);
+  border-radius: 999px;
+  color: rgb(var(--reading-ink-secondary));
+  cursor: pointer;
+  font-size: 0.95rem;
+  height: 1.65rem;
+  line-height: 1;
+  width: 1.65rem;
+}
+
+.lab-image-qa__message-thumb {
+  border: 1px solid rgb(var(--border) / 0.4);
+  border-radius: 0.55rem;
+  display: block;
+  height: 3.25rem;
+  margin-top: 0.45rem;
+  object-fit: cover;
+  width: 3.25rem;
+}
+
+.lab-image-qa__settings,
+.lab-image-qa__debug {
+  border: 1px solid rgb(var(--border) / 0.4);
+  border-radius: 0.85rem;
+  margin-top: 0.75rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.lab-image-qa__settings summary,
+.lab-image-qa__debug summary {
+  color: rgb(var(--reading-ink-secondary));
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.lab-image-qa__settings-body,
+.lab-image-qa__debug-body {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.65rem;
+}
+
+.lab-image-qa__field-label {
+  color: rgb(var(--reading-ink-secondary));
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
+.lab-image-qa__select {
+  background: rgb(var(--surface));
+  border: 1px solid rgb(var(--border) / 0.45);
+  border-radius: 0.65rem;
+  color: rgb(var(--reading-ink));
+  font: inherit;
+  font-size: 0.88rem;
+  padding: 0.45rem 0.55rem;
+  width: 100%;
+}
+
+.lab-image-qa__checkbox-row {
+  align-items: flex-start;
+  color: rgb(var(--reading-ink-secondary));
+  display: flex;
+  font-size: 0.84rem;
+  gap: 0.45rem;
+}
+
+.lab-image-qa__debug-block {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.lab-image-qa__debug-pre {
+  background: rgb(var(--surface-subtle));
+  border: 1px solid rgb(var(--border) / 0.35);
+  border-radius: 0.65rem;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  max-height: 12rem;
+  overflow: auto;
+  padding: 0.55rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.lab-image-qa__warnings {
+  color: rgb(146 64 14);
+  font-size: 0.82rem;
+  list-style: disc;
+  padding-left: 1.1rem;
+}
+
+.inline-chat-shell[data-inline-chat-mode="progressive"] .lab-image-qa__compose .inline-chat-shell__compose-send {
+  align-self: flex-end;
+}
+
+@media (max-width: 639px) {
+  .inline-chat-shell[data-inline-chat-mode="progressive"] .lab-image-qa__compose .inline-chat-shell__compose-send {
+    height: 2.68rem;
+    min-height: 2.68rem;
+    width: 2.68rem;
+  }
+
+  .inline-chat-shell[data-inline-chat-mode="progressive"] .lab-image-qa__attach {
+    height: 2.68rem;
+    min-height: 2.68rem;
+    width: 2.68rem;
+  }
+}


### PR DESCRIPTION
## Summary

Align `/lab/image-qa` with the existing Viddel AI chat shell instead of using a separate technical QA form.

This updates the Lab image QA prototype so it behaves like the real Viddel chat experience with image attachment support in the composer.

## Changes

- Rewrites `src/pages/lab/image-qa.astro` to use the Viddel standalone chat shell and composer flow.
- Adds lab-only CSS in `src/styles/lab-image-qa.css` for attachment thumbnail, composer image state and collapsible debug.
- Adds camera/attachment action on the left side of the composer.
- Shows selected image as a small thumbnail inside the composer.
- Keeps text input usable with image attached.
- Keeps Debug / QA data secondary and collapsed by default.

## Verification from Cursor

- Commit: `d6acd9be383825cd917f1b29f4ad8d7d851bb4f9`
- `npm run build` OK, including Lab gate guard.
- `/no/chat` unchanged.
- `/lab/image-qa` uses `shellVariant="standalone-chat"` and imports the same chat CSS base.
- Camera icon is first element in composer grid.
- Selected image appears as a 3×3 rem thumbnail, not full-view.
- Send works with text + image.
- Debug/QA is closed by default.
- #239 remains fixed: selected image enables send immediately; base64 conversion happens on submit.
- No images or secrets in git.

## Related

- #239
- #240

## Production behavior

Lab remains behind shared-password gate and `VIDDEL_LAB_PUBLIC_ENABLED=true` in production.

No public `/no/chat` image upload is added.