### PR TITLE
Improve Lab image QA answer fusion

### DIFF
--- a/src/lib/lab-image-qa-chat-message-v01.ts
+++ b/src/lib/lab-image-qa-chat-message-v01.ts
@@ -1,0 +1,66 @@
+/* CONTRACT: Lab-only — compose rich /api/chat message from vision JSON + user text (#242). Not used in /no/chat. */
+import type { ImageVisionBridgeResult } from "./image-vision-bridge-v01.ts";
+
+const CHAT_INSTRUCTION =
+  "Svar brukeren direkte. Skill mellom det som kan ses i bildet og det som ikke kan fastslås. Ikke påstå eksakt modell uten lesbar tekst.";
+
+function formatScalar(value: string): string {
+  const trimmed = value.trim();
+  return trimmed || "ikke oppgitt / ukjent";
+}
+
+function formatList(items: string[]): string {
+  const filtered = items.map((item) => item.trim()).filter(Boolean);
+  if (filtered.length === 0) return "ingen";
+  return filtered.map((item) => `  • ${item}`).join("\n");
+}
+
+/** Build Lab image-QA message for POST /api/chat — vision context + user question, contract unchanged. */
+export function composeLabImageQaChatMessage(
+  vision: ImageVisionBridgeResult,
+  userProblem: string,
+): string {
+  const lines: string[] = [
+    "[Lab bildeanalyse — svar brukeren basert på disse observasjonene]",
+    "",
+    "INSTRUKS TIL VIDEL:",
+    CHAT_INSTRUCTION,
+    "",
+  ];
+
+  const problem = userProblem.trim();
+  if (problem) {
+    lines.push("BRUKERENS SPØRSMÅL / PROBLEM:", problem, "");
+  }
+
+  lines.push(
+    "OBSERVASJONER FRA BILDET:",
+    `- Synlig utstyrstype: ${formatScalar(vision.visible_device_type)}`,
+    `- Mulig merke: ${formatScalar(vision.possible_brand)}`,
+    `- Lesbar tekst i bildet: ${formatScalar(vision.readable_text)}`,
+    `- Synlig komponent/del: ${formatScalar(vision.visible_component)}`,
+    `- Synlig statuslys: ${formatScalar(vision.visible_status_light)}`,
+    `- Confidence (vision): ${vision.confidence}`,
+    "",
+    "FORESLÅTTE OPPFØLGINGSSPØRSMÅL (fra vision):",
+    formatList(vision.suggested_followup_questions),
+    "",
+    "SIKKERHETS-/AVGRENSNINGSMERKNADER:",
+    formatList(vision.safety_notes),
+  );
+
+  const rag = vision.rag_query_text.trim();
+  if (rag) {
+    lines.push("", "RAG-SPØRRING (til oppslag i manualer):", rag);
+  }
+
+  lines.push(
+    "",
+    "OPPGAVE:",
+    problem
+      ? `Svar brukeren på spørsmålet/problemet over, med utgangspunkt i observasjonene. Si tydelig hva som kan sees, hva som er usikkert, og be om nærbilde av tekst/merking eller bedre vinkel hvis modell ikke kan fastslås.`
+      : "Svar brukeren basert på observasjonene. Si tydelig hva som kan sees, hva som er usikkert, og be om nærbilde av tekst/merking eller bedre vinkel hvis modell ikke kan fastslås.",
+  );
+
+  return lines.join("\n");
+}

--- a/src/pages/lab/image-qa.astro
+++ b/src/pages/lab/image-qa.astro
@@ -92,6 +92,10 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
                     <span class="lab-image-qa__field-label">rag_query_text</span>
                     <pre class="lab-image-qa__debug-pre" data-viddel-lab-debug-rag>—</pre>
                   </div>
+                  <div class="lab-image-qa__debug-block hidden" data-viddel-lab-debug-chat-message-wrap>
+                    <span class="lab-image-qa__field-label">/api/chat-melding (komponert)</span>
+                    <pre class="lab-image-qa__debug-pre" data-viddel-lab-debug-chat-message>—</pre>
+                  </div>
                   <ul class="lab-image-qa__warnings hidden" data-viddel-lab-debug-warnings></ul>
                   <div class="lab-image-qa__debug-block">
                     <span class="lab-image-qa__field-label">Vision JSON</span>
@@ -121,7 +125,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
                 </div>
                 <label class="lab-image-qa__checkbox-row">
                   <input id="image-qa-call-chat" type="checkbox" data-viddel-lab-call-chat checked />
-                  <span>Kjør også <code>/api/chat</code> med <code>rag_query_text</code></span>
+                  <span>Kjør også <code>/api/chat</code> med vision-kontekst + brukerspørsmål</span>
                 </label>
               </div>
             </details>
@@ -205,6 +209,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
   </style>
 
   <script>
+    import { composeLabImageQaChatMessage } from "../../lib/lab-image-qa-chat-message-v01";
     import { renderAssistantMarkdownInto } from "../../lib/render-assistant-markdown";
 
     (() => {
@@ -232,6 +237,8 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
       const debugRag = document.querySelector("[data-viddel-lab-debug-rag]");
       const debugWarnings = document.querySelector("[data-viddel-lab-debug-warnings]");
       const debugJson = document.querySelector("[data-viddel-lab-debug-json]");
+      const debugChatMessageWrap = document.querySelector("[data-viddel-lab-debug-chat-message-wrap]");
+      const debugChatMessage = document.querySelector("[data-viddel-lab-debug-chat-message]");
       const debugChatWrap = document.querySelector("[data-viddel-lab-debug-chat-wrap]");
       const debugChatMeta = document.querySelector("[data-viddel-lab-debug-chat-meta]");
       const debugChatText = document.querySelector("[data-viddel-lab-debug-chat-text]");
@@ -422,11 +429,19 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         assistant.scrollIntoView({ behavior: "smooth", block: "nearest" });
       };
 
-      const updateDebug = (visionPayload, chatPayload, chatStatus) => {
+      const updateDebug = (visionPayload, chatPayload, chatStatus, composedChatMessage) => {
         const vision = visionPayload?.vision ?? {};
         debugConfidence.textContent = vision.confidence ?? "—";
         debugRag.textContent = vision.rag_query_text ?? "—";
         debugJson.textContent = JSON.stringify(visionPayload, null, 2);
+
+        if (composedChatMessage) {
+          debugChatMessageWrap?.classList.remove("hidden");
+          if (debugChatMessage) debugChatMessage.textContent = composedChatMessage;
+        } else {
+          debugChatMessageWrap?.classList.add("hidden");
+          if (debugChatMessage) debugChatMessage.textContent = "—";
+        }
 
         const warnings = Array.isArray(visionPayload?.warnings) ? visionPayload.warnings : [];
         debugWarnings.replaceChildren(
@@ -502,13 +517,16 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
           let chatPayload = null;
           let chatStatus = null;
 
-          if (callChat && visionPayload.vision?.rag_query_text) {
+          let composedChatMessage = null;
+
+          if (callChat && visionPayload.vision) {
+            composedChatMessage = composeLabImageQaChatMessage(visionPayload.vision, userProblem);
             const chatRes = await fetch("/api/chat", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               credentials: "same-origin",
               body: JSON.stringify({
-                message: visionPayload.vision.rag_query_text,
+                message: composedChatMessage,
                 sessionId: `image-qa-${Date.now().toString(36)}`,
               }),
             });
@@ -522,7 +540,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
           }
 
           appendAssistantMessage(assistantText);
-          updateDebug(visionPayload, chatPayload, chatStatus);
+          updateDebug(visionPayload, chatPayload, chatStatus, composedChatMessage);
           clearAttachment();
           input.value = "";
           resizeInput();


### PR DESCRIPTION
## Summary

Improve `/lab/image-qa` answer fusion so the final `/api/chat` call receives the original user question plus structured vision observations, not only compressed `rag_query_text`.

This should make Viddel answer as if it has actually seen the image, while still keeping `/api/chat` contract unchanged.

## Changes

- Adds `src/lib/lab-image-qa-chat-message-v01.ts`
- Updates `src/pages/lab/image-qa.astro` to send a richer composed message to `/api/chat`
- Includes original user text, visible device type, possible brand, readable text, visible component, status light, confidence, follow-up questions, safety notes and `rag_query_text`
- Adds explicit instruction to distinguish what is visible from what cannot be confirmed
- Adds composed `/api/chat` message to the Lab debug panel

## Verification from Cursor

- Commit: `afeaa2ded50480cf2ebef414c01d59196f39c5b8`
- `npm run build` OK
- `/no/chat` unchanged
- `/api/chat` contract unchanged: still `{ message, sessionId }`
- Lab-only changes
- No image storage
- No images/secrets in git

## Expected behavior

For a user question like:

```text
Dette er apparatene mine. Ser du hvilken modell det er?
```

with vision observations such as Phonak / medium confidence / no readable exact model, the answer should say roughly:

```text
Det ser ut som Phonak-apparater, men jeg kan ikke fastslå eksakt modell fra dette bildet alene.
```

and ask for a close-up of label/marking if needed.

## Related

- #242
- #236
- #237
- #240