### PR TITLE
Fix Lab image QA mobile scroll and answer start

### DIFF
--- a/src/lib/lab-image-qa-chat-message-v01.ts
+++ b/src/lib/lab-image-qa-chat-message-v01.ts
@@ -1,8 +1,11 @@
 /* CONTRACT: Lab-only — compose rich /api/chat message from vision JSON + user text (#242). Not used in /no/chat. */
 import type { ImageVisionBridgeResult } from "./image-vision-bridge-v01.ts";
 
-const CHAT_INSTRUCTION =
-  "Svar brukeren direkte. Skill mellom det som kan ses i bildet og det som ikke kan fastslås. Ikke påstå eksakt modell uten lesbar tekst.";
+const CHAT_INSTRUCTION = [
+  "Svar brukeren direkte. Skill mellom det som kan ses i bildet og det som ikke kan fastslås. Ikke påstå eksakt modell uten lesbar tekst.",
+  "Start svaret med hva bildet ser ut til å vise. Bruk formuleringen «Bildet ser ut til å vise …» når mulig. Deretter forklar hva som ikke kan fastslås.",
+  "Ikke start med generell dokumentasjon eller brukerguide dersom brukeren spør hva bildet viser.",
+].join(" ");
 
 function formatScalar(value: string): string {
   const trimmed = value.trim();
@@ -58,8 +61,8 @@ export function composeLabImageQaChatMessage(
     "",
     "OPPGAVE:",
     problem
-      ? `Svar brukeren på spørsmålet/problemet over, med utgangspunkt i observasjonene. Si tydelig hva som kan sees, hva som er usikkert, og be om nærbilde av tekst/merking eller bedre vinkel hvis modell ikke kan fastslås.`
-      : "Svar brukeren basert på observasjonene. Si tydelig hva som kan sees, hva som er usikkert, og be om nærbilde av tekst/merking eller bedre vinkel hvis modell ikke kan fastslås.",
+      ? `Svar brukeren på spørsmålet/problemet over. Start med «Bildet ser ut til å vise …» basert på observasjonene. Forklar deretter hva som ikke kan fastslås (f.eks. nøyaktig modell uten lesbar tekst). Avslutt med neste steg — gjerne nærbilde av tekst/merking på apparatet eller ladeetuiet.`
+      : "Svar brukeren basert på observasjonene. Start med «Bildet ser ut til å vise …». Forklar deretter hva som ikke kan fastslås, og be om nærbilde av tekst/merking eller bedre vinkel hvis nødvendig.",
   );
 
   return lines.join("\n");

--- a/src/pages/lab/image-qa.astro
+++ b/src/pages/lab/image-qa.astro
@@ -279,8 +279,8 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
       let activeTurn = null;
 
       const syncComposeReserve = () => {
-        const h = composeStack.getBoundingClientRect().height;
-        const reserve = `${Math.ceil(h + 12)}px`;
+        const h = Math.ceil(composeStack.getBoundingClientRect().height);
+        const reserve = `${h}px`;
         shell.style.setProperty("--inline-chat-bottom-reserve", reserve);
         document.body.style.setProperty("--viddel-chat-compose-reserve", reserve);
       };
@@ -600,7 +600,19 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
       if ("ResizeObserver" in window) {
         const observer = new ResizeObserver(syncComposeReserve);
         observer.observe(composeStack);
+        observer.observe(attachmentWrap);
+        observer.observe(input);
+        observer.observe(dialog);
       }
+
+      debugEl.addEventListener("toggle", () => {
+        syncComposeReserve();
+        if (debugEl.open) {
+          requestAnimationFrame(() => {
+            debugEl.scrollIntoView({ behavior: "smooth", block: "nearest" });
+          });
+        }
+      });
 
       window.addEventListener("resize", syncComposeReserve, { passive: true });
       syncComposeReserve();

--- a/src/styles/lab-image-qa.css
+++ b/src/styles/lab-image-qa.css
@@ -1,5 +1,37 @@
 /* CONTRACT: Lab image-QA composer extensions — attachment + thumbnail in inline-chat-shell (#240). Lab-only; /no/chat unchanged. */
 
+[data-viddel-lab-image-qa] {
+  --lab-compose-scroll-tail: calc(max(0.75rem, env(safe-area-inset-bottom, 0px)) + 1.25rem);
+}
+
+[data-viddel-lab-image-qa]
+  .inline-chat-shell[data-inline-chat-conversation="active"]
+  .inline-chat-shell__dialog-thread {
+  padding-bottom: calc(var(--inline-chat-bottom-reserve, 7.5rem) + var(--lab-compose-scroll-tail));
+}
+
+[data-viddel-lab-image-qa]
+  .inline-chat-shell[data-inline-chat-conversation="active"]
+  .inline-chat-shell__message-text,
+[data-viddel-lab-image-qa]
+  .inline-chat-shell[data-inline-chat-conversation="active"]
+  .lab-image-qa__debug,
+[data-viddel-lab-image-qa]
+  .inline-chat-shell[data-inline-chat-conversation="active"]
+  .lab-image-qa__debug-body {
+  scroll-margin-bottom: calc(var(--inline-chat-bottom-reserve, 7.5rem) + var(--lab-compose-scroll-tail));
+}
+
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .lab-image-qa__settings {
+  display: none;
+}
+
+@media (max-width: 639px) {
+  body.vox-shell--standalone-chat:not([data-viddel-chat-active]) [data-viddel-lab-image-qa] .r1-editorial-container {
+    padding-bottom: calc(var(--viddel-chat-compose-reserve, 7.5rem) + var(--lab-compose-scroll-tail));
+  }
+}
+
 .lab-image-qa__intro-actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Merge the latest Lab image QA fixes from Cursor.

This covers:

- #245 mobile scroll/layout issue where response and Vision/QA data could sit behind the fixed composer
- #242 answer-quality adjustment so replies start from visible image observations before general guidance

## Changes

- Adds Lab-only scroll padding / safe-area handling for fixed composer
- Adds ResizeObserver handling for composer, thumbnail, textarea and dialog reserve
- Adds scroll handling when opening Vision / QA-data
- Hides Lab settings under active conversation
- Strengthens composed `/api/chat` instruction to start with `Bildet ser ut til å vise ...` when the user asks what the image shows

## Verification from Cursor

- Commit: `d194d7a4cdf01a6fbfcbe7903aac5d29a65ed091`
- `npm run build` OK
- `/no/chat` unchanged
- Lab-only scoped changes
- `/api/chat` contract unchanged
- No images/secrets in git

## Related

- #242
- #245

## Notes

A new follow-up polish issue has been created for conversation behavior and follow-up composer details: #247