### PR TITLE
Fix Lab image QA mobile scroll reserve and composer thumbnail

### DIFF
--- a/src/pages/lab/image-qa.astro
+++ b/src/pages/lab/image-qa.astro
@@ -104,6 +104,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
                   </div>
                 </div>
               </details>
+              <div class="lab-image-qa__scroll-spacer" data-viddel-lab-scroll-spacer aria-hidden="true"></div>
             </div>
 
             <details class="lab-image-qa__settings mt-3" data-viddel-lab-settings>
@@ -276,10 +277,20 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
       let chatSessionId = `image-qa-${Date.now().toString(36)}`;
 
       const syncComposeReserve = () => {
-        const h = Math.ceil(composeStack.getBoundingClientRect().height);
-        const reserve = `${h}px`;
-        shell.style.setProperty("--inline-chat-bottom-reserve", reserve);
-        document.body.style.setProperty("--viddel-chat-compose-reserve", reserve);
+        const rect = composeStack.getBoundingClientRect();
+        const composeHeight = Math.ceil(rect.height);
+        const bottomInset = Math.max(0, Math.ceil(window.innerHeight - rect.bottom));
+        const readMargin = 24;
+        const reserve = composeHeight + bottomInset + readMargin;
+        const reservePx = `${reserve}px`;
+        shell.style.setProperty("--inline-chat-bottom-reserve", reservePx);
+        document.body.style.setProperty("--viddel-chat-compose-reserve", reservePx);
+      };
+
+      const scrollDialogToEnd = () => {
+        requestAnimationFrame(() => {
+          dialog.scrollTop = dialog.scrollHeight;
+        });
       };
 
       const canSend = () => {
@@ -427,7 +438,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         turn.append(userTurn);
         transcript.append(turn);
         activeTurn = turn;
-        turn.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        scrollDialogToEnd();
       };
 
       const showPendingAssistant = () => {
@@ -446,7 +457,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         assistant.append(eyebrow, body);
         activeTurn.append(assistant);
         pendingAssistantEl = assistant;
-        assistant.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        scrollDialogToEnd();
       };
 
       const removePendingAssistant = () => {
@@ -467,7 +478,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         renderAssistantMarkdownInto(body, text);
         assistant.append(eyebrow, body);
         activeTurn.append(assistant);
-        assistant.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        scrollDialogToEnd();
       };
 
       const updateDebug = (visionPayload, chatPayload, chatStatus, composedChatMessage) => {
@@ -506,6 +517,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         }
 
         debugEl.classList.remove("hidden");
+        scrollDialogToEnd();
       };
 
       const beginSendUi = () => {
@@ -705,11 +717,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
 
       debugEl.addEventListener("toggle", () => {
         syncComposeReserve();
-        if (debugEl.open) {
-          requestAnimationFrame(() => {
-            debugEl.scrollIntoView({ behavior: "smooth", block: "nearest" });
-          });
-        }
+        if (debugEl.open) scrollDialogToEnd();
       });
 
       window.addEventListener("resize", syncComposeReserve, { passive: true });

--- a/src/styles/lab-image-qa.css
+++ b/src/styles/lab-image-qa.css
@@ -1,13 +1,56 @@
 /* CONTRACT: Lab image-QA composer extensions — attachment + thumbnail in inline-chat-shell (#240). Lab-only; /no/chat unchanged. */
 
 [data-viddel-lab-image-qa] {
-  --lab-compose-scroll-tail: calc(max(0.75rem, env(safe-area-inset-bottom, 0px)) + 1.25rem);
+  --lab-compose-scroll-tail: calc(max(0.75rem, env(safe-area-inset-bottom, 0px)) + 1.75rem);
+}
+
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .r1-editorial-container {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .viddel-chat-standalone__editorial {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .inline-chat-shell {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .inline-chat-shell__dialog-thread:not(.hidden) {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  -webkit-overflow-scrolling: touch;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scroll-padding-bottom: calc(var(--inline-chat-bottom-reserve, 8rem) + var(--lab-compose-scroll-tail));
 }
 
 [data-viddel-lab-image-qa]
   .inline-chat-shell[data-inline-chat-conversation="active"]
   .inline-chat-shell__dialog-thread {
-  padding-bottom: calc(var(--inline-chat-bottom-reserve, 7.5rem) + var(--lab-compose-scroll-tail));
+  padding-bottom: 0;
+}
+
+.lab-image-qa__scroll-spacer {
+  flex-shrink: 0;
+  height: calc(var(--inline-chat-bottom-reserve, 8rem) + var(--lab-compose-scroll-tail));
+  pointer-events: none;
+  width: 100%;
 }
 
 [data-viddel-lab-image-qa]
@@ -94,16 +137,24 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
   width: 1.15rem;
 }
 
-.lab-image-qa__compose-input-wrap {
+[data-viddel-lab-image-qa] .lab-image-qa__compose-input-wrap {
+  align-items: flex-start;
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+  justify-content: flex-start;
   min-width: 0;
   overflow: hidden;
+  width: 100%;
 }
 
-.lab-image-qa__compose-input-wrap:has(.lab-image-qa__attachment:not(.hidden)) {
+[data-viddel-lab-image-qa] .lab-image-qa__compose-input-wrap:has(.lab-image-qa__attachment:not(.hidden)) {
   overflow: visible;
+}
+
+[data-viddel-lab-image-qa] .lab-image-qa__compose-input-wrap > .inline-chat-shell__compose-input {
+  align-self: stretch;
+  width: 100%;
 }
 
 [data-viddel-lab-image-qa] .inline-chat-shell[data-inline-chat-conversation="idle"] .lab-image-qa__compose {
@@ -136,8 +187,9 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
 
 .lab-image-qa__attachment {
   align-self: flex-start;
-  display: inline-block;
+  display: block;
   flex-shrink: 0;
+  margin: 0;
   max-width: 100%;
   position: relative;
   width: 3rem;
@@ -303,5 +355,29 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
     height: 2.68rem;
     min-height: 2.68rem;
     width: 2.68rem;
+  }
+
+  [data-viddel-lab-image-qa] .lab-image-qa__compose-input-wrap:has(.lab-image-qa__attachment:not(.hidden)) {
+    align-items: flex-end;
+    flex-direction: row;
+    gap: 0.45rem;
+  }
+
+  [data-viddel-lab-image-qa]
+    .lab-image-qa__compose-input-wrap:has(.lab-image-qa__attachment:not(.hidden))
+    > .inline-chat-shell__compose-input {
+    align-self: stretch;
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  [data-viddel-lab-image-qa] .lab-image-qa__attachment {
+    width: 3.35rem;
+  }
+
+  [data-viddel-lab-image-qa] .lab-image-qa__thumb {
+    border-radius: 999px;
+    height: 2.15rem;
+    width: 3.35rem;
   }
 }


### PR DESCRIPTION
## Summary

Merge the latest #247 mobile scroll and composer thumbnail fixes from Cursor.

This addresses the remaining mobile usability issues in `/lab/image-qa`:

- long responses not fully scrollable above fixed composer
- Vision/QA panel not reliably readable above composer
- composer thumbnail alignment and shape on mobile

## Changes

- Stabilizes Lab-only scroll chain:
  - `r1-editorial-container`
  - editorial
  - inline chat shell
  - dialog thread
- Uses a viewport-measured composer reserve via `syncComposeReserve()`.
- Adds bottom scroll spacer in the dialog thread.
- Calls `scrollDialogToEnd()` on new messages, pending, debug open and answer.
- Left-aligns composer thumbnail in content area.
- Uses compact/pill-like mobile thumbnail treatment.
- Keeps remove × over thumbnail, top-right.

## Verification from Cursor

- Commit: `37a489f9854102b7e791a1bca2552f8e1f613554`
- `npm run build` OK
- `/no/chat` unchanged
- Lab-only changes
- `/api/chat` unchanged
- no images/secrets in git

## Related

- #247
- #245
- #240

## Not included

- Plus menu for camera/gallery. This remains a separate follow-up.