### PR TITLE
Refine Lab image QA scroll viewport and attachment strip

### DIFF
--- a/src/pages/lab/image-qa.astro
+++ b/src/pages/lab/image-qa.astro
@@ -62,22 +62,23 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
             </header>
 
             <div class="inline-chat-shell__dialog-thread mt-3 hidden" data-viddel-lab-dialog>
-              <div class="inline-chat-shell__transcript-divider">
-                <span class="inline-chat-shell__transcript-divider-line" aria-hidden="true"></span>
-                <span class="inline-chat-shell__transcript-divider-label" id="viddel-lab-dialog-label">
-                  Dialog med Viddel
-                </span>
-              </div>
-              <div
-                class="inline-chat-shell__transcript"
-                data-viddel-lab-transcript
-                role="log"
-                aria-live="polite"
-                aria-relevant="additions text"
-              >
-              </div>
+              <div class="lab-image-qa__scroll-viewport" data-viddel-lab-scroll-viewport>
+                <div class="inline-chat-shell__transcript-divider">
+                  <span class="inline-chat-shell__transcript-divider-line" aria-hidden="true"></span>
+                  <span class="inline-chat-shell__transcript-divider-label" id="viddel-lab-dialog-label">
+                    Dialog med Viddel
+                  </span>
+                </div>
+                <div
+                  class="inline-chat-shell__transcript"
+                  data-viddel-lab-transcript
+                  role="log"
+                  aria-live="polite"
+                  aria-relevant="additions text"
+                >
+                </div>
 
-              <details class="lab-image-qa__debug hidden" data-viddel-lab-debug>
+                <details class="lab-image-qa__debug hidden" data-viddel-lab-debug>
                 <summary>Vision / QA-data</summary>
                 <div class="lab-image-qa__debug-body">
                   <div class="lab-image-qa__debug-block">
@@ -103,8 +104,9 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
                     <pre class="lab-image-qa__debug-pre" data-viddel-lab-debug-chat-text></pre>
                   </div>
                 </div>
-              </details>
-              <div class="lab-image-qa__scroll-spacer" data-viddel-lab-scroll-spacer aria-hidden="true"></div>
+                </details>
+                <div class="lab-image-qa__scroll-spacer" data-viddel-lab-scroll-spacer aria-hidden="true"></div>
+              </div>
             </div>
 
             <details class="lab-image-qa__settings mt-3" data-viddel-lab-settings>
@@ -138,46 +140,57 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
                   class="sr-only"
                   data-viddel-lab-file
                 />
-                <button
-                  type="button"
-                  class="lab-image-qa__attach"
-                  data-viddel-lab-attach
-                  aria-label="Legg ved bilde av utstyr"
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" aria-hidden="true">
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M4 7a3 3 0 0 1 3-3h4.5a2.5 2.5 0 0 1 2.12 1.18L15 7h2a3 3 0 0 1 3 3v7a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7Z"
-                    ></path>
-                    <circle cx="12" cy="13" r="3.25"></circle>
-                  </svg>
-                </button>
-                <div class="inline-chat-shell__compose-input-wrap lab-image-qa__compose-input-wrap">
-                  <div class="lab-image-qa__attachment hidden" data-viddel-lab-attachment>
-                    <img class="lab-image-qa__thumb" data-viddel-lab-thumb alt="Valgt utstyr-bilde" />
-                    <button type="button" class="lab-image-qa__remove-attachment" data-viddel-lab-remove aria-label="Fjern bilde">
-                      ×
-                    </button>
+                <div class="lab-image-qa__attachment-strip hidden" data-viddel-lab-attachment-strip>
+                  <div class="lab-image-qa__attachment-list" data-viddel-lab-attachment-list>
+                    <div class="lab-image-qa__attachment" data-viddel-lab-attachment>
+                      <img class="lab-image-qa__thumb" data-viddel-lab-thumb alt="Valgt utstyr-bilde" />
+                      <button
+                        type="button"
+                        class="lab-image-qa__remove-attachment"
+                        data-viddel-lab-remove
+                        aria-label="Fjern bilde"
+                      >
+                        ×
+                      </button>
+                    </div>
                   </div>
-                  <label class="sr-only" for="viddel-lab-input">Beskriv situasjonen eller spørsmålet ditt</label>
-                  <textarea
-                    id="viddel-lab-input"
-                    data-viddel-lab-input
-                    class="inline-chat-shell__compose-input"
-                    rows="1"
-                    placeholder="Hva lurer du på?"
-                  ></textarea>
                 </div>
-                <button
-                  type="submit"
-                  class="inline-chat-shell__compose-send"
-                  data-viddel-lab-send
-                  aria-label="Send med bilde"
-                  disabled
-                >
-                  <span aria-hidden="true">↑</span>
-                </button>
+                <div class="lab-image-qa__compose-row">
+                  <button
+                    type="button"
+                    class="lab-image-qa__attach"
+                    data-viddel-lab-attach
+                    aria-label="Legg ved bilde av utstyr"
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" aria-hidden="true">
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M4 7a3 3 0 0 1 3-3h4.5a2.5 2.5 0 0 1 2.12 1.18L15 7h2a3 3 0 0 1 3 3v7a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7Z"
+                      ></path>
+                      <circle cx="12" cy="13" r="3.25"></circle>
+                    </svg>
+                  </button>
+                  <div class="inline-chat-shell__compose-input-wrap lab-image-qa__compose-input-wrap">
+                    <label class="sr-only" for="viddel-lab-input">Beskriv situasjonen eller spørsmålet ditt</label>
+                    <textarea
+                      id="viddel-lab-input"
+                      data-viddel-lab-input
+                      class="inline-chat-shell__compose-input"
+                      rows="1"
+                      placeholder="Hva lurer du på?"
+                    ></textarea>
+                  </div>
+                  <button
+                    type="submit"
+                    class="inline-chat-shell__compose-send"
+                    data-viddel-lab-send
+                    aria-label="Send med bilde"
+                    disabled
+                  >
+                    <span aria-hidden="true">↑</span>
+                  </button>
+                </div>
               </form>
             </div>
           </section>
@@ -215,6 +228,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
       const intro = document.querySelector("[data-viddel-lab-intro]");
       const header = shell?.querySelector("[data-inline-chat-header]");
       const dialog = document.querySelector("[data-viddel-lab-dialog]");
+      const scrollViewport = document.querySelector("[data-viddel-lab-scroll-viewport]");
       const transcript = document.querySelector("[data-viddel-lab-transcript]");
       const composeStack = document.querySelector("[data-viddel-lab-compose-stack]");
       const errorEl = document.querySelector("[data-viddel-lab-error]");
@@ -223,6 +237,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
       const sendBtn = document.querySelector("[data-viddel-lab-send]");
       const fileInput = document.querySelector("[data-viddel-lab-file]");
       const attachBtn = document.querySelector("[data-viddel-lab-attach]");
+      const attachmentStrip = document.querySelector("[data-viddel-lab-attachment-strip]");
       const attachmentWrap = document.querySelector("[data-viddel-lab-attachment]");
       const thumbEl = document.querySelector("[data-viddel-lab-thumb]");
       const removeBtn = document.querySelector("[data-viddel-lab-remove]");
@@ -246,6 +261,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         !intro ||
         !header ||
         !dialog ||
+        !scrollViewport ||
         !transcript ||
         !composeStack ||
         !errorEl ||
@@ -254,6 +270,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         !sendBtn ||
         !fileInput ||
         !attachBtn ||
+        !attachmentStrip ||
         !attachmentWrap ||
         !thumbEl ||
         !removeBtn ||
@@ -289,7 +306,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
 
       const scrollDialogToEnd = () => {
         requestAnimationFrame(() => {
-          dialog.scrollTop = dialog.scrollHeight;
+          scrollViewport.scrollTop = scrollViewport.scrollHeight;
         });
       };
 
@@ -367,7 +384,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         selectedFile = null;
         fileInput.value = "";
         thumbEl.removeAttribute("src");
-        attachmentWrap.classList.add("hidden");
+        attachmentStrip.classList.add("hidden");
         refreshSendState();
         resizeInput();
         syncComposeReserve();
@@ -391,7 +408,7 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
         clearError();
         const previewUrl = URL.createObjectURL(file);
         thumbEl.src = previewUrl;
-        attachmentWrap.classList.remove("hidden");
+        attachmentStrip.classList.remove("hidden");
         selectedFile = { file, previewUrl };
         refreshSendState();
         resizeInput();
@@ -710,9 +727,9 @@ const aiHeadingId = "viddel-lab-image-qa-ai";
       if ("ResizeObserver" in window) {
         const observer = new ResizeObserver(syncComposeReserve);
         observer.observe(composeStack);
-        observer.observe(attachmentWrap);
+        observer.observe(attachmentStrip);
         observer.observe(input);
-        observer.observe(dialog);
+        observer.observe(scrollViewport);
       }
 
       debugEl.addEventListener("toggle", () => {

--- a/src/styles/lab-image-qa.css
+++ b/src/styles/lab-image-qa.css
@@ -2,47 +2,43 @@
 
 [data-viddel-lab-image-qa] {
   --lab-compose-scroll-tail: calc(max(0.75rem, env(safe-area-inset-bottom, 0px)) + 1.75rem);
+  --lab-header-scroll-pad: calc(4.5rem + env(safe-area-inset-top, 0px));
 }
 
-body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .r1-editorial-container {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  min-height: 0;
-  overflow: hidden;
+body.vox-shell--standalone-chat[data-viddel-chat-active] .vox-shell-standalone-chat__stage:has([data-viddel-lab-image-qa]) {
+  padding-top: 0;
 }
 
-body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .viddel-chat-standalone__editorial {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  min-height: 0;
-  overflow: hidden;
-}
-
-body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .inline-chat-shell {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  min-height: 0;
-  overflow: hidden;
-}
-
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa],
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .r1-editorial-container,
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .viddel-chat-standalone__editorial,
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .r1-ai-bridge,
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .inline-chat-shell,
 body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .inline-chat-shell__dialog-thread:not(.hidden) {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
   min-height: 0;
+  overflow: hidden;
+}
+
+.lab-image-qa__scroll-viewport {
   -webkit-overflow-scrolling: touch;
+  flex: 1 1 auto;
+  margin-bottom: calc(var(--inline-chat-bottom-reserve, 8rem) + var(--lab-compose-scroll-tail));
+  min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
+  padding-top: 0.35rem;
+  scroll-padding-top: var(--lab-header-scroll-pad);
   scroll-padding-bottom: calc(var(--inline-chat-bottom-reserve, 8rem) + var(--lab-compose-scroll-tail));
 }
 
 [data-viddel-lab-image-qa]
   .inline-chat-shell[data-inline-chat-conversation="active"]
   .inline-chat-shell__dialog-thread {
+  margin-top: 0;
   padding-bottom: 0;
 }
 
@@ -53,16 +49,14 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
   width: 100%;
 }
 
-[data-viddel-lab-image-qa]
-  .inline-chat-shell[data-inline-chat-conversation="active"]
-  .inline-chat-shell__message-text,
-[data-viddel-lab-image-qa]
-  .inline-chat-shell[data-inline-chat-conversation="active"]
-  .lab-image-qa__debug,
-[data-viddel-lab-image-qa]
-  .inline-chat-shell[data-inline-chat-conversation="active"]
-  .lab-image-qa__debug-body {
-  scroll-margin-bottom: calc(var(--inline-chat-bottom-reserve, 7.5rem) + var(--lab-compose-scroll-tail));
+[data-viddel-lab-image-qa] .lab-image-qa__scroll-viewport .inline-chat-shell__message-text,
+[data-viddel-lab-image-qa] .lab-image-qa__scroll-viewport .lab-image-qa__debug,
+[data-viddel-lab-image-qa] .lab-image-qa__scroll-viewport .lab-image-qa__debug-body {
+  scroll-margin-bottom: calc(var(--inline-chat-bottom-reserve, 8rem) + var(--lab-compose-scroll-tail));
+}
+
+[data-viddel-lab-image-qa] .lab-image-qa__scroll-viewport .inline-chat-shell__transcript-divider {
+  scroll-margin-top: var(--lab-header-scroll-pad);
 }
 
 body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-qa] .lab-image-qa__settings {
@@ -106,9 +100,36 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
   outline-offset: 2px;
 }
 
-.lab-image-qa__compose {
+[data-viddel-lab-image-qa] .lab-image-qa__compose {
+  align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.lab-image-qa__attachment-strip {
+  display: flex;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.lab-image-qa__attachment-strip.hidden {
+  display: none;
+}
+
+.lab-image-qa__attachment-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: flex-start;
+}
+
+.lab-image-qa__compose-row {
   align-items: flex-end;
+  display: grid;
+  gap: 0.55rem;
   grid-template-columns: auto minmax(0, 1fr) auto;
+  width: 100%;
 }
 
 .lab-image-qa__attach {
@@ -138,22 +159,15 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
 }
 
 [data-viddel-lab-image-qa] .lab-image-qa__compose-input-wrap {
-  align-items: flex-start;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  justify-content: flex-start;
+  display: grid;
   min-width: 0;
   overflow: hidden;
+  position: relative;
   width: 100%;
 }
 
-[data-viddel-lab-image-qa] .lab-image-qa__compose-input-wrap:has(.lab-image-qa__attachment:not(.hidden)) {
-  overflow: visible;
-}
-
 [data-viddel-lab-image-qa] .lab-image-qa__compose-input-wrap > .inline-chat-shell__compose-input {
-  align-self: stretch;
+  grid-area: 1 / 1;
   width: 100%;
 }
 
@@ -170,7 +184,7 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
 }
 
 [data-viddel-lab-image-qa]
-  .inline-chat-shell[data-inline-chat-conversation="idle"]:not(:has(.lab-image-qa__attachment:not(.hidden)))
+  .inline-chat-shell[data-inline-chat-conversation="idle"]:not(:has(.lab-image-qa__attachment-strip:not(.hidden)))
   .lab-image-qa__compose
   .inline-chat-shell__compose-input {
   overflow-y: hidden;
@@ -193,10 +207,6 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
   max-width: 100%;
   position: relative;
   width: 3rem;
-}
-
-.lab-image-qa__attachment.hidden {
-  display: none;
 }
 
 .lab-image-qa__thumb {
@@ -340,12 +350,12 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
   padding-left: 1.1rem;
 }
 
-.inline-chat-shell[data-inline-chat-mode="progressive"] .lab-image-qa__compose .inline-chat-shell__compose-send {
+.inline-chat-shell[data-inline-chat-mode="progressive"] .lab-image-qa__compose-row .inline-chat-shell__compose-send {
   align-self: flex-end;
 }
 
 @media (max-width: 639px) {
-  .inline-chat-shell[data-inline-chat-mode="progressive"] .lab-image-qa__compose .inline-chat-shell__compose-send {
+  .inline-chat-shell[data-inline-chat-mode="progressive"] .lab-image-qa__compose-row .inline-chat-shell__compose-send {
     height: 2.68rem;
     min-height: 2.68rem;
     width: 2.68rem;
@@ -355,20 +365,6 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-lab-image-
     height: 2.68rem;
     min-height: 2.68rem;
     width: 2.68rem;
-  }
-
-  [data-viddel-lab-image-qa] .lab-image-qa__compose-input-wrap:has(.lab-image-qa__attachment:not(.hidden)) {
-    align-items: flex-end;
-    flex-direction: row;
-    gap: 0.45rem;
-  }
-
-  [data-viddel-lab-image-qa]
-    .lab-image-qa__compose-input-wrap:has(.lab-image-qa__attachment:not(.hidden))
-    > .inline-chat-shell__compose-input {
-    align-self: stretch;
-    flex: 1 1 0;
-    min-width: 0;
   }
 
   [data-viddel-lab-image-qa] .lab-image-qa__attachment {


### PR DESCRIPTION
## Summary

Merge the latest #247 Lab image QA layout fix from Cursor.

This addresses the remaining mobile layout issues:

- transcript/content should scroll in its own viewport
- content should move naturally behind the glass header
- scrollbar should stop above the fixed composer
- attached image should live in a dedicated attachment strip above the input row

## Changes

- Adds dedicated Lab scroll viewport inside the dialog thread.
- Moves transcript, debug and spacer into that viewport.
- Adjusts active conversation stage/header scroll behavior.
- Uses `scroll-padding-top` for header/safe-area behavior.
- Uses composer reserve + tail so the scroll area ends above fixed composer.
- Adds attachment strip above input row.
- Keeps input row as `[camera] [textarea] [send]`.
- Keeps thumbnail/pill separate from text area.

## Verification from Cursor

- Commit: `f295f41ce25b5ccd9ea874ec62cf019ce6c10dc0`
- `npm run build` OK
- `/no/chat` unchanged
- Lab-only changes
- `/api/chat` unchanged
- no images/secrets in git

## Related

- #247
- #245
- #240

## Not included

- Plus menu for camera/gallery. This remains a later follow-up.