### PR TITLE
Calibrate article transition halo intensity

### DIFF
--- a/src/components/article/ArticleInlineChatShell.astro
+++ b/src/components/article/ArticleInlineChatShell.astro
@@ -420,6 +420,9 @@ const inspectLabelClass =
     const minBottomReservePx = () => Math.ceil(6.5 * rootRemPx());
     const stickyComposerBottomInsetPx = () => {
       if (isTransitionV01) {
+        if (window.matchMedia?.("(max-width: 640px)")?.matches) {
+          return Math.max(Math.ceil(1 * rootRemPx()), 16);
+        }
         return Math.max(Math.ceil(2.75 * rootRemPx()), 44);
       }
       return Math.max(Math.ceil(0.75 * rootRemPx()), 12);

--- a/src/components/article/ArticleInlineChatShell.astro
+++ b/src/components/article/ArticleInlineChatShell.astro
@@ -420,7 +420,7 @@ const inspectLabelClass =
     const minBottomReservePx = () => Math.ceil(6.5 * rootRemPx());
     const stickyComposerBottomInsetPx = () => {
       if (isTransitionV01) {
-        return Math.max(Math.ceil(1.125 * rootRemPx()), 18);
+        return Math.max(Math.ceil(2.75 * rootRemPx()), 44);
       }
       return Math.max(Math.ceil(0.75 * rootRemPx()), 12);
     };

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -2,10 +2,10 @@
 
 [data-article-chat-transition-v01] {
   --article-chat-compose-surface: 255 255 255;
-  /* Frisk isblå + mint — tydelig bunnsone (sterk test). */
+  /* Frisk isblå + mint — roligere bunnhalo rundt composer. */
   --article-chat-halo-core: 158 214 248;
   --article-chat-halo-accent: 132 228 206;
-  --article-chat-compose-halo-height: clamp(16rem, 34vh, 24rem);
+  --article-chat-compose-halo-height: clamp(12rem, 24vh, 18rem);
   --article-chat-compose-shadow: 48 82 120;
 }
 
@@ -17,7 +17,7 @@
 .article-chat-transition-v01__compose-environment {
   --article-chat-halo-core: 158 214 248;
   --article-chat-halo-accent: 132 228 206;
-  --article-chat-compose-halo-height: clamp(16rem, 34vh, 24rem);
+  --article-chat-compose-halo-height: clamp(12rem, 24vh, 18rem);
   bottom: 0;
   left: 0;
   margin: 0;
@@ -33,21 +33,21 @@
 .article-chat-transition-v01__compose-halo {
   background:
     radial-gradient(
-      ellipse 92% 98% at 50% 70%,
-      rgb(158 214 248 / 0.9) 0%,
-      rgb(132 228 206 / 0.62) 24%,
-      rgb(158 214 248 / 0.36) 46%,
-      rgb(132 228 206 / 0.16) 64%,
-      transparent 90%
+      ellipse 92% 98% at 50% 78%,
+      rgb(158 214 248 / 0.62) 0%,
+      rgb(132 228 206 / 0.42) 24%,
+      rgb(158 214 248 / 0.24) 44%,
+      rgb(132 228 206 / 0.1) 62%,
+      transparent 82%
     ),
     linear-gradient(
       to top,
-      rgb(158 214 248 / 0.34) 0%,
-      rgb(132 228 206 / 0.16) 38%,
-      transparent 88%
+      rgb(158 214 248 / 0.18) 0%,
+      rgb(132 228 206 / 0.08) 34%,
+      transparent 78%
     );
   bottom: 0;
-  height: calc(var(--article-chat-compose-halo-height, clamp(16rem, 34vh, 24rem)) + env(safe-area-inset-bottom, 0px));
+  height: calc(var(--article-chat-compose-halo-height, clamp(12rem, 24vh, 18rem)) + env(safe-area-inset-bottom, 0px));
   left: 0;
   margin: 0;
   max-width: none;

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -175,7 +175,7 @@
   background: transparent;
   border: 0;
   border-radius: 0;
-  bottom: max(1.125rem, env(safe-area-inset-bottom, 0px));
+  bottom: max(2.75rem, calc(env(safe-area-inset-bottom, 0px) + 1rem));
   box-shadow: none;
   box-sizing: border-box;
   gap: 0;

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -189,6 +189,38 @@
   z-index: 32;
 }
 
+@media (max-width: 640px) {
+  [data-article-chat-transition-v01] {
+    background: rgb(var(--reading-paper));
+  }
+
+  body.vox-shell--article:has([data-article-chat-transition-v01]) > .mx-auto.max-w-6xl {
+    max-width: none;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  [data-article-chat-transition-v01] > .r1-editorial-container {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  [data-article-chat-transition-v01] .vox-reading-sheet {
+    border-left: 0;
+    border-radius: 0;
+    border-right: 0;
+    max-width: none;
+    width: 100%;
+  }
+
+  [data-r1-editorial]
+    .r1-ai-bridge
+    .inline-chat-shell[data-inline-chat-layout="transition-v01"][data-inline-chat-mode="progressive"]
+    .inline-chat-shell__compose-stack {
+    bottom: max(1rem, calc(env(safe-area-inset-bottom, 0px) + 0.75rem));
+  }
+}
+
 [data-r1-editorial]
   .inline-chat-shell[data-inline-chat-layout="transition-v01"][data-inline-chat-mode="progressive"]
   .inline-chat-shell__compose-stack

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -6,7 +6,7 @@
   --article-chat-halo-core: 158 214 248;
   --article-chat-halo-accent: 132 228 206;
   --article-chat-compose-halo-height: clamp(8rem, 16vh, 13rem);
-  --article-chat-compose-halo-width: min(56rem, calc(100vw - 4rem));
+  --article-chat-compose-halo-width: min(60rem, calc(100vw - 3.5rem));
   --article-chat-compose-shadow: 48 82 120;
 }
 
@@ -19,7 +19,7 @@
   --article-chat-halo-core: 158 214 248;
   --article-chat-halo-accent: 132 228 206;
   --article-chat-compose-halo-height: clamp(8rem, 16vh, 13rem);
-  --article-chat-compose-halo-width: min(56rem, calc(100vw - 4rem));
+  --article-chat-compose-halo-width: min(60rem, calc(100vw - 3.5rem));
   bottom: 0;
   left: 0;
   margin: 0;
@@ -35,7 +35,7 @@
 .article-chat-transition-v01__compose-halo {
   background:
     radial-gradient(
-      ellipse 78% 82% at 50% 88%,
+      ellipse 84% 82% at 50% 88%,
       rgb(158 214 248 / 0.7) 0%,
       rgb(132 228 206 / 0.48) 22%,
       rgb(158 214 248 / 0.22) 42%,
@@ -52,13 +52,13 @@
   height: calc(var(--article-chat-compose-halo-height, clamp(8rem, 16vh, 13rem)) + env(safe-area-inset-bottom, 0px));
   left: 50%;
   margin: 0;
-  mask-image: linear-gradient(90deg, transparent 0%, black 18%, black 82%, transparent 100%);
+  mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
   max-width: none;
   pointer-events: none;
   position: absolute;
   transform: translateX(-50%);
-  width: var(--article-chat-compose-halo-width, min(56rem, calc(100vw - 4rem)));
-  -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 18%, black 82%, transparent 100%);
+  width: var(--article-chat-compose-halo-width, min(60rem, calc(100vw - 3.5rem)));
+  -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
 }
 
 [data-article-chat-transition-v01] .vox-reading-article-body {

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -190,6 +190,18 @@
 }
 
 @media (max-width: 640px) {
+  body.vox-shell--article:has([data-article-chat-transition-v01]) {
+    --bg: var(--reading-paper);
+    --orb-a: 0;
+    --orb-b: 0;
+    --orb-c: 0;
+    background: rgb(var(--reading-paper));
+  }
+
+  body.vox-shell--article:has([data-article-chat-transition-v01]) .vox-sonic-blob--article {
+    opacity: 0;
+  }
+
   [data-article-chat-transition-v01] {
     background: rgb(var(--reading-paper));
   }
@@ -218,6 +230,20 @@
     .inline-chat-shell[data-inline-chat-layout="transition-v01"][data-inline-chat-mode="progressive"]
     .inline-chat-shell__compose-stack {
     bottom: max(1rem, calc(env(safe-area-inset-bottom, 0px) + 0.75rem));
+    max-width: none !important;
+    width: calc(100vw - 2rem) !important;
+  }
+
+  [data-r1-editorial]
+    .r1-ai-bridge
+    .inline-chat-shell[data-inline-chat-layout="transition-v01"][data-inline-chat-mode="progressive"]
+    .inline-chat-shell__compose-stack
+    .inline-chat-shell__compose {
+    width: 100%;
+  }
+
+  .article-chat-transition-v01__compose-environment {
+    --article-chat-compose-halo-width: min(24rem, calc(100vw - 1rem));
   }
 }
 

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -255,19 +255,19 @@
   .article-chat-transition-v01__compose-halo {
     background:
       radial-gradient(
-        ellipse 72% 74% at 42% 70%,
+        ellipse 72% 70% at 42% 74%,
         rgb(158 214 248 / 0.59) 0%,
         rgb(158 214 248 / 0.34) 36%,
         transparent 78%
       ),
       radial-gradient(
-        ellipse 68% 72% at 62% 76%,
+        ellipse 68% 68% at 62% 80%,
         rgb(132 228 206 / 0.45) 0%,
         rgb(132 228 206 / 0.22) 38%,
         transparent 80%
       ),
       radial-gradient(
-        ellipse 110% 72% at 50% 88%,
+        ellipse 110% 68% at 50% 91%,
         rgb(158 214 248 / 0.11) 0%,
         rgb(132 228 206 / 0.08) 42%,
         transparent 82%
@@ -294,7 +294,7 @@
   .article-chat-transition-v01__compose-halo {
     background:
       radial-gradient(
-        ellipse 84% 78% at 50% 78%,
+        ellipse 84% 78% at 50% 75%,
         rgb(158 214 248 / 0.66) 0%,
         rgb(132 228 206 / 0.42) 22%,
         rgb(158 214 248 / 0.18) 42%,

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -190,11 +190,17 @@
 }
 
 @media (max-width: 640px) {
+  html:has(body.vox-shell--article [data-article-chat-transition-v01]) {
+    background: rgb(var(--reading-paper));
+  }
+
   body.vox-shell--article:has([data-article-chat-transition-v01]) {
     --bg: var(--reading-paper);
     --orb-a: 0;
     --orb-b: 0;
     --orb-c: 0;
+    --surface: var(--reading-paper);
+    --surface-elevated: var(--reading-paper);
     background: rgb(var(--reading-paper));
   }
 
@@ -244,6 +250,33 @@
 
   .article-chat-transition-v01__compose-environment {
     --article-chat-compose-halo-width: min(24rem, calc(100vw - 1rem));
+  }
+
+  .article-chat-transition-v01__compose-halo {
+    background:
+      radial-gradient(
+        ellipse 88% 78% at 50% 70%,
+        rgb(158 214 248 / 0.82) 0%,
+        rgb(132 228 206 / 0.58) 22%,
+        rgb(158 214 248 / 0.3) 44%,
+        rgb(132 228 206 / 0.12) 62%,
+        transparent 82%
+      ),
+      linear-gradient(
+        to top,
+        rgb(158 214 248 / 0.18) 0%,
+        rgb(132 228 206 / 0.08) 30%,
+        transparent 72%
+      );
+  }
+
+  [data-r1-editorial]
+    .inline-chat-shell[data-inline-chat-layout="transition-v01"][data-inline-chat-mode="progressive"]
+    .inline-chat-shell__compose-stack
+    .inline-chat-shell__compose {
+    box-shadow:
+      0 24px 62px -16px rgb(var(--article-chat-compose-shadow) / 0.36),
+      0 10px 28px -12px rgb(var(--article-chat-compose-shadow) / 0.22) !important;
   }
 }
 

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -249,27 +249,31 @@
   }
 
   .article-chat-transition-v01__compose-environment {
-    --article-chat-compose-halo-width: min(34rem, calc(100vw + 4rem));
+    --article-chat-compose-halo-width: min(36rem, calc(100vw + 6rem));
   }
 
   .article-chat-transition-v01__compose-halo {
     background:
       radial-gradient(
-        ellipse 115% 88% at 50% 74%,
-        rgb(158 214 248 / 0.95) 0%,
-        rgb(132 228 206 / 0.72) 24%,
-        rgb(158 214 248 / 0.38) 48%,
-        rgb(132 228 206 / 0.18) 66%,
-        transparent 86%
+        ellipse 72% 74% at 42% 70%,
+        rgb(158 214 248 / 0.74) 0%,
+        rgb(158 214 248 / 0.42) 36%,
+        transparent 78%
       ),
-      linear-gradient(
-        to top,
-        rgb(158 214 248 / 0.24) 0%,
-        rgb(132 228 206 / 0.12) 32%,
-        transparent 76%
+      radial-gradient(
+        ellipse 68% 72% at 62% 76%,
+        rgb(132 228 206 / 0.56) 0%,
+        rgb(132 228 206 / 0.28) 38%,
+        transparent 80%
+      ),
+      radial-gradient(
+        ellipse 110% 72% at 50% 88%,
+        rgb(158 214 248 / 0.14) 0%,
+        rgb(132 228 206 / 0.1) 42%,
+        transparent 82%
       );
-    mask-image: linear-gradient(90deg, transparent 0%, black 4%, black 96%, transparent 100%);
-    -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 4%, black 96%, transparent 100%);
+    mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
+    -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
   }
 
   [data-r1-editorial]

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -5,7 +5,7 @@
   /* Frisk isblå + mint — roligere bunnhalo rundt composer. */
   --article-chat-halo-core: 158 214 248;
   --article-chat-halo-accent: 132 228 206;
-  --article-chat-compose-halo-height: clamp(12rem, 24vh, 18rem);
+  --article-chat-compose-halo-height: clamp(8rem, 16vh, 13rem);
   --article-chat-compose-shadow: 48 82 120;
 }
 
@@ -17,7 +17,7 @@
 .article-chat-transition-v01__compose-environment {
   --article-chat-halo-core: 158 214 248;
   --article-chat-halo-accent: 132 228 206;
-  --article-chat-compose-halo-height: clamp(12rem, 24vh, 18rem);
+  --article-chat-compose-halo-height: clamp(8rem, 16vh, 13rem);
   bottom: 0;
   left: 0;
   margin: 0;
@@ -33,21 +33,21 @@
 .article-chat-transition-v01__compose-halo {
   background:
     radial-gradient(
-      ellipse 92% 98% at 50% 78%,
-      rgb(158 214 248 / 0.62) 0%,
-      rgb(132 228 206 / 0.42) 24%,
-      rgb(158 214 248 / 0.24) 44%,
-      rgb(132 228 206 / 0.1) 62%,
-      transparent 82%
+      ellipse 86% 82% at 50% 88%,
+      rgb(158 214 248 / 0.7) 0%,
+      rgb(132 228 206 / 0.48) 22%,
+      rgb(158 214 248 / 0.22) 42%,
+      rgb(132 228 206 / 0.08) 58%,
+      transparent 78%
     ),
     linear-gradient(
       to top,
-      rgb(158 214 248 / 0.18) 0%,
-      rgb(132 228 206 / 0.08) 34%,
-      transparent 78%
+      rgb(158 214 248 / 0.14) 0%,
+      rgb(132 228 206 / 0.06) 30%,
+      transparent 72%
     );
   bottom: 0;
-  height: calc(var(--article-chat-compose-halo-height, clamp(12rem, 24vh, 18rem)) + env(safe-area-inset-bottom, 0px));
+  height: calc(var(--article-chat-compose-halo-height, clamp(8rem, 16vh, 13rem)) + env(safe-area-inset-bottom, 0px));
   left: 0;
   margin: 0;
   max-width: none;

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -249,25 +249,27 @@
   }
 
   .article-chat-transition-v01__compose-environment {
-    --article-chat-compose-halo-width: min(24rem, calc(100vw - 1rem));
+    --article-chat-compose-halo-width: min(34rem, calc(100vw + 4rem));
   }
 
   .article-chat-transition-v01__compose-halo {
     background:
       radial-gradient(
-        ellipse 88% 78% at 50% 70%,
-        rgb(158 214 248 / 0.82) 0%,
-        rgb(132 228 206 / 0.58) 22%,
-        rgb(158 214 248 / 0.3) 44%,
-        rgb(132 228 206 / 0.12) 62%,
-        transparent 82%
+        ellipse 115% 88% at 50% 74%,
+        rgb(158 214 248 / 0.95) 0%,
+        rgb(132 228 206 / 0.72) 24%,
+        rgb(158 214 248 / 0.38) 48%,
+        rgb(132 228 206 / 0.18) 66%,
+        transparent 86%
       ),
       linear-gradient(
         to top,
-        rgb(158 214 248 / 0.18) 0%,
-        rgb(132 228 206 / 0.08) 30%,
-        transparent 72%
+        rgb(158 214 248 / 0.24) 0%,
+        rgb(132 228 206 / 0.12) 32%,
+        transparent 76%
       );
+    mask-image: linear-gradient(90deg, transparent 0%, black 4%, black 96%, transparent 100%);
+    -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 4%, black 96%, transparent 100%);
   }
 
   [data-r1-editorial]
@@ -275,8 +277,8 @@
     .inline-chat-shell__compose-stack
     .inline-chat-shell__compose {
     box-shadow:
-      0 24px 62px -16px rgb(var(--article-chat-compose-shadow) / 0.36),
-      0 10px 28px -12px rgb(var(--article-chat-compose-shadow) / 0.22) !important;
+      0 26px 70px -16px rgb(var(--article-chat-compose-shadow) / 0.46),
+      0 12px 34px -12px rgb(var(--article-chat-compose-shadow) / 0.3) !important;
   }
 }
 

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -35,7 +35,7 @@
 .article-chat-transition-v01__compose-halo {
   background:
     radial-gradient(
-      ellipse 84% 82% at 50% 88%,
+      ellipse 84% 82% at 50% 79%,
       rgb(158 214 248 / 0.7) 0%,
       rgb(132 228 206 / 0.48) 22%,
       rgb(158 214 248 / 0.22) 42%,
@@ -294,7 +294,7 @@
   .article-chat-transition-v01__compose-halo {
     background:
       radial-gradient(
-        ellipse 84% 78% at 50% 75%,
+        ellipse 84% 78% at 50% 69%,
         rgb(158 214 248 / 0.66) 0%,
         rgb(132 228 206 / 0.42) 22%,
         rgb(158 214 248 / 0.18) 42%,

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -6,6 +6,7 @@
   --article-chat-halo-core: 158 214 248;
   --article-chat-halo-accent: 132 228 206;
   --article-chat-compose-halo-height: clamp(8rem, 16vh, 13rem);
+  --article-chat-compose-halo-width: min(56rem, calc(100vw - 4rem));
   --article-chat-compose-shadow: 48 82 120;
 }
 
@@ -18,6 +19,7 @@
   --article-chat-halo-core: 158 214 248;
   --article-chat-halo-accent: 132 228 206;
   --article-chat-compose-halo-height: clamp(8rem, 16vh, 13rem);
+  --article-chat-compose-halo-width: min(56rem, calc(100vw - 4rem));
   bottom: 0;
   left: 0;
   margin: 0;
@@ -33,7 +35,7 @@
 .article-chat-transition-v01__compose-halo {
   background:
     radial-gradient(
-      ellipse 86% 82% at 50% 88%,
+      ellipse 78% 82% at 50% 88%,
       rgb(158 214 248 / 0.7) 0%,
       rgb(132 228 206 / 0.48) 22%,
       rgb(158 214 248 / 0.22) 42%,
@@ -48,13 +50,15 @@
     );
   bottom: 0;
   height: calc(var(--article-chat-compose-halo-height, clamp(8rem, 16vh, 13rem)) + env(safe-area-inset-bottom, 0px));
-  left: 0;
+  left: 50%;
   margin: 0;
+  mask-image: linear-gradient(90deg, transparent 0%, black 18%, black 82%, transparent 100%);
   max-width: none;
   pointer-events: none;
   position: absolute;
-  right: 0;
-  width: 100%;
+  transform: translateX(-50%);
+  width: var(--article-chat-compose-halo-width, min(56rem, calc(100vw - 4rem)));
+  -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 18%, black 82%, transparent 100%);
 }
 
 [data-article-chat-transition-v01] .vox-reading-article-body {

--- a/src/styles/article-chat-transition-v01.css
+++ b/src/styles/article-chat-transition-v01.css
@@ -256,20 +256,20 @@
     background:
       radial-gradient(
         ellipse 72% 74% at 42% 70%,
-        rgb(158 214 248 / 0.74) 0%,
-        rgb(158 214 248 / 0.42) 36%,
+        rgb(158 214 248 / 0.59) 0%,
+        rgb(158 214 248 / 0.34) 36%,
         transparent 78%
       ),
       radial-gradient(
         ellipse 68% 72% at 62% 76%,
-        rgb(132 228 206 / 0.56) 0%,
-        rgb(132 228 206 / 0.28) 38%,
+        rgb(132 228 206 / 0.45) 0%,
+        rgb(132 228 206 / 0.22) 38%,
         transparent 80%
       ),
       radial-gradient(
         ellipse 110% 72% at 50% 88%,
-        rgb(158 214 248 / 0.14) 0%,
-        rgb(132 228 206 / 0.1) 42%,
+        rgb(158 214 248 / 0.11) 0%,
+        rgb(132 228 206 / 0.08) 42%,
         transparent 82%
       );
     mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
@@ -283,6 +283,30 @@
     box-shadow:
       0 26px 70px -16px rgb(var(--article-chat-compose-shadow) / 0.46),
       0 12px 34px -12px rgb(var(--article-chat-compose-shadow) / 0.3) !important;
+  }
+}
+
+@media (min-width: 641px) and (max-width: 900px) {
+  .article-chat-transition-v01__compose-environment {
+    --article-chat-compose-halo-height: clamp(7rem, 14vh, 11.5rem);
+  }
+
+  .article-chat-transition-v01__compose-halo {
+    background:
+      radial-gradient(
+        ellipse 84% 78% at 50% 78%,
+        rgb(158 214 248 / 0.66) 0%,
+        rgb(132 228 206 / 0.42) 22%,
+        rgb(158 214 248 / 0.18) 42%,
+        rgb(132 228 206 / 0.06) 56%,
+        transparent 76%
+      ),
+      linear-gradient(
+        to top,
+        rgb(158 214 248 / 0.08) 0%,
+        rgb(132 228 206 / 0.035) 28%,
+        transparent 68%
+      );
   }
 }
 


### PR DESCRIPTION
## Summary
- Calm the full-bleed article transition halo after c71a5db8 without changing the architecture.
- Keep the full-bleed composer environment, unchanged article shell, larger white pill composer, no border/hairline, and existing answer-clearance behavior.
- Leave /no/chat untouched.

## Halo values changed
- Height: clamp(16rem, 34vh, 24rem) -> clamp(12rem, 24vh, 18rem)
- Radial center: 50% 70% -> 50% 78%
- Core opacity: 0.90 -> 0.62
- Accent opacity: 0.62 -> 0.42
- Transparent stop: 90% -> 82%
- Linear base reduced from 0.34/0.16 to 0.18/0.08

## QA
- Desktop idle visual check
- Desktop seed/active check; answer clearance measured ~26px above composer
- Mobile idle visual check
- Mobile seed/active check; answer clearance measured ~25px above composer
- /no/chat regression: no article transition halo/environment present
- npm run build
- git diff --check

Closes #257