### PR TITLE
Test Viddel Composer style on standalone chat

### DIFF
--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -97,18 +97,20 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
         ) : null
       }
     </nav>
-    <a
-      href={chatHref}
-      data-viddel-track="ai_entry_clicked"
-      data-viddel-entry-surface="header_nav"
-      class={`hidden items-center justify-center rounded-full border px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex ${
-        chatActive
-          ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"
-          : "border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface))/0.42] text-[rgb(var(--text))] hover:border-[rgb(var(--text))/0.34] hover:bg-[rgb(var(--surface-subtle))/0.62]"
-      }`}
-    >
-      {NO_NAV_CHAT_LABEL}
-    </a>
+    {
+      chatActive ? (
+        <div class="pointer-events-none hidden w-[8.75rem] lg:block" aria-hidden="true"></div>
+      ) : (
+        <a
+          href={chatHref}
+          data-viddel-track="ai_entry_clicked"
+          data-viddel-entry-surface="header_nav"
+          class="hidden items-center justify-center rounded-full border border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface))/0.42] px-5 py-2.5 text-sm font-semibold text-[rgb(var(--text))] transition-colors hover:border-[rgb(var(--text))/0.34] hover:bg-[rgb(var(--surface-subtle))/0.62] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))/0.4] lg:inline-flex"
+        >
+          {NO_NAV_CHAT_LABEL}
+        </a>
+      )
+    }
     <MobileMenuTrigger />
   </div>
 </header>

--- a/src/components/nav/MobileMenuSheet.astro
+++ b/src/components/nav/MobileMenuSheet.astro
@@ -56,16 +56,16 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
         })
       }
     </nav>
-    <a
-      href={NO_NAV_CHAT_HREF}
-      class={`mt-4 flex w-full items-center justify-center rounded-full border px-5 py-3 text-sm font-semibold transition-colors ${
-        chatActive
-          ? "border-[rgb(var(--text))/0.34] bg-[rgb(var(--reading-ink))] text-[rgb(var(--reading-paper))]"
-          : "border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface-subtle))] text-[rgb(var(--text))]"
-      }`}
-    >
-      {NO_NAV_CHAT_LABEL}
-    </a>
+    {
+      !chatActive ? (
+        <a
+          href={NO_NAV_CHAT_HREF}
+          class="mt-4 flex w-full items-center justify-center rounded-full border border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface-subtle))] px-5 py-3 text-sm font-semibold text-[rgb(var(--text))] transition-colors"
+        >
+          {NO_NAV_CHAT_LABEL}
+        </a>
+      ) : null
+    }
     {
       showDevtoolsToggle ? (
         <div class="mt-4 border-t border-[rgb(var(--border))/0.35] pt-4">

--- a/src/pages/no/chat.astro
+++ b/src/pages/no/chat.astro
@@ -529,7 +529,7 @@ const exampleQuestions = [
       };
 
       const resizeInput = () => {
-        const minHeight = 38;
+        const minHeight = 44;
         input.style.height = "auto";
         const nextHeight = Math.max(minHeight, input.scrollHeight);
         const isExpanded = input.value.includes("\n") || nextHeight > minHeight + 2;

--- a/src/pages/no/chat.astro
+++ b/src/pages/no/chat.astro
@@ -529,7 +529,7 @@ const exampleQuestions = [
       };
 
       const resizeInput = () => {
-        const minHeight = 44;
+        const minHeight = 46;
         input.style.height = "auto";
         const nextHeight = Math.max(minHeight, input.scrollHeight);
         const isExpanded = input.value.includes("\n") || nextHeight > minHeight + 2;

--- a/src/styles/viddel-chat-attachment.css
+++ b/src/styles/viddel-chat-attachment.css
@@ -25,7 +25,7 @@
 }
 
 .viddel-chat-attach__compose-row {
-  align-items: flex-end;
+  align-items: center;
   display: grid;
   gap: 0.55rem;
   grid-template-columns: auto minmax(0, 1fr) auto;
@@ -225,6 +225,14 @@
   .inline-chat-shell__compose-input {
   max-height: 2.35rem;
   overflow: hidden;
+}
+
+[data-viddel-chat]
+  .inline-chat-shell[data-inline-chat-conversation="idle"]
+  .viddel-chat-attach__compose
+  .inline-chat-shell__compose-input[data-chat-input-expanded] {
+  max-height: min(9rem, 32vh);
+  overflow-y: auto;
 }
 
 [data-viddel-chat]

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -50,8 +50,18 @@ body.vox-shell--standalone-chat [data-viddel-chat] {
   --viddel-chat-compose-shadow: 48 82 120;
   --viddel-chat-halo-core: 158 214 248;
   --viddel-chat-halo-accent: 132 228 206;
-  --viddel-chat-compose-halo-height: clamp(7rem, 14vh, 11rem);
-  --viddel-chat-compose-halo-width: min(52rem, calc(100vw - 2rem));
+  --viddel-chat-compose-halo-height: clamp(8rem, 18vh, 14rem);
+  --viddel-chat-compose-halo-width: min(58rem, calc(100vw - 1rem));
+}
+
+body.vox-shell--standalone-chat {
+  --orb-a: 0;
+  --orb-b: 0;
+  --orb-c: 0;
+}
+
+body.vox-shell--standalone-chat .vox-sonic-blob {
+  opacity: 0.12;
 }
 
 /* --- Standalone idle start surface (seeds + composer) --- */
@@ -59,7 +69,7 @@ body.vox-shell--standalone-chat [data-viddel-chat] {
 body.vox-shell--standalone-chat:not([data-viddel-chat-active]) [data-viddel-chat] .viddel-chat-standalone__editorial {
   display: flex;
   flex-direction: column;
-  min-height: min(100%, calc(100dvh - 4.5rem));
+  min-height: min(100%, calc(100dvh - 6rem));
 }
 
 body.vox-shell--standalone-chat:not([data-viddel-chat-active]) [data-viddel-chat] .r1-ai-bridge {
@@ -68,8 +78,8 @@ body.vox-shell--standalone-chat:not([data-viddel-chat-active]) [data-viddel-chat
   flex-direction: column;
   justify-content: center;
   margin-bottom: 0;
-  padding-bottom: clamp(1.5rem, 8vh, 4rem);
-  padding-top: clamp(1.25rem, 6vh, 3rem);
+  padding-bottom: clamp(1rem, 6vh, 3.5rem);
+  padding-top: clamp(3rem, 14vh, 8rem);
 }
 
 body.vox-shell--standalone-chat:not([data-viddel-chat-active]) [data-viddel-chat] .inline-chat-shell {
@@ -82,6 +92,12 @@ body.vox-shell--standalone-chat:not([data-viddel-chat-active]) [data-viddel-chat
   margin-inline: auto;
   max-width: min(100%, var(--r1-ai-dialog-measure, min(100%, 46rem)));
   width: 100%;
+}
+
+@media (min-width: 640px) {
+  body.vox-shell--standalone-chat:not([data-viddel-chat-active]) [data-viddel-chat] .viddel-chat-start {
+    transform: translateY(clamp(4rem, 10vh, 6rem));
+  }
 }
 
 .viddel-chat-start__intro {
@@ -229,24 +245,24 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__seed-row 
 body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
   background:
     radial-gradient(
-      ellipse 80% 78% at 46% 72%,
-      rgb(var(--viddel-chat-halo-core) / 0.46) 0%,
-      rgb(var(--viddel-chat-halo-core) / 0.24) 38%,
+      ellipse 82% 76% at 45% 70%,
+      rgb(var(--viddel-chat-halo-core) / 0.5) 0%,
+      rgb(var(--viddel-chat-halo-core) / 0.26) 38%,
       transparent 78%
     ),
     radial-gradient(
-      ellipse 72% 74% at 60% 78%,
-      rgb(var(--viddel-chat-halo-accent) / 0.32) 0%,
-      rgb(var(--viddel-chat-halo-accent) / 0.16) 38%,
+      ellipse 76% 72% at 62% 78%,
+      rgb(var(--viddel-chat-halo-accent) / 0.36) 0%,
+      rgb(var(--viddel-chat-halo-accent) / 0.18) 40%,
       transparent 80%
     ),
     linear-gradient(
       to top,
-      rgb(var(--viddel-chat-halo-core) / 0.08) 0%,
-      rgb(var(--viddel-chat-halo-accent) / 0.035) 34%,
-      transparent 72%
+      rgb(var(--viddel-chat-halo-core) / 0.06) 0%,
+      rgb(var(--viddel-chat-halo-accent) / 0.025) 30%,
+      transparent 68%
     );
-  bottom: -1.65rem;
+  bottom: -0.35rem;
   content: "";
   height: var(--viddel-chat-compose-halo-height);
   left: 50%;
@@ -454,6 +470,17 @@ body.vox-shell--standalone-chat
   [data-r1-editorial]
   .r1-ai-bridge
   .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:not(:has(.viddel-chat-attach__attachment-strip:not(.hidden))):not(
+    :has(.inline-chat-shell__compose-input[data-chat-input-expanded])
+  ) {
+  border-radius: 999px;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
   .inline-chat-shell__compose:focus-within {
   box-shadow:
     0 24px 56px -14px rgb(var(--viddel-chat-compose-shadow) / 0.34),
@@ -473,6 +500,29 @@ body.vox-shell--standalone-chat
   .inline-chat-shell[data-inline-chat-mode="progressive"]
   .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
   border-radius: 1.55rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  [data-inline-chat-mode="progressive"]
+  .inline-chat-shell__message--user {
+  background: rgb(var(--viddel-chat-compose-surface) / 0.96);
+  border: 1px solid rgb(var(--border) / 0.32);
+  box-shadow:
+    0 14px 34px -20px rgb(var(--viddel-chat-compose-shadow) / 0.36),
+    0 1px 0 rgb(255 255 255 / 0.82) inset;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  [data-inline-chat-mode="progressive"]
+  .inline-chat-shell__message--user
+  .inline-chat-shell__message-text {
+  color: rgb(var(--reading-ink));
 }
 
 .inline-chat-shell__turn {
@@ -628,7 +678,7 @@ body.vox-shell--standalone-chat
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
-    bottom: -1.15rem;
+    bottom: 0;
     background:
       radial-gradient(
         ellipse 76% 72% at 44% 74%,
@@ -677,6 +727,28 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] .inline-chat-shell__dia
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
+}
+
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-chat] {
+  --viddel-chat-compose-halo-height: clamp(5.5rem, 11vh, 8rem);
+  --viddel-chat-compose-halo-width: min(42rem, calc(100vw - 2rem));
+}
+
+body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-chat] .inline-chat-shell__compose-stack::before {
+  background:
+    radial-gradient(
+      ellipse 78% 70% at 48% 72%,
+      rgb(var(--viddel-chat-halo-core) / 0.28) 0%,
+      rgb(var(--viddel-chat-halo-core) / 0.14) 40%,
+      transparent 78%
+    ),
+    radial-gradient(
+      ellipse 72% 66% at 60% 78%,
+      rgb(var(--viddel-chat-halo-accent) / 0.2) 0%,
+      rgb(var(--viddel-chat-halo-accent) / 0.1) 40%,
+      transparent 82%
+    );
+  bottom: 0;
 }
 
 @media (min-width: 640px) {

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -50,18 +50,33 @@ body.vox-shell--standalone-chat [data-viddel-chat] {
   --viddel-chat-compose-shadow: 48 82 120;
   --viddel-chat-halo-core: 158 214 248;
   --viddel-chat-halo-accent: 132 228 206;
-  --viddel-chat-compose-halo-height: clamp(8rem, 18vh, 14rem);
+  --viddel-chat-compose-halo-height: clamp(7rem, 13vh, 10.5rem);
   --viddel-chat-compose-halo-width: min(58rem, calc(100vw - 1rem));
 }
 
 body.vox-shell--standalone-chat {
+  --bg: var(--reading-paper);
   --orb-a: 0;
   --orb-b: 0;
   --orb-c: 0;
+  --surface: var(--reading-paper);
+  --surface-elevated: var(--reading-paper);
+  background: rgb(var(--reading-paper));
+}
+
+html:has(body.vox-shell--standalone-chat) {
+  background: rgb(var(--reading-paper));
 }
 
 body.vox-shell--standalone-chat .vox-sonic-blob {
-  opacity: 0.12;
+  opacity: 0;
+}
+
+body.vox-shell--standalone-chat .vox-shell-standalone-chat__stage,
+body.vox-shell--standalone-chat .viddel-chat-standalone,
+body.vox-shell--standalone-chat .r1-editorial-container,
+body.vox-shell--standalone-chat .viddel-chat-standalone__editorial {
+  background: rgb(var(--reading-paper));
 }
 
 /* --- Standalone idle start surface (seeds + composer) --- */
@@ -245,24 +260,24 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__seed-row 
 body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
   background:
     radial-gradient(
-      ellipse 82% 76% at 45% 70%,
-      rgb(var(--viddel-chat-halo-core) / 0.5) 0%,
-      rgb(var(--viddel-chat-halo-core) / 0.26) 38%,
-      transparent 78%
+      ellipse 82% 72% at 45% 55%,
+      rgb(var(--viddel-chat-halo-core) / 0.4) 0%,
+      rgb(var(--viddel-chat-halo-core) / 0.2) 38%,
+      transparent 80%
     ),
     radial-gradient(
-      ellipse 76% 72% at 62% 78%,
-      rgb(var(--viddel-chat-halo-accent) / 0.36) 0%,
-      rgb(var(--viddel-chat-halo-accent) / 0.18) 40%,
+      ellipse 76% 70% at 62% 62%,
+      rgb(var(--viddel-chat-halo-accent) / 0.3) 0%,
+      rgb(var(--viddel-chat-halo-accent) / 0.14) 40%,
       transparent 80%
     ),
     linear-gradient(
       to top,
-      rgb(var(--viddel-chat-halo-core) / 0.06) 0%,
-      rgb(var(--viddel-chat-halo-accent) / 0.025) 30%,
-      transparent 68%
+      rgb(var(--viddel-chat-halo-core) / 0.035) 0%,
+      rgb(var(--viddel-chat-halo-accent) / 0.015) 28%,
+      transparent 66%
     );
-  bottom: -0.35rem;
+  bottom: -3rem;
   content: "";
   height: var(--viddel-chat-compose-halo-height);
   left: 50%;
@@ -324,7 +339,7 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-s
 body.vox-shell--standalone-chat
   .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="active"]
   .inline-chat-shell__compose-stack {
-  bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
+  bottom: max(2.75rem, calc(env(safe-area-inset-bottom, 0px) + 1rem));
 }
 
 .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="active"] .inline-chat-shell__compose-stack .inline-chat-shell__status--dock {
@@ -342,24 +357,28 @@ body.vox-shell--standalone-chat
     0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.18);
   margin-top: 0;
   max-width: none;
-  padding: 0.52rem 0.58rem 0.52rem 0.68rem;
+  min-height: 3.4rem;
+  padding: 0.5rem 0.58rem;
   position: static;
+  transition: border-radius 160ms ease;
   transform: none;
   width: 100%;
   z-index: auto;
 }
 
 .inline-chat-shell[data-inline-chat-mode="progressive"] .inline-chat-shell__compose-send {
-  box-shadow: 0 2px 10px rgb(15 23 42 / 0.2);
-  font-size: 1.02rem;
+  align-self: center;
+  box-shadow: 0 4px 16px rgb(var(--viddel-chat-compose-shadow) / 0.24);
+  flex-shrink: 0;
+  font-size: 1.05rem;
   font-weight: 700;
-  height: 2.68rem;
-  min-height: 2.68rem;
-  width: 2.68rem;
+  height: 2.85rem;
+  min-height: 2.85rem;
+  width: 2.85rem;
 }
 
 .inline-chat-shell__compose {
-  align-items: flex-end;
+  align-items: center;
   background: rgb(var(--viddel-chat-compose-surface));
   border: 0;
   border-radius: 999px;
@@ -367,12 +386,14 @@ body.vox-shell--standalone-chat
     0 22px 52px -14px rgb(var(--viddel-chat-compose-shadow) / 0.28),
     0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.16);
   display: grid;
-  gap: 0.55rem;
+  gap: 0.5rem;
   grid-template-columns: minmax(0, 1fr) auto;
   margin-top: 1rem;
   max-width: 36rem;
-  padding: 0.52rem 0.58rem 0.52rem 0.68rem;
+  min-height: 3.4rem;
+  padding: 0.5rem 0.58rem;
   position: sticky;
+  transition: border-radius 160ms ease;
   bottom: max(0.75rem, env(safe-area-inset-bottom));
   z-index: 4;
 }
@@ -382,13 +403,13 @@ body.vox-shell--standalone-chat
   border: 0;
   color: rgb(var(--reading-ink));
   font: inherit;
-  font-size: 1rem;
+  font-size: 1.02rem;
   line-height: 1.4;
   max-height: min(9rem, 32vh);
-  min-height: 2.68rem;
+  min-height: 2.75rem;
   outline: 0;
   overflow-y: auto;
-  padding: 0.42rem 0.34rem;
+  padding: 0.58rem 0.15rem 0.58rem 0;
   resize: none;
   width: 100%;
 }
@@ -462,7 +483,42 @@ body.vox-shell--standalone-chat
   box-shadow:
     0 22px 52px -14px rgb(var(--viddel-chat-compose-shadow) / 0.28),
     0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.16);
-  padding: 0.52rem 0.58rem 0.52rem 0.68rem;
+  min-height: 3.4rem;
+  padding: 0.5rem 0.58rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .viddel-chat-attach__compose-row {
+  align-items: center;
+  gap: 0.5rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .viddel-chat-attach__attach {
+  align-self: center;
+  background: rgb(var(--surface-subtle) / 0.9);
+  height: 2.85rem;
+  min-height: 2.85rem;
+  width: 2.85rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .viddel-chat-attach__attach
+  svg {
+  height: 1.2rem;
+  width: 1.2rem;
 }
 
 body.vox-shell--standalone-chat
@@ -500,6 +556,73 @@ body.vox-shell--standalone-chat
   .inline-chat-shell[data-inline-chat-mode="progressive"]
   .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
   border-radius: 1.55rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden)),
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
+  align-items: flex-end;
+  border-radius: 1.65rem;
+  padding-bottom: 0.45rem;
+  padding-top: 0.45rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden))
+  .viddel-chat-attach__compose-row,
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded])
+  .viddel-chat-attach__compose-row {
+  align-items: flex-end;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden))
+  .viddel-chat-attach__attach,
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded])
+  .viddel-chat-attach__attach,
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden))
+  .inline-chat-shell__compose-send,
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded])
+  .inline-chat-shell__compose-send {
+  align-self: flex-end;
+  margin-bottom: 0.08rem;
 }
 
 body.vox-shell--standalone-chat
@@ -667,33 +790,40 @@ body.vox-shell--standalone-chat
       0 12px 34px -12px rgb(var(--viddel-chat-compose-shadow) / 0.24);
     margin-top: 0;
     max-width: none;
-    padding: 0.52rem 0.58rem 0.52rem 0.68rem;
+    min-height: 3.4rem;
+    padding: 0.5rem 0.58rem;
     position: static;
     width: 100%;
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] {
-    --viddel-chat-compose-halo-height: clamp(6.25rem, 14vh, 9rem);
+    --viddel-chat-compose-halo-height: clamp(6rem, 12vh, 8rem);
     --viddel-chat-compose-halo-width: min(34rem, calc(100vw + 3rem));
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
-    bottom: 0;
+    bottom: -2.25rem;
     background:
       radial-gradient(
-        ellipse 76% 72% at 44% 74%,
-        rgb(var(--viddel-chat-halo-core) / 0.5) 0%,
-        rgb(var(--viddel-chat-halo-core) / 0.28) 38%,
+        ellipse 76% 68% at 44% 55%,
+        rgb(var(--viddel-chat-halo-core) / 0.42) 0%,
+        rgb(var(--viddel-chat-halo-core) / 0.22) 38%,
         transparent 80%
       ),
       radial-gradient(
-        ellipse 70% 70% at 62% 80%,
-        rgb(var(--viddel-chat-halo-accent) / 0.36) 0%,
-        rgb(var(--viddel-chat-halo-accent) / 0.18) 40%,
+        ellipse 70% 68% at 62% 62%,
+        rgb(var(--viddel-chat-halo-accent) / 0.3) 0%,
+        rgb(var(--viddel-chat-halo-accent) / 0.15) 40%,
         transparent 82%
       );
     mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
     -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
+  }
+
+  body.vox-shell--standalone-chat
+    .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="active"]
+    .inline-chat-shell__compose-stack {
+    bottom: max(1rem, calc(env(safe-area-inset-bottom, 0px) + 0.75rem));
   }
 
 }

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -507,7 +507,7 @@ body.vox-shell--standalone-chat
 
 [data-viddel-chat] .viddel-chat-attach__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden)),
 [data-viddel-chat] .viddel-chat-attach__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
-  border-radius: 1.65rem;
+  border-radius: 1.65rem !important;
 }
 
 body.vox-shell--standalone-chat
@@ -609,7 +609,7 @@ body.vox-shell--standalone-chat
   .r1-ai-bridge
   .inline-chat-shell[data-inline-chat-mode="progressive"]
   .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
-  border-radius: 1.65rem;
+  border-radius: 1.65rem !important;
 }
 
 body.vox-shell--standalone-chat
@@ -625,7 +625,7 @@ body.vox-shell--standalone-chat
   .inline-chat-shell[data-inline-chat-mode="progressive"]
   .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
   align-items: flex-end;
-  border-radius: 1.65rem;
+  border-radius: 1.65rem !important;
   padding-bottom: 0.45rem;
   padding-top: 0.45rem;
 }
@@ -850,6 +850,29 @@ body.vox-shell--standalone-chat
     padding: 0.5rem 0.58rem;
     position: static;
     width: 100%;
+  }
+
+  body.vox-shell--standalone-chat
+    .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="idle"]
+    .viddel-chat-start__surface
+    .inline-chat-shell__compose-stack
+    .inline-chat-shell__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden)),
+  body.vox-shell--standalone-chat
+    .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="idle"]
+    .viddel-chat-start__surface
+    .inline-chat-shell__compose-stack
+    .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
+    border-radius: 1.65rem !important;
+  }
+
+  body.vox-shell--standalone-chat
+    .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="idle"]
+    .viddel-chat-start__surface
+    .inline-chat-shell__compose-stack
+    .inline-chat-shell__compose
+    .inline-chat-shell__compose-input[data-chat-input-expanded] {
+    max-height: min(9rem, 32vh);
+    overflow-y: auto;
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] {

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -50,7 +50,7 @@ body.vox-shell--standalone-chat [data-viddel-chat] {
   --viddel-chat-compose-shadow: 48 82 120;
   --viddel-chat-halo-core: 158 214 248;
   --viddel-chat-halo-accent: 132 228 206;
-  --viddel-chat-compose-halo-height: clamp(8rem, 14vh, 11.5rem);
+  --viddel-chat-compose-halo-height: clamp(10rem, 17vh, 14rem);
   --viddel-chat-compose-halo-width: min(58rem, calc(100vw - 1rem));
   --viddel-chat-user-bubble-surface: 238 243 248;
 }
@@ -274,7 +274,7 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-s
       rgb(var(--viddel-chat-halo-accent) / 0.045) 66%,
       transparent 94%
     );
-  bottom: -3rem;
+  bottom: -5rem;
   content: "";
   height: var(--viddel-chat-compose-halo-height);
   left: 50%;
@@ -351,8 +351,9 @@ body.vox-shell--standalone-chat
   border-radius: 999px;
   bottom: auto;
   box-shadow:
-    0 22px 52px -14px rgb(var(--viddel-chat-compose-shadow) / 0.3),
-    0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.18);
+    0 28px 72px -16px rgb(var(--viddel-chat-compose-shadow) / 0.42),
+    0 12px 34px -12px rgb(var(--viddel-chat-compose-shadow) / 0.26),
+    0 1px 0 rgb(255 255 255 / 0.92) inset;
   margin-top: 0;
   max-width: none;
   min-height: 3.4rem;
@@ -483,10 +484,23 @@ body.vox-shell--standalone-chat
   box-shadow:
     0 22px 52px -14px rgb(var(--viddel-chat-compose-shadow) / 0.28),
     0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.16);
-  clip-path: inset(0 round 999px);
   min-height: 3.4rem;
   overflow: hidden;
   padding: 0.5rem 0.58rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="active"]
+  .inline-chat-shell__compose-stack
+  .inline-chat-shell__compose {
+  background: rgb(var(--viddel-chat-compose-surface));
+  box-shadow:
+    0 28px 72px -16px rgb(var(--viddel-chat-compose-shadow) / 0.42),
+    0 12px 34px -12px rgb(var(--viddel-chat-compose-shadow) / 0.26),
+    0 1px 0 rgb(255 255 255 / 0.92) inset;
 }
 
 body.vox-shell--standalone-chat
@@ -574,7 +588,6 @@ body.vox-shell--standalone-chat
   .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
   align-items: flex-end;
   border-radius: 1.65rem;
-  clip-path: inset(0 round 1.65rem);
   padding-bottom: 0.45rem;
   padding-top: 0.45rem;
 }
@@ -635,9 +648,10 @@ body.vox-shell--standalone-chat
   [data-inline-chat-mode="progressive"]
   .inline-chat-shell__message--user {
   background: rgb(var(--viddel-chat-user-bubble-surface));
-  border: 1px solid rgb(148 163 184 / 0.32);
+  border: 0;
+  border-radius: 999px;
   box-shadow:
-    0 14px 30px -22px rgb(var(--viddel-chat-compose-shadow) / 0.28),
+    0 14px 30px -24px rgb(var(--viddel-chat-compose-shadow) / 0.24),
     0 1px 0 rgb(255 255 255 / 0.9) inset;
 }
 
@@ -794,7 +808,6 @@ body.vox-shell--standalone-chat
     margin-top: 0;
     max-width: none;
     min-height: 3.4rem;
-    clip-path: inset(0 round 999px);
     overflow: hidden;
     padding: 0.5rem 0.58rem;
     position: static;
@@ -802,12 +815,12 @@ body.vox-shell--standalone-chat
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] {
-    --viddel-chat-compose-halo-height: clamp(7rem, 13vh, 9rem);
+    --viddel-chat-compose-halo-height: clamp(8rem, 15vh, 11rem);
     --viddel-chat-compose-halo-width: min(34rem, calc(100vw + 3rem));
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
-    bottom: -2.25rem;
+    bottom: -4rem;
     background:
       radial-gradient(
         ellipse 82% 72% at 44% 58%,

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -50,7 +50,8 @@ body.vox-shell--standalone-chat [data-viddel-chat] {
   --viddel-chat-compose-shadow: 48 82 120;
   --viddel-chat-halo-core: 158 214 248;
   --viddel-chat-halo-accent: 132 228 206;
-  --viddel-chat-compose-halo-height: clamp(10rem, 17vh, 14rem);
+  --viddel-chat-compose-halo-height: clamp(8rem, 14vh, 11.5rem);
+  --viddel-chat-compose-halo-overscan: 4rem;
   --viddel-chat-compose-halo-width: min(58rem, calc(100vw - 1rem));
   --viddel-chat-user-bubble-surface: 238 243 248;
 }
@@ -274,9 +275,12 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-s
       rgb(var(--viddel-chat-halo-accent) / 0.045) 66%,
       transparent 94%
     );
-  bottom: -5rem;
+  background-position: center top;
+  background-repeat: no-repeat;
+  background-size: 100% var(--viddel-chat-compose-halo-height);
+  bottom: calc(-3rem - var(--viddel-chat-compose-halo-overscan, 0rem));
   content: "";
-  height: var(--viddel-chat-compose-halo-height);
+  height: calc(var(--viddel-chat-compose-halo-height) + var(--viddel-chat-compose-halo-overscan, 0rem));
   left: 50%;
   mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
   opacity: 0.96;
@@ -815,12 +819,13 @@ body.vox-shell--standalone-chat
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] {
-    --viddel-chat-compose-halo-height: clamp(8rem, 15vh, 11rem);
+    --viddel-chat-compose-halo-height: clamp(7rem, 13vh, 9rem);
+    --viddel-chat-compose-halo-overscan: 3rem;
     --viddel-chat-compose-halo-width: min(34rem, calc(100vw + 3rem));
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
-    bottom: -4rem;
+    bottom: calc(-2.25rem - var(--viddel-chat-compose-halo-overscan, 0rem));
     background:
       radial-gradient(
         ellipse 82% 72% at 44% 58%,
@@ -881,6 +886,7 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] .inline-chat-shell__dia
 
 body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-chat] {
   --viddel-chat-compose-halo-height: clamp(6.25rem, 12vh, 9rem);
+  --viddel-chat-compose-halo-overscan: 0rem;
   --viddel-chat-compose-halo-width: min(42rem, calc(100vw - 2rem));
 }
 

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -52,7 +52,7 @@ body.vox-shell--standalone-chat [data-viddel-chat] {
   --viddel-chat-halo-accent: 132 228 206;
   --viddel-chat-compose-halo-height: clamp(8rem, 14vh, 11.5rem);
   --viddel-chat-compose-halo-width: min(58rem, calc(100vw - 1rem));
-  --viddel-chat-user-bubble-surface: 245 248 251;
+  --viddel-chat-user-bubble-surface: 238 243 248;
 }
 
 body.vox-shell--standalone-chat {
@@ -261,30 +261,25 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__seed-row 
 body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
   background:
     radial-gradient(
-      ellipse 82% 72% at 45% 55%,
+      ellipse 86% 76% at 45% 58%,
       rgb(var(--viddel-chat-halo-core) / 0.4) 0%,
       rgb(var(--viddel-chat-halo-core) / 0.19) 34%,
       rgb(var(--viddel-chat-halo-core) / 0.055) 64%,
       transparent 92%
     ),
     radial-gradient(
-      ellipse 76% 70% at 62% 62%,
+      ellipse 80% 74% at 62% 64%,
       rgb(var(--viddel-chat-halo-accent) / 0.3) 0%,
       rgb(var(--viddel-chat-halo-accent) / 0.13) 36%,
       rgb(var(--viddel-chat-halo-accent) / 0.045) 66%,
       transparent 94%
-    ),
-    linear-gradient(
-      to top,
-      rgb(var(--viddel-chat-halo-core) / 0.035) 0%,
-      rgb(var(--viddel-chat-halo-accent) / 0.012) 26%,
-      transparent 82%
     );
   bottom: -3rem;
   content: "";
   height: var(--viddel-chat-compose-halo-height);
   left: 50%;
   mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
+  opacity: 0.96;
   pointer-events: none;
   position: absolute;
   transform: translateX(-50%);
@@ -361,6 +356,7 @@ body.vox-shell--standalone-chat
   margin-top: 0;
   max-width: none;
   min-height: 3.4rem;
+  overflow: hidden;
   padding: 0.5rem 0.58rem;
   position: static;
   transition: border-radius 160ms ease;
@@ -394,6 +390,7 @@ body.vox-shell--standalone-chat
   margin-top: 1rem;
   max-width: 36rem;
   min-height: 3.4rem;
+  overflow: hidden;
   padding: 0.5rem 0.58rem;
   position: sticky;
   transition: border-radius 160ms ease;
@@ -486,7 +483,9 @@ body.vox-shell--standalone-chat
   box-shadow:
     0 22px 52px -14px rgb(var(--viddel-chat-compose-shadow) / 0.28),
     0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.16);
+  clip-path: inset(0 round 999px);
   min-height: 3.4rem;
+  overflow: hidden;
   padding: 0.5rem 0.58rem;
 }
 
@@ -575,6 +574,7 @@ body.vox-shell--standalone-chat
   .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
   align-items: flex-end;
   border-radius: 1.65rem;
+  clip-path: inset(0 round 1.65rem);
   padding-bottom: 0.45rem;
   padding-top: 0.45rem;
 }
@@ -634,10 +634,10 @@ body.vox-shell--standalone-chat
   .r1-ai-bridge
   [data-inline-chat-mode="progressive"]
   .inline-chat-shell__message--user {
-  background: rgb(var(--viddel-chat-user-bubble-surface) / 0.98);
-  border: 1px solid rgb(203 213 225 / 0.52);
+  background: rgb(var(--viddel-chat-user-bubble-surface));
+  border: 1px solid rgb(148 163 184 / 0.32);
   box-shadow:
-    0 12px 28px -22px rgb(var(--viddel-chat-compose-shadow) / 0.22),
+    0 14px 30px -22px rgb(var(--viddel-chat-compose-shadow) / 0.28),
     0 1px 0 rgb(255 255 255 / 0.9) inset;
 }
 
@@ -794,6 +794,8 @@ body.vox-shell--standalone-chat
     margin-top: 0;
     max-width: none;
     min-height: 3.4rem;
+    clip-path: inset(0 round 999px);
+    overflow: hidden;
     padding: 0.5rem 0.58rem;
     position: static;
     width: 100%;
@@ -808,14 +810,14 @@ body.vox-shell--standalone-chat
     bottom: -2.25rem;
     background:
       radial-gradient(
-        ellipse 76% 68% at 44% 55%,
+        ellipse 82% 72% at 44% 58%,
         rgb(var(--viddel-chat-halo-core) / 0.42) 0%,
         rgb(var(--viddel-chat-halo-core) / 0.2) 34%,
         rgb(var(--viddel-chat-halo-core) / 0.055) 64%,
         transparent 92%
       ),
       radial-gradient(
-        ellipse 70% 68% at 62% 62%,
+        ellipse 76% 72% at 62% 64%,
         rgb(var(--viddel-chat-halo-accent) / 0.3) 0%,
         rgb(var(--viddel-chat-halo-accent) / 0.13) 36%,
         rgb(var(--viddel-chat-halo-accent) / 0.045) 66%,
@@ -872,14 +874,14 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-chat] {
 body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-chat] .inline-chat-shell__compose-stack::before {
   background:
     radial-gradient(
-      ellipse 78% 70% at 48% 72%,
+      ellipse 82% 74% at 48% 70%,
       rgb(var(--viddel-chat-halo-core) / 0.28) 0%,
       rgb(var(--viddel-chat-halo-core) / 0.12) 36%,
       rgb(var(--viddel-chat-halo-core) / 0.035) 66%,
       transparent 92%
     ),
     radial-gradient(
-      ellipse 72% 66% at 60% 78%,
+      ellipse 76% 72% at 60% 74%,
       rgb(var(--viddel-chat-halo-accent) / 0.2) 0%,
       rgb(var(--viddel-chat-halo-accent) / 0.085) 36%,
       rgb(var(--viddel-chat-halo-accent) / 0.028) 68%,

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -45,6 +45,15 @@ body.vox-shell--standalone-chat #ces-widget {
   color: rgb(var(--text));
 }
 
+body.vox-shell--standalone-chat [data-viddel-chat] {
+  --viddel-chat-compose-surface: 255 255 255;
+  --viddel-chat-compose-shadow: 48 82 120;
+  --viddel-chat-halo-core: 158 214 248;
+  --viddel-chat-halo-accent: 132 228 206;
+  --viddel-chat-compose-halo-height: clamp(7rem, 14vh, 11rem);
+  --viddel-chat-compose-halo-width: min(52rem, calc(100vw - 2rem));
+}
+
 /* --- Standalone idle start surface (seeds + composer) --- */
 
 body.vox-shell--standalone-chat:not([data-viddel-chat-active]) [data-viddel-chat] .viddel-chat-standalone__editorial {
@@ -209,10 +218,45 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__seed-row 
   flex-direction: column;
   gap: 0.35rem;
   box-sizing: border-box;
+  isolation: isolate;
   margin-left: auto;
   margin-right: auto;
   max-width: min(100%, var(--r1-ai-dialog-measure, min(100%, 46rem)));
+  position: relative;
   width: 100%;
+}
+
+body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
+  background:
+    radial-gradient(
+      ellipse 80% 78% at 46% 72%,
+      rgb(var(--viddel-chat-halo-core) / 0.46) 0%,
+      rgb(var(--viddel-chat-halo-core) / 0.24) 38%,
+      transparent 78%
+    ),
+    radial-gradient(
+      ellipse 72% 74% at 60% 78%,
+      rgb(var(--viddel-chat-halo-accent) / 0.32) 0%,
+      rgb(var(--viddel-chat-halo-accent) / 0.16) 38%,
+      transparent 80%
+    ),
+    linear-gradient(
+      to top,
+      rgb(var(--viddel-chat-halo-core) / 0.08) 0%,
+      rgb(var(--viddel-chat-halo-accent) / 0.035) 34%,
+      transparent 72%
+    );
+  bottom: -1.65rem;
+  content: "";
+  height: var(--viddel-chat-compose-halo-height);
+  left: 50%;
+  mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
+  pointer-events: none;
+  position: absolute;
+  transform: translateX(-50%);
+  width: var(--viddel-chat-compose-halo-width);
+  z-index: -1;
+  -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
 }
 
 .inline-chat-shell[data-inline-chat-mode="progressive"]:not([data-inline-chat-conversation="active"]) .inline-chat-shell__compose {
@@ -243,17 +287,17 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__seed-row 
 }
 
 .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="active"] .inline-chat-shell__compose-stack {
-  background: rgb(var(--surface) / 0.98);
-  border: 1px solid rgb(var(--border) / 0.44);
-  border-radius: 1.12rem;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
   bottom: calc(max(0.75rem, env(safe-area-inset-bottom, 0px)) + 40px);
-  box-shadow: 0 14px 38px -10px rgb(15 23 42 / 0.16), 0 4px 14px -6px rgb(15 23 42 / 0.08);
+  box-shadow: none;
   box-sizing: border-box;
   gap: 0;
   left: 50%;
   margin: 0;
   max-width: min(var(--r1-ai-dialog-measure, min(100%, 46rem)), calc(100vw - 1.5rem));
-  padding: 0.42rem 0.58rem 0.55rem;
+  padding: 0 0.15rem;
   position: fixed;
   transform: translateX(-50%);
   width: min(var(--r1-ai-dialog-measure, min(100%, 46rem)), calc(100vw - 1.5rem));
@@ -273,14 +317,16 @@ body.vox-shell--standalone-chat
 }
 
 .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="active"] .inline-chat-shell__compose-stack .inline-chat-shell__compose {
-  background: transparent;
+  background: rgb(var(--viddel-chat-compose-surface));
   border: 0;
-  border-radius: 0.85rem;
+  border-radius: 999px;
   bottom: auto;
-  box-shadow: none;
+  box-shadow:
+    0 22px 52px -14px rgb(var(--viddel-chat-compose-shadow) / 0.3),
+    0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.18);
   margin-top: 0;
   max-width: none;
-  padding: 0.35rem 0.28rem 0.28rem;
+  padding: 0.52rem 0.58rem 0.52rem 0.68rem;
   position: static;
   transform: none;
   width: 100%;
@@ -298,16 +344,18 @@ body.vox-shell--standalone-chat
 
 .inline-chat-shell__compose {
   align-items: flex-end;
-  background: rgb(var(--surface) / 0.97);
-  border: 1px solid rgb(var(--border) / 0.5);
-  border-radius: 1.15rem;
-  box-shadow: 0 16px 42px rgb(15 23 42 / 0.12);
+  background: rgb(var(--viddel-chat-compose-surface));
+  border: 0;
+  border-radius: 999px;
+  box-shadow:
+    0 22px 52px -14px rgb(var(--viddel-chat-compose-shadow) / 0.28),
+    0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.16);
   display: grid;
   gap: 0.55rem;
   grid-template-columns: minmax(0, 1fr) auto;
   margin-top: 1rem;
   max-width: 36rem;
-  padding: 0.58rem;
+  padding: 0.52rem 0.58rem 0.52rem 0.68rem;
   position: sticky;
   bottom: max(0.75rem, env(safe-area-inset-bottom));
   z-index: 4;
@@ -318,10 +366,10 @@ body.vox-shell--standalone-chat
   border: 0;
   color: rgb(var(--reading-ink));
   font: inherit;
-  font-size: 0.95rem;
-  line-height: 1.45;
+  font-size: 1rem;
+  line-height: 1.4;
   max-height: min(9rem, 32vh);
-  min-height: 2.35rem;
+  min-height: 2.68rem;
   outline: 0;
   overflow-y: auto;
   padding: 0.42rem 0.34rem;
@@ -376,8 +424,55 @@ body.vox-shell--standalone-chat
 }
 
 .inline-chat-shell__compose:focus-within {
-  border-color: rgb(var(--reading-accent-iris) / 0.46);
-  box-shadow: 0 18px 46px rgb(15 23 42 / 0.14);
+  box-shadow:
+    0 24px 56px -14px rgb(var(--viddel-chat-compose-shadow) / 0.34),
+    0 10px 28px -10px rgb(var(--viddel-chat-compose-shadow) / 0.2);
+}
+
+[data-viddel-chat] .viddel-chat-attach__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden)),
+[data-viddel-chat] .viddel-chat-attach__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
+  border-radius: 1.55rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose {
+  background: rgb(var(--viddel-chat-compose-surface));
+  border: 0;
+  border-radius: 999px;
+  box-shadow:
+    0 22px 52px -14px rgb(var(--viddel-chat-compose-shadow) / 0.28),
+    0 8px 24px -10px rgb(var(--viddel-chat-compose-shadow) / 0.16);
+  padding: 0.52rem 0.58rem 0.52rem 0.68rem;
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:focus-within {
+  box-shadow:
+    0 24px 56px -14px rgb(var(--viddel-chat-compose-shadow) / 0.34),
+    0 10px 28px -10px rgb(var(--viddel-chat-compose-shadow) / 0.2);
+}
+
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden)),
+body.vox-shell--standalone-chat
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
+  border-radius: 1.55rem;
 }
 
 .inline-chat-shell__turn {
@@ -429,10 +524,10 @@ body.vox-shell--standalone-chat
     box-sizing: border-box;
     left: 50%;
     margin: 0;
-    max-width: min(var(--r1-ai-dialog-measure, min(100%, 46rem)), calc(100vw - 1.5rem));
+    max-width: none;
     position: fixed;
     transform: translateX(-50%);
-    width: min(var(--r1-ai-dialog-measure, min(100%, 46rem)), calc(100vw - 1.5rem));
+    width: calc(100vw - 2rem);
     z-index: 24;
   }
 
@@ -469,15 +564,15 @@ body.vox-shell--standalone-chat
   body.vox-shell--standalone-chat
     .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="idle"]
     .viddel-chat-start__surface {
-    background: rgb(var(--surface) / 0.98);
-    border: 1px solid rgb(var(--border) / 0.44);
-    border-radius: 1.12rem;
-    box-shadow: 0 14px 38px -10px rgb(15 23 42 / 0.16), 0 4px 14px -6px rgb(15 23 42 / 0.08);
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
     box-sizing: border-box;
     gap: 0.42rem;
     margin: 0;
     max-width: none;
-    padding: 0.5rem 0.58rem 0.55rem;
+    padding: 0;
     position: static;
     transform: none;
     width: 100%;
@@ -514,16 +609,43 @@ body.vox-shell--standalone-chat
     .viddel-chat-start__surface
     .inline-chat-shell__compose-stack
     .inline-chat-shell__compose {
-    background: transparent;
+    background: rgb(var(--viddel-chat-compose-surface));
     border: 0;
-    border-radius: 0.85rem;
-    box-shadow: none;
+    border-radius: 999px;
+    box-shadow:
+      0 26px 70px -16px rgb(var(--viddel-chat-compose-shadow) / 0.38),
+      0 12px 34px -12px rgb(var(--viddel-chat-compose-shadow) / 0.24);
     margin-top: 0;
     max-width: none;
-    padding: 0.35rem 0.28rem 0.28rem;
+    padding: 0.52rem 0.58rem 0.52rem 0.68rem;
     position: static;
     width: 100%;
   }
+
+  body.vox-shell--standalone-chat [data-viddel-chat] {
+    --viddel-chat-compose-halo-height: clamp(6.25rem, 14vh, 9rem);
+    --viddel-chat-compose-halo-width: min(34rem, calc(100vw + 3rem));
+  }
+
+  body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-stack::before {
+    bottom: -1.15rem;
+    background:
+      radial-gradient(
+        ellipse 76% 72% at 44% 74%,
+        rgb(var(--viddel-chat-halo-core) / 0.5) 0%,
+        rgb(var(--viddel-chat-halo-core) / 0.28) 38%,
+        transparent 80%
+      ),
+      radial-gradient(
+        ellipse 70% 70% at 62% 80%,
+        rgb(var(--viddel-chat-halo-accent) / 0.36) 0%,
+        rgb(var(--viddel-chat-halo-accent) / 0.18) 40%,
+        transparent 82%
+      );
+    mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
+    -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
+  }
+
 }
 
 /* --- Standalone active: internal transcript scroll (ChatGPT primary) --- */
@@ -560,5 +682,21 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] .inline-chat-shell__dia
 @media (min-width: 640px) {
   body.vox-shell--standalone-chat .vox-shell-standalone-chat__stage {
     max-width: min(100%, 46rem);
+  }
+}
+
+@media (max-width: 639px) {
+  body.vox-shell--standalone-chat
+    [data-viddel-chat]
+    .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="idle"]
+    .viddel-chat-start,
+  body.vox-shell--standalone-chat
+    [data-viddel-chat]
+    .inline-chat-shell[data-inline-chat-mode="progressive"][data-inline-chat-conversation="active"]
+    .inline-chat-shell__compose-stack {
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    width: calc(100vw - 2rem) !important;
   }
 }

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -292,17 +292,38 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-s
   -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
 }
 
-body.vox-shell--standalone-chat:not([data-viddel-chat-active])
-  [data-viddel-chat]
-  .inline-chat-shell__compose-stack::before {
-  mask-composite: intersect;
-  mask-image:
-    linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%),
-    linear-gradient(180deg, black 0%, black 58%, transparent 100%);
-  -webkit-mask-composite: source-in;
-  -webkit-mask-image:
-    linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%),
-    linear-gradient(180deg, black 0%, black 58%, transparent 100%);
+@media (min-width: 640px) {
+  body.vox-shell--standalone-chat:not([data-viddel-chat-active])
+    [data-viddel-chat]
+    .inline-chat-shell__compose-stack::before {
+    background:
+      radial-gradient(
+        ellipse 86% 76% at 45% 18%,
+        rgb(var(--viddel-chat-halo-core) / 0.4) 0%,
+        rgb(var(--viddel-chat-halo-core) / 0.19) 34%,
+        rgb(var(--viddel-chat-halo-core) / 0.055) 64%,
+        transparent 92%
+      ),
+      radial-gradient(
+        ellipse 80% 74% at 62% 21%,
+        rgb(var(--viddel-chat-halo-accent) / 0.3) 0%,
+        rgb(var(--viddel-chat-halo-accent) / 0.13) 36%,
+        rgb(var(--viddel-chat-halo-accent) / 0.045) 66%,
+        transparent 94%
+      );
+    background-size: 100% 100%;
+    bottom: auto;
+    height: clamp(24rem, 48vh, 34rem);
+    mask-composite: intersect;
+    mask-image:
+      linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%),
+      linear-gradient(180deg, transparent 0%, black 6%, black 44%, transparent 80%);
+    top: -1.25rem;
+    -webkit-mask-composite: source-in;
+    -webkit-mask-image:
+      linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%),
+      linear-gradient(180deg, transparent 0%, black 6%, black 44%, transparent 80%);
+  }
 }
 
 .inline-chat-shell[data-inline-chat-mode="progressive"]:not([data-inline-chat-conversation="active"]) .inline-chat-shell__compose {

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -292,6 +292,19 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-s
   -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%);
 }
 
+body.vox-shell--standalone-chat:not([data-viddel-chat-active])
+  [data-viddel-chat]
+  .inline-chat-shell__compose-stack::before {
+  mask-composite: intersect;
+  mask-image:
+    linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%),
+    linear-gradient(180deg, black 0%, black 58%, transparent 100%);
+  -webkit-mask-composite: source-in;
+  -webkit-mask-image:
+    linear-gradient(90deg, transparent 0%, black 12%, black 88%, transparent 100%),
+    linear-gradient(180deg, black 0%, black 58%, transparent 100%);
+}
+
 .inline-chat-shell[data-inline-chat-mode="progressive"]:not([data-inline-chat-conversation="active"]) .inline-chat-shell__compose {
   bottom: auto;
   box-sizing: border-box;

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -527,6 +527,27 @@ body.vox-shell--standalone-chat
   padding: 0.5rem 0.58rem;
 }
 
+body.vox-shell--standalone-chat:not([data-viddel-chat-active])
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose {
+  min-height: 4.25rem;
+  padding: 0.68rem 0.72rem;
+}
+
+body.vox-shell--standalone-chat:not([data-viddel-chat-active])
+  [data-viddel-chat]
+  [data-r1-editorial]
+  .r1-ai-bridge
+  .inline-chat-shell[data-inline-chat-mode="progressive"]
+  .inline-chat-shell__compose-input {
+  min-height: 2.85rem;
+  padding-bottom: 0.62rem;
+  padding-top: 0.62rem;
+}
+
 body.vox-shell--standalone-chat
   [data-viddel-chat]
   [data-r1-editorial]

--- a/src/styles/viddel-standalone-chat.css
+++ b/src/styles/viddel-standalone-chat.css
@@ -50,8 +50,9 @@ body.vox-shell--standalone-chat [data-viddel-chat] {
   --viddel-chat-compose-shadow: 48 82 120;
   --viddel-chat-halo-core: 158 214 248;
   --viddel-chat-halo-accent: 132 228 206;
-  --viddel-chat-compose-halo-height: clamp(7rem, 13vh, 10.5rem);
+  --viddel-chat-compose-halo-height: clamp(8rem, 14vh, 11.5rem);
   --viddel-chat-compose-halo-width: min(58rem, calc(100vw - 1rem));
+  --viddel-chat-user-bubble-surface: 245 248 251;
 }
 
 body.vox-shell--standalone-chat {
@@ -262,20 +263,22 @@ body.vox-shell--standalone-chat [data-viddel-chat] .inline-chat-shell__compose-s
     radial-gradient(
       ellipse 82% 72% at 45% 55%,
       rgb(var(--viddel-chat-halo-core) / 0.4) 0%,
-      rgb(var(--viddel-chat-halo-core) / 0.2) 38%,
-      transparent 80%
+      rgb(var(--viddel-chat-halo-core) / 0.19) 34%,
+      rgb(var(--viddel-chat-halo-core) / 0.055) 64%,
+      transparent 92%
     ),
     radial-gradient(
       ellipse 76% 70% at 62% 62%,
       rgb(var(--viddel-chat-halo-accent) / 0.3) 0%,
-      rgb(var(--viddel-chat-halo-accent) / 0.14) 40%,
-      transparent 80%
+      rgb(var(--viddel-chat-halo-accent) / 0.13) 36%,
+      rgb(var(--viddel-chat-halo-accent) / 0.045) 66%,
+      transparent 94%
     ),
     linear-gradient(
       to top,
       rgb(var(--viddel-chat-halo-core) / 0.035) 0%,
-      rgb(var(--viddel-chat-halo-accent) / 0.015) 28%,
-      transparent 66%
+      rgb(var(--viddel-chat-halo-accent) / 0.012) 26%,
+      transparent 82%
     );
   bottom: -3rem;
   content: "";
@@ -468,7 +471,7 @@ body.vox-shell--standalone-chat
 
 [data-viddel-chat] .viddel-chat-attach__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden)),
 [data-viddel-chat] .viddel-chat-attach__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
-  border-radius: 1.55rem;
+  border-radius: 1.65rem;
 }
 
 body.vox-shell--standalone-chat
@@ -555,7 +558,7 @@ body.vox-shell--standalone-chat
   .r1-ai-bridge
   .inline-chat-shell[data-inline-chat-mode="progressive"]
   .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
-  border-radius: 1.55rem;
+  border-radius: 1.65rem;
 }
 
 body.vox-shell--standalone-chat
@@ -631,11 +634,11 @@ body.vox-shell--standalone-chat
   .r1-ai-bridge
   [data-inline-chat-mode="progressive"]
   .inline-chat-shell__message--user {
-  background: rgb(var(--viddel-chat-compose-surface) / 0.96);
-  border: 1px solid rgb(var(--border) / 0.32);
+  background: rgb(var(--viddel-chat-user-bubble-surface) / 0.98);
+  border: 1px solid rgb(203 213 225 / 0.52);
   box-shadow:
-    0 14px 34px -20px rgb(var(--viddel-chat-compose-shadow) / 0.36),
-    0 1px 0 rgb(255 255 255 / 0.82) inset;
+    0 12px 28px -22px rgb(var(--viddel-chat-compose-shadow) / 0.22),
+    0 1px 0 rgb(255 255 255 / 0.9) inset;
 }
 
 body.vox-shell--standalone-chat
@@ -797,7 +800,7 @@ body.vox-shell--standalone-chat
   }
 
   body.vox-shell--standalone-chat [data-viddel-chat] {
-    --viddel-chat-compose-halo-height: clamp(6rem, 12vh, 8rem);
+    --viddel-chat-compose-halo-height: clamp(7rem, 13vh, 9rem);
     --viddel-chat-compose-halo-width: min(34rem, calc(100vw + 3rem));
   }
 
@@ -807,14 +810,16 @@ body.vox-shell--standalone-chat
       radial-gradient(
         ellipse 76% 68% at 44% 55%,
         rgb(var(--viddel-chat-halo-core) / 0.42) 0%,
-        rgb(var(--viddel-chat-halo-core) / 0.22) 38%,
-        transparent 80%
+        rgb(var(--viddel-chat-halo-core) / 0.2) 34%,
+        rgb(var(--viddel-chat-halo-core) / 0.055) 64%,
+        transparent 92%
       ),
       radial-gradient(
         ellipse 70% 68% at 62% 62%,
         rgb(var(--viddel-chat-halo-accent) / 0.3) 0%,
-        rgb(var(--viddel-chat-halo-accent) / 0.15) 40%,
-        transparent 82%
+        rgb(var(--viddel-chat-halo-accent) / 0.13) 36%,
+        rgb(var(--viddel-chat-halo-accent) / 0.045) 66%,
+        transparent 94%
       );
     mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
     -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
@@ -860,7 +865,7 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] .inline-chat-shell__dia
 }
 
 body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-chat] {
-  --viddel-chat-compose-halo-height: clamp(5.5rem, 11vh, 8rem);
+  --viddel-chat-compose-halo-height: clamp(6.25rem, 12vh, 9rem);
   --viddel-chat-compose-halo-width: min(42rem, calc(100vw - 2rem));
 }
 
@@ -869,14 +874,16 @@ body.vox-shell--standalone-chat[data-viddel-chat-active] [data-viddel-chat] .inl
     radial-gradient(
       ellipse 78% 70% at 48% 72%,
       rgb(var(--viddel-chat-halo-core) / 0.28) 0%,
-      rgb(var(--viddel-chat-halo-core) / 0.14) 40%,
-      transparent 78%
+      rgb(var(--viddel-chat-halo-core) / 0.12) 36%,
+      rgb(var(--viddel-chat-halo-core) / 0.035) 66%,
+      transparent 92%
     ),
     radial-gradient(
       ellipse 72% 66% at 60% 78%,
       rgb(var(--viddel-chat-halo-accent) / 0.2) 0%,
-      rgb(var(--viddel-chat-halo-accent) / 0.1) 40%,
-      transparent 82%
+      rgb(var(--viddel-chat-halo-accent) / 0.085) 36%,
+      rgb(var(--viddel-chat-halo-accent) / 0.028) 68%,
+      transparent 94%
     );
   bottom: 0;
 }


### PR DESCRIPTION
## Summary\n- Tests the approved article composer visual family on standalone /no/chat.\n- Adds a scoped white pill composer, stronger shadow/contrast, and blue/green halo via standalone chat CSS.\n- Keeps the existing add-button and image/upload flow.\n\n## Scope\n- Standalone /no/chat composer styling only.\n- No article transition changes.\n- No API/backend/session changes.\n\n## Verification\n- npm run build\n- git diff --check\n- Browser smoke: /no/chat desktop idle, mobile idle, mobile active via submit, add-menu, /no/artikkel/ingen-lyd-svak-lyd regression\n\nCloses #259