### PR TITLE
Disable scheduled VIS runtime status commits

### DIFF
--- a/.github/workflows/github-runtime-status.yml
+++ b/.github/workflows/github-runtime-status.yml
@@ -1,11 +1,8 @@
-# CONTRACT: Periodisk oppdatering av GitHub runtime-status for @navigator (#107). Commiter markdown til repo; push trigger vanlig Pages-deploy.
+# CONTRACT: Manuell oppdatering av GitHub runtime-status for @navigator (#107). Commiter markdown til repo; push trigger vanlig Pages-deploy.
 name: GitHub runtime status (navigator)
 
 on:
   workflow_dispatch:
-  schedule:
-    # Hverdager ~07:00 Europe/Oslo (vinter: 06 UTC ≈ +1; justér ved behov)
-    - cron: "0 6 * * 1-5"
 
 permissions:
   contents: write


### PR DESCRIPTION
## What changed

- Removed the weekday `schedule` trigger from `.github/workflows/github-runtime-status.yml`.
- Kept `workflow_dispatch` so the runtime feed can still be refreshed manually.
- Updated the workflow contract comment to describe manual rather than periodic refresh.

## Why

The generator writes a new timestamp and rolling 24-hour window on every run. The weekday schedule therefore created a new bot commit and triggered a GitHub Pages deploy even when no meaningful project state had changed.

## What remains unchanged

- The VIS runtime generator remains available.
- Manual refresh remains available through GitHub Actions.
- The ordinary GitHub Pages deploy workflow still generates the feed before build when real code is pushed to `main`.
- No runtime, product UI or chat behavior changes.

## Follow-up

- #272 tracks a later, more precise event-driven refresh mechanism without timestamp-only commits.
- Related control issue: #224.

## Verification

- Inspected the branch version of `.github/workflows/github-runtime-status.yml`.
- Confirmed the only trigger is now `workflow_dispatch`.
- Confirmed the generate and conditional commit steps remain intact.
- YAML-only workflow change; no application build was run through the connector.