### PR TITLE
Add Viddel Concept Prototype v0.1

### DIFF
--- a/docs/preview/VIDDEL_CONCEPT_PROTOTYPE_V0_1.md
+++ b/docs/preview/VIDDEL_CONCEPT_PROTOTYPE_V0_1.md
@@ -1,0 +1,74 @@
+# Viddel Concept Prototype v0.1
+
+Status: Reviewklar prototype  
+Owner issue: #283  
+Route: `/preview/viddel-concept-v01/`
+
+## Formål
+
+Prototypen er et møteverktøy for første dialog med Hørselsforbundet Asker. Den skal gjøre helheten forståelig, invitere til korreksjon og undersøke om lokallaget ønsker å bidra til neste valideringssteg.
+
+## Sannhetskart
+
+| Del | Modenhet | Hva som er sant |
+| --- | --- | --- |
+| Artikkel og oppfølgingschat | Finnes i dag | Den faktiske artikkelruten kan åpnes fra første state. Dialogen i prototypen er et kontrollert eksempel. |
+| Mine sider og historikk | Konsept | Syntetisk frontend-state. Ingen profil, historikk eller preferanse lagres. |
+| Brukerstyrt oppsummering | Konsept | Interaktivt eksempel. Ingenting kopieres, sendes eller lagres. |
+| Medlemsinnsikt | Konsept | Alle tall og situasjoner er syntetiske. Det finnes ikke et reelt medlemsdatagrunnlag. |
+
+Konseptdelen skal alltid være merket:
+
+> Konseptprototype · syntetiske eksempeldata · ingen data lagres
+
+## Demonstrasjonsmanus — 6 minutter
+
+### 1. Hjelp nå
+
+«Vi starter med noe Viddel allerede gjør: Kari opplever svak lyd i ett apparat. Hun får to enkle sjekker og kan spørre videre når problemet ikke løser seg.»
+
+Vis neste handling og lenken til dagens faktiske artikkelreise.
+
+### 2. Fra hjelp til kontinuitet
+
+«I dag hjelper Viddel i øyeblikket. Nå går vi tydelig over i konseptet og undersøker hva som blir mulig dersom brukeren selv lar Viddel huske relevant informasjon.»
+
+Pek på tre verdier: slippe å gjenta, se sammenheng og ta informasjonen med videre.
+
+### 3. Mine sider
+
+«Kari har oppgitt apparat, erfaring og hvordan hun ønsker hjelp. Hun kan se og rette informasjonen. Historikken gjør at Viddel ikke trenger å starte på nytt hver gang.»
+
+Klikk mellom to historikkelementer for å vise kontinuiteten.
+
+### 4. Min oppsummering
+
+«Kari velger selv hva hun vil ta med til en pårørende, likeperson eller audiograf. Dette er et samtalegrunnlag, ikke en diagnose eller journal.»
+
+Fjern ett punkt og vis at valgt antall oppdateres. Trykk «Forhåndsvis deling» for å vise at prototypen ikke sender noe.
+
+### 5. Medlemsinnsikt
+
+«Når mange frivillige hjelpesituasjoner sees samlet på en trygg måte, kan lokallaget få et bedre bilde av hva medlemmene trenger hjelp med og hvilke aktiviteter som kan være relevante.»
+
+Presiser at alle tall er syntetiske og at framtidig databruk forutsetter tydelig brukernytte, frivillighet og samtykke.
+
+Avslutt med:
+
+«Hva opplever dere som mest nyttig for medlemmene, og hva bør vi forstå bedre før neste steg?»
+
+## Valideringsspørsmål
+
+1. Hva opplever dere som den viktigste nytten for medlemmene?
+2. Er noe i reisen uklart eller lite troverdig?
+3. Hvilken informasjon ville medlemmer vært komfortable med at Viddel husket?
+4. Hvilke aggregerte spørsmål ville vært mest nyttige for lokallaget?
+5. Vil dere bidra til neste steg — testbrukere, arbeidsøkt eller videre introduksjoner?
+
+## Guardrails
+
+- Ikke presenter syntetiske tall som funn.
+- Ikke lov database, innlogging, delt tilgang eller produsentintegrasjoner.
+- Ikke framstill oppsummeringen som journal eller medisinsk vurdering.
+- Ikke bruk prototypen som bevis på faktisk effekt.
+- Hold første dialog lærings- og samarbeidsorientert, ikke som ferdig salgspitch.

--- a/src/data/preview/viddel-concept-v01.ts
+++ b/src/data/preview/viddel-concept-v01.ts
@@ -1,0 +1,64 @@
+/* CONTRACT: Synthetic, non-persistent data for #283 concept prototype only. */
+
+export const conceptPersona = {
+  name: "Kari",
+  age: 67,
+  device: "Phonak Audéo Lumity",
+  phone: "iPhone",
+  phase: "Etablert bruker",
+  usage: "Bruker apparatene hver dag",
+  preference: "Vil ha korte steg, ett om gangen",
+};
+
+export const conceptHistory = [
+  {
+    date: "I dag",
+    title: "Svak lyd i høyre apparat",
+    status: "Trenger oppfølging",
+    detail: "Startet etter lading. Filter er kontrollert, men lyden er fortsatt svak.",
+  },
+  {
+    date: "8. juli",
+    title: "Ustabil Bluetooth på telefon",
+    status: "Løst",
+    detail: "Startet telefon og apparater på nytt. Tilkoblingen har vært stabil siden.",
+  },
+  {
+    date: "24. juni",
+    title: "Vanskelig å høre i familieselskap",
+    status: "Prøver tiltak",
+    detail: "Sitter nærmere den som snakker og bruker eget restaurantprogram.",
+  },
+];
+
+export const conceptSummaryItems = [
+  "Lyden er svakere i høyre apparat enn i venstre.",
+  "Apparatet er slått av og på og har vært ladet.",
+  "Filter og lydutgang er kontrollert.",
+  "Problemet vedvarer og brukeren ønsker råd om neste steg.",
+];
+
+export const conceptInsights = [
+  {
+    value: "38 %",
+    label: "trenger mest hjelp med lyd og teknisk feilsøking",
+    note: "Eksempel basert på 120 syntetiske hjelpesituasjoner",
+  },
+  {
+    value: "27 %",
+    label: "står fortsatt fast etter de første egenhjelpsstegene",
+    note: "Eksempel basert på syntetisk «hjalp / hjalp ikke»-state",
+  },
+  {
+    value: "1.",
+    label: "foreslått lokallagstema: praktisk hjelp med apparat og app",
+    note: "Eksempel på hvordan behov kan bli til aktivitet",
+  },
+];
+
+export const conceptTopics = [
+  { label: "Svak eller manglende lyd", value: 38 },
+  { label: "Bluetooth og app", value: 24 },
+  { label: "Samtaler i støy", value: 21 },
+  { label: "Tilvenning og bruk", value: 17 },
+];

--- a/src/pages/preview/viddel-concept-v01.astro
+++ b/src/pages/preview/viddel-concept-v01.astro
@@ -1,0 +1,474 @@
+---
+/* CONTRACT: #283 disposable concept prototype. No API, auth, persistence, analytics, or production navigation. */
+import {
+  conceptHistory,
+  conceptInsights,
+  conceptPersona,
+  conceptSummaryItems,
+  conceptTopics,
+} from "../../data/preview/viddel-concept-v01";
+
+Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
+
+const steps = [
+  { id: "today", short: "I dag", label: "Hjelp nå" },
+  { id: "bridge", short: "Neste", label: "Fra hjelp til kontinuitet" },
+  { id: "profile", short: "Mine sider", label: "Viddel kjenner meg" },
+  { id: "summary", short: "Ta med", label: "Min oppsummering" },
+  { id: "insight", short: "Sammen", label: "Medlemsinnsikt" },
+];
+---
+
+<!doctype html>
+<html lang="no">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="robots" content="noindex,nofollow" />
+    <title>Viddel Concept Prototype v0.1</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Epilogue:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+    />
+  </head>
+  <body>
+    <div class="prototype-banner" role="note">
+      <span class="prototype-banner__dot" aria-hidden="true"></span>
+      <strong>Konseptprototype</strong>
+      <span>Syntetiske eksempeldata · ingen data lagres</span>
+    </div>
+
+    <header class="prototype-header">
+      <a class="wordmark" href="#today" aria-label="Viddel prototype, gå til start">
+        <span>VID</span><span class="wordmark__signal" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></span><span>EL</span>
+      </a>
+      <div class="prototype-header__context">
+        <span>Viddel Concept Prototype v0.1</span>
+        <span class="prototype-header__audience">For dialog med Hørselsforbundet Asker</span>
+      </div>
+    </header>
+
+    <nav class="journey-nav" aria-label="Prototypereise">
+      {steps.map((step, index) => (
+        <a href={`#${step.id}`} data-step-link={step.id} class:list={[index === 0 && "is-active"]}>
+          <span class="journey-nav__number">{index + 1}</span>
+          <span><small>{step.short}</small>{step.label}</span>
+        </a>
+      ))}
+    </nav>
+
+    <main>
+      <section class="scene scene--today is-active" id="today" data-scene="today" tabindex="-1">
+        <div class="scene__eyebrow"><span class="state-badge state-badge--today">Dette finnes i dag</span> Konkret hjelp i øyeblikket</div>
+        <div class="today-grid">
+          <div class="today-copy">
+            <p class="kicker">Ingen lyd eller svak lyd</p>
+            <h1>Fra frustrasjon til et tydelig neste steg.</h1>
+            <p class="lead">Kari opplever at høyre høreapparat plutselig har blitt mye svakere. Viddel hjelper henne å sjekke det enkleste først — og spørre videre når problemet ikke løser seg.</p>
+
+            <div class="check-card">
+              <div><span>1</span><p><strong>Sjekk strøm og lading</strong>Slå apparatet av og på. Bekreft at det har ladet.</p></div>
+              <div><span>2</span><p><strong>Sjekk filter og lydutgang</strong>Se om filter, dome eller propp er tett eller sitter feil.</p></div>
+            </div>
+
+            <div class="action-row">
+              <a class="button button--primary" href="/no/artikkel/ingen-lyd-svak-lyd/" target="_blank" rel="noreferrer">Åpne dagens løsning <span aria-hidden="true">↗</span></a>
+              <a class="button button--quiet" href="#bridge">Se hvordan Viddel kan følge opp <span aria-hidden="true">→</span></a>
+            </div>
+          </div>
+
+          <div class="chat-card" aria-label="Eksempel på oppfølgingsdialog">
+            <div class="chat-card__top"><span class="assistant-mark">V</span><div><strong>Spør Viddel</strong><small>Trygg hjelp videre</small></div></div>
+            <div class="bubble bubble--user">Jeg har prøvd dette, men lyden er fortsatt svak.</div>
+            <div class="bubble bubble--assistant"><strong>Da har du allerede gjort de viktigste første sjekkene.</strong><p>Når bare ett apparat fortsatt er svakt etter lading og filterkontroll, kan det være lurt å sammenligne høyre og venstre side og notere når problemet startet.</p><p>Hvis forskjellen vedvarer, bør klinikken hjelpe deg med å kontrollere apparatet.</p></div>
+            <div class="next-action"><span aria-hidden="true">✓</span><p><strong>Neste handling</strong>Noter hva du har prøvd, og kontakt klinikken hvis høyre side fortsatt er svak.</p></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="scene scene--bridge" id="bridge" data-scene="bridge" tabindex="-1">
+        <div class="bridge-card">
+          <span class="state-badge">Her går vi over i konseptet</span>
+          <p class="kicker">Neste steg for Viddel</p>
+          <h2>I dag hjelper Viddel i øyeblikket. Hva om hjelpen også kunne henge sammen over tid?</h2>
+          <p>Resten av reisen viser en mulig framtid der brukeren selv kan la Viddel huske relevant informasjon, ta vare på historikk og lage en oppsummering. Alle data er syntetiske og ingen funksjoner er koblet til backend.</p>
+          <div class="bridge-values">
+            <div><span>01</span><strong>Slipp å gjenta</strong><p>Relevant informasjon oppgis én gang.</p></div>
+            <div><span>02</span><strong>Se sammenheng</strong><p>Problemer og prøvde tiltak blir synlige.</p></div>
+            <div><span>03</span><strong>Ta det med videre</strong><p>Brukeren kontrollerer hva som deles.</p></div>
+          </div>
+          <a class="button button--primary" href="#profile">Gå til Mine sider <span aria-hidden="true">→</span></a>
+        </div>
+      </section>
+
+      <section class="scene scene--profile" id="profile" data-scene="profile" tabindex="-1">
+        <div class="scene__eyebrow"><span class="state-badge">Konsept · Mine sider</span> Personlig kontinuitet</div>
+        <div class="profile-heading">
+          <div><p class="kicker">Hei, {conceptPersona.name}</p><h2>Viddel kjenner det viktigste — fordi du har valgt å fortelle det.</h2></div>
+          <div class="profile-avatar" aria-hidden="true">K</div>
+        </div>
+
+        <div class="profile-grid">
+          <article class="panel profile-facts">
+            <div class="panel__heading"><div><small>Min informasjon</small><h3>Dette bruker Viddel for å hjelpe</h3></div><button type="button" class="text-button" data-demo-toast="I en ekte tjeneste skal Kari kunne se og endre opplysningene sine.">Endre</button></div>
+            <dl>
+              <div><dt>Høreapparat</dt><dd>{conceptPersona.device}</dd></div>
+              <div><dt>Telefon</dt><dd>{conceptPersona.phone}</dd></div>
+              <div><dt>Erfaring</dt><dd>{conceptPersona.phase}</dd></div>
+              <div><dt>Bruk</dt><dd>{conceptPersona.usage}</dd></div>
+              <div><dt>Hjelp som passer</dt><dd>{conceptPersona.preference}</dd></div>
+            </dl>
+            <p class="privacy-note"><span aria-hidden="true">◉</span> Kari skal kunne se, rette og slette informasjon som eventuelt lagres i en framtidig tjeneste.</p>
+          </article>
+
+          <article class="panel history-panel">
+            <div class="panel__heading"><div><small>Min historikk</small><h3>Det vi har jobbet med sammen</h3></div><span class="count-badge">3 situasjoner</span></div>
+            <div class="timeline">
+              {conceptHistory.map((item, index) => (
+                <button type="button" class:list={["timeline-item", index === 0 && "is-current"]} data-history-detail={item.detail}>
+                  <span class="timeline-item__marker"></span>
+                  <span class="timeline-item__content"><small>{item.date}</small><strong>{item.title}</strong><span>{item.status}</span></span>
+                  <span aria-hidden="true">›</span>
+                </button>
+              ))}
+            </div>
+            <div class="history-detail" data-history-output>{conceptHistory[0].detail}</div>
+          </article>
+        </div>
+        <div class="action-row action-row--right"><a class="button button--primary" href="#summary">Lag en oppsummering <span aria-hidden="true">→</span></a></div>
+      </section>
+
+      <section class="scene scene--summary" id="summary" data-scene="summary" tabindex="-1">
+        <div class="scene__eyebrow"><span class="state-badge">Konsept · brukerstyrt</span> Ta informasjonen med videre</div>
+        <div class="summary-layout">
+          <div class="summary-copy">
+            <p class="kicker">Min oppsummering</p>
+            <h2>Kari bestemmer hva hun vil ta med — og hvem hun vil vise det til.</h2>
+            <p>Oppsummeringen bruker bare det Kari selv velger. Den er et samtalegrunnlag, ikke en medisinsk vurdering eller journal.</p>
+            <div class="recipient-list" aria-label="Mulige mottakere">
+              <span>Pårørende</span><span>Likeperson</span><span>Audiograf</span>
+            </div>
+          </div>
+
+          <article class="summary-sheet">
+            <div class="summary-sheet__top"><div><small>Forberedelse til hjelp</small><h3>Svak lyd i høyre høreapparat</h3></div><span>22. juli 2026</span></div>
+            <p class="summary-sheet__intro">Kari har valgt disse punktene:</p>
+            <div class="summary-checks">
+              {conceptSummaryItems.map((item, index) => (
+                <label><input type="checkbox" checked /><span>{item}</span></label>
+              ))}
+            </div>
+            <label class="summary-note"><span>Det jeg vil spørre om</span><textarea rows="3">Kan dere kontrollere hvorfor høyre side fortsatt er svakere, og om noe må justeres?</textarea></label>
+            <div class="summary-sheet__footer"><span><strong data-summary-count>4</strong> valgte punkter</span><button type="button" class="button button--primary" data-demo-toast="Konsept: I denne prototypen kopieres eller sendes ingenting.">Forhåndsvis deling</button></div>
+          </article>
+        </div>
+        <div class="action-row action-row--right"><a class="button button--quiet" href="#insight">Se mulig verdi for lokallaget <span aria-hidden="true">→</span></a></div>
+      </section>
+
+      <section class="scene scene--insight" id="insight" data-scene="insight" tabindex="-1">
+        <div class="scene__eyebrow"><span class="state-badge">Konsept · aggregert innsikt</span> Ingen enkeltpersoner eller rå samtaler</div>
+        <div class="insight-heading"><div><p class="kicker">Medlemsbehov i Asker</p><h2>Hva kan lokallaget forstå bedre når mange hjelpesituasjoner sees samlet?</h2></div><div class="synthetic-seal"><strong>120</strong><span>syntetiske<br />hjelpesituasjoner</span></div></div>
+
+        <div class="insight-cards">
+          {conceptInsights.map((item) => (
+            <article><strong>{item.value}</strong><h3>{item.label}</h3><p>{item.note}</p></article>
+          ))}
+        </div>
+
+        <div class="insight-grid">
+          <article class="panel topic-panel">
+            <div class="panel__heading"><div><small>Spørsmål 1</small><h3>Hva trenger medlemmene mest hjelp med?</h3></div></div>
+            <div class="bars">
+              {conceptTopics.map((topic) => (
+                <div><span>{topic.label}</span><strong>{topic.value} %</strong><i style={`--bar: ${topic.value}%`}></i></div>
+              ))}
+            </div>
+          </article>
+          <article class="panel action-panel">
+            <small>Spørsmål 2 og 3</small>
+            <h3>Hvor står medlemmene fast — og hva kan lokallaget gjøre?</h3>
+            <div class="action-panel__item"><span>Behov</span><p>Mange kommer ikke videre etter enkle tekniske sjekker og er usikre på når de bør kontakte klinikken.</p></div>
+            <div class="action-panel__item"><span>Mulig aktivitet</span><p>Praktisk medlemskveld: filter, lading, app og når du bør be om faglig hjelp.</p></div>
+            <div class="action-panel__item"><span>Spørsmål å undersøke</span><p>Hvilke problemer møter medlemmer igjen og igjen etter utlevering?</p></div>
+          </article>
+        </div>
+
+        <div class="truth-card"><strong>Dette viser en mulighet — ikke et eksisterende datagrunnlag.</strong><p>En framtidig løsning må bygge på tydelig brukernytte, frivillighet, samtykke og aggregater som ikke kan føres tilbake til enkeltpersoner.</p></div>
+        <div class="closing-card"><div><p class="kicker">Hva vil vi lære av dere?</p><h3>Hva er mest nyttig for medlemmene — og hva bør Viddel forstå bedre før neste steg?</h3></div><a class="button button--primary" href="#today">Start reisen på nytt <span aria-hidden="true">↺</span></a></div>
+      </section>
+    </main>
+
+    <div class="toast" role="status" aria-live="polite" data-toast></div>
+
+    <script>
+      const links = Array.from(document.querySelectorAll("[data-step-link]"));
+      const scenes = Array.from(document.querySelectorAll("[data-scene]"));
+
+      const setActive = (id) => {
+        links.forEach((link) => link.classList.toggle("is-active", link.dataset.stepLink === id));
+        scenes.forEach((scene) => scene.classList.toggle("is-active", scene.dataset.scene === id));
+      };
+
+      const activateFromHash = () => {
+        const id = window.location.hash.slice(1) || "today";
+        if (scenes.some((scene) => scene.dataset.scene === id)) setActive(id);
+      };
+
+      window.addEventListener("hashchange", activateFromHash);
+      activateFromHash();
+
+      document.querySelectorAll("[data-history-detail]").forEach((button) => {
+        button.addEventListener("click", () => {
+          document.querySelectorAll("[data-history-detail]").forEach((item) => item.classList.remove("is-current"));
+          button.classList.add("is-current");
+          const output = document.querySelector("[data-history-output]");
+          if (output) output.textContent = button.dataset.historyDetail || "";
+        });
+      });
+
+      const syncSummaryCount = () => {
+        const count = document.querySelectorAll(".summary-checks input:checked").length;
+        const output = document.querySelector("[data-summary-count]");
+        if (output) output.textContent = String(count);
+      };
+      document.querySelectorAll(".summary-checks input").forEach((input) => input.addEventListener("change", syncSummaryCount));
+
+      let toastTimer;
+      document.querySelectorAll("[data-demo-toast]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const toast = document.querySelector("[data-toast]");
+          if (!toast) return;
+          toast.textContent = button.dataset.demoToast || "";
+          toast.classList.add("is-visible");
+          window.clearTimeout(toastTimer);
+          toastTimer = window.setTimeout(() => toast.classList.remove("is-visible"), 3600);
+        });
+      });
+    </script>
+  </body>
+</html>
+
+<style is:global>
+  :root {
+    --ink: #111827;
+    --ink-soft: #52606f;
+    --line: #dce2e8;
+    --paper: #ffffff;
+    --canvas: #f5f7f9;
+    --blue: #0879b9;
+    --blue-dark: #075985;
+    --blue-soft: #e9f5fb;
+    --mint: #daf3e8;
+    --mint-ink: #176b52;
+    --amber: #fff2ce;
+    --amber-ink: #7b5911;
+    --shadow: 0 20px 60px -38px rgba(15, 37, 58, 0.38);
+    font-family: "Inter", system-ui, sans-serif;
+    color: var(--ink);
+    background: var(--canvas);
+  }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body { margin: 0; min-width: 320px; background: radial-gradient(circle at 80% 0%, rgba(14, 165, 233, .09), transparent 34rem), var(--canvas); color: var(--ink); }
+  button, textarea { font: inherit; }
+  button, a { -webkit-tap-highlight-color: transparent; }
+  a { color: inherit; }
+
+  .prototype-banner { min-height: 40px; display: flex; align-items: center; justify-content: center; gap: .55rem; padding: .55rem 1rem; background: #12212d; color: #fff; font-size: .78rem; letter-spacing: .01em; text-align: center; }
+  .prototype-banner__dot { width: .5rem; height: .5rem; border-radius: 50%; background: #57d9a3; box-shadow: 0 0 0 4px rgba(87, 217, 163, .15); }
+  .prototype-banner span:last-child { color: #c6d0d7; }
+
+  .prototype-header { max-width: 1180px; margin: 0 auto; padding: 1.15rem 1.4rem; display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; }
+  .wordmark { display: inline-flex; align-items: center; text-decoration: none; font: 700 1.25rem/1 "Epilogue", sans-serif; letter-spacing: -.04em; }
+  .wordmark__signal { display: inline-flex; align-items: center; gap: 2px; height: 1.05rem; margin: 0 2px; }
+  .wordmark__signal i { display: block; width: 2px; border-radius: 2px; background: var(--blue); }
+  .wordmark__signal i:nth-child(1), .wordmark__signal i:nth-child(5) { height: 34%; }
+  .wordmark__signal i:nth-child(2), .wordmark__signal i:nth-child(4) { height: 68%; }
+  .wordmark__signal i:nth-child(3) { height: 100%; }
+  .prototype-header__context { display: flex; align-items: center; gap: .75rem; color: var(--ink-soft); font-size: .78rem; }
+  .prototype-header__audience { padding-left: .75rem; border-left: 1px solid var(--line); }
+
+  .journey-nav { position: sticky; top: 0; z-index: 20; display: grid; grid-template-columns: repeat(5, 1fr); max-width: 1180px; margin: 0 auto; padding: 0 1.4rem; background: rgba(245, 247, 249, .93); backdrop-filter: blur(16px); }
+  .journey-nav::after { content: ""; position: absolute; left: 1.4rem; right: 1.4rem; bottom: 0; height: 1px; background: var(--line); }
+  .journey-nav a { position: relative; z-index: 1; display: flex; align-items: center; justify-content: center; gap: .65rem; min-height: 64px; padding: .65rem; color: #687583; text-decoration: none; font-size: .78rem; font-weight: 600; border-bottom: 3px solid transparent; }
+  .journey-nav a small { display: block; margin-bottom: .08rem; color: #89939c; font-size: .62rem; font-weight: 500; text-transform: uppercase; letter-spacing: .08em; }
+  .journey-nav__number { display: grid; place-items: center; width: 1.7rem; height: 1.7rem; flex: 0 0 auto; border: 1px solid #cbd3da; border-radius: 50%; font-size: .68rem; }
+  .journey-nav a.is-active { color: var(--ink); border-color: var(--blue); }
+  .journey-nav a.is-active .journey-nav__number { color: #fff; border-color: var(--blue); background: var(--blue); }
+
+  main { max-width: 1180px; margin: 0 auto; padding: 0 1.4rem 5rem; }
+  .scene { display: none; min-height: calc(100vh - 168px); padding: clamp(2.4rem, 6vw, 5.5rem) 0; scroll-margin-top: 64px; }
+  .scene.is-active { display: block; animation: scene-in .32s ease-out both; }
+  @keyframes scene-in { from { opacity: 0; transform: translateY(8px); } }
+  .scene__eyebrow { display: flex; align-items: center; gap: .8rem; margin-bottom: 1.5rem; color: var(--ink-soft); font-size: .8rem; font-weight: 600; }
+  .state-badge { display: inline-flex; align-items: center; width: fit-content; padding: .4rem .68rem; border: 1px solid #b5d8ea; border-radius: 999px; background: var(--blue-soft); color: var(--blue-dark); font-size: .68rem; font-weight: 700; letter-spacing: .03em; text-transform: uppercase; }
+  .state-badge--today { border-color: #a9dfcb; background: var(--mint); color: var(--mint-ink); }
+  .kicker { margin: 0 0 .65rem; color: var(--blue-dark); font-size: .8rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+  h1, h2, h3, p { margin-top: 0; }
+  h1, h2 { font-family: "Epilogue", sans-serif; letter-spacing: -.045em; }
+  h1 { max-width: 780px; margin-bottom: 1.25rem; font-size: clamp(2.45rem, 6vw, 5rem); line-height: 1.01; }
+  h2 { margin-bottom: 1rem; font-size: clamp(2rem, 4.2vw, 3.7rem); line-height: 1.06; }
+  h3 { line-height: 1.3; }
+  .lead { max-width: 680px; color: var(--ink-soft); font-size: clamp(1.05rem, 1.8vw, 1.25rem); line-height: 1.62; }
+
+  .button { display: inline-flex; align-items: center; justify-content: center; gap: .55rem; min-height: 46px; padding: .75rem 1.05rem; border: 1px solid transparent; border-radius: 999px; text-decoration: none; font-size: .85rem; font-weight: 700; cursor: pointer; }
+  .button--primary { background: #152b3b; color: #fff; box-shadow: 0 10px 24px -16px rgba(8, 40, 62, .9); }
+  .button--primary:hover { background: #0c1d29; }
+  .button--quiet { border-color: #cbd4dc; background: #fff; color: #263948; }
+  .button--quiet:hover { border-color: #8aaabd; }
+  .action-row { display: flex; flex-wrap: wrap; align-items: center; gap: .7rem; margin-top: 1.5rem; }
+  .action-row--right { justify-content: flex-end; }
+
+  .today-grid { display: grid; grid-template-columns: minmax(0, 1.08fr) minmax(330px, .72fr); gap: clamp(2rem, 6vw, 5rem); align-items: center; }
+  .check-card { max-width: 650px; margin: 1.5rem 0; padding: .35rem 1.1rem; border: 1px solid var(--line); border-radius: 22px; background: rgba(255, 255, 255, .72); }
+  .check-card > div { display: grid; grid-template-columns: 2rem 1fr; gap: .8rem; padding: 1rem 0; }
+  .check-card > div + div { border-top: 1px solid var(--line); }
+  .check-card > div > span { display: grid; place-items: center; width: 1.8rem; height: 1.8rem; border-radius: 50%; background: var(--blue-soft); color: var(--blue-dark); font-size: .75rem; font-weight: 700; }
+  .check-card p { margin: 0; color: var(--ink-soft); font-size: .88rem; line-height: 1.45; }
+  .check-card strong { display: block; margin-bottom: .2rem; color: var(--ink); }
+  .chat-card { padding: 1.2rem; border: 1px solid #d8e0e6; border-radius: 28px; background: #fff; box-shadow: var(--shadow); }
+  .chat-card__top { display: flex; align-items: center; gap: .7rem; padding: .1rem .2rem 1rem; border-bottom: 1px solid #edf0f2; }
+  .chat-card__top small { display: block; margin-top: .15rem; color: var(--ink-soft); }
+  .assistant-mark { display: grid; place-items: center; width: 2.25rem; height: 2.25rem; border-radius: 50%; background: #142c3b; color: #fff; font: 700 .9rem/1 "Epilogue"; }
+  .bubble { max-width: 92%; margin-top: 1rem; padding: .85rem 1rem; border-radius: 18px; font-size: .88rem; line-height: 1.55; }
+  .bubble p { margin: .45rem 0 0; }
+  .bubble--user { margin-left: auto; border-bottom-right-radius: 5px; background: #e9f5fb; }
+  .bubble--assistant { border-bottom-left-radius: 5px; background: #f4f5f6; color: #344554; }
+  .bubble--assistant strong { color: var(--ink); }
+  .next-action { display: grid; grid-template-columns: 1.9rem 1fr; gap: .6rem; margin-top: 1rem; padding: .8rem; border: 1px solid #c2e6d8; border-radius: 16px; background: #f0faf6; }
+  .next-action > span { display: grid; place-items: center; width: 1.7rem; height: 1.7rem; border-radius: 50%; background: var(--mint); color: var(--mint-ink); font-weight: 700; }
+  .next-action p { margin: 0; color: #496156; font-size: .78rem; line-height: 1.45; }
+  .next-action strong { display: block; color: #174f3e; }
+
+  .scene--bridge { display: none; place-items: center; }
+  .scene--bridge.is-active { display: grid; }
+  .bridge-card { max-width: 970px; padding: clamp(2rem, 5vw, 4.5rem); border: 1px solid #c9dce7; border-radius: 36px; background: linear-gradient(145deg, #fff, #edf7fb); box-shadow: var(--shadow); text-align: center; }
+  .bridge-card > .state-badge { margin: 0 auto 2rem; }
+  .bridge-card > p:not(.kicker) { max-width: 760px; margin: 0 auto; color: var(--ink-soft); font-size: 1.05rem; line-height: 1.65; }
+  .bridge-values { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin: 2.5rem 0; text-align: left; }
+  .bridge-values div { padding: 1.25rem; border: 1px solid #d9e5eb; border-radius: 20px; background: rgba(255,255,255,.78); }
+  .bridge-values span { display: block; margin-bottom: 1.4rem; color: var(--blue); font-size: .7rem; font-weight: 700; }
+  .bridge-values strong { display: block; margin-bottom: .35rem; }
+  .bridge-values p { margin: 0; color: var(--ink-soft); font-size: .82rem; line-height: 1.5; }
+
+  .profile-heading, .insight-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 2rem; margin-bottom: 2rem; }
+  .profile-heading h2, .insight-heading h2 { max-width: 820px; }
+  .profile-avatar { display: grid; place-items: center; width: 4.5rem; height: 4.5rem; flex: 0 0 auto; border-radius: 50%; background: linear-gradient(135deg, #c5e6f4, #e8ddec); color: #1b536f; font: 700 1.4rem/1 "Epilogue"; }
+  .profile-grid { display: grid; grid-template-columns: minmax(0, .85fr) minmax(0, 1.15fr); gap: 1rem; }
+  .panel { padding: 1.4rem; border: 1px solid var(--line); border-radius: 24px; background: #fff; box-shadow: var(--shadow); }
+  .panel__heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1.2rem; }
+  .panel__heading small, .action-panel > small { display: block; margin-bottom: .32rem; color: var(--blue-dark); font-size: .7rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
+  .panel__heading h3 { margin: 0; font-size: 1rem; }
+  .text-button { padding: 0; border: 0; background: none; color: var(--blue-dark); font-size: .78rem; font-weight: 700; cursor: pointer; }
+  .profile-facts dl { margin: 0; }
+  .profile-facts dl div { display: grid; grid-template-columns: 8.5rem 1fr; gap: .8rem; padding: .72rem 0; border-top: 1px solid #edf0f2; }
+  .profile-facts dt { color: var(--ink-soft); font-size: .78rem; }
+  .profile-facts dd { margin: 0; font-size: .82rem; font-weight: 600; }
+  .privacy-note { display: flex; gap: .55rem; margin: 1rem 0 0; padding: .85rem; border-radius: 14px; background: #f4f7f8; color: #536370; font-size: .72rem; line-height: 1.45; }
+  .count-badge { padding: .38rem .6rem; border-radius: 999px; background: #eef2f4; color: #566572; font-size: .68rem; font-weight: 700; }
+  .timeline { display: grid; gap: .25rem; }
+  .timeline-item { display: grid; grid-template-columns: 1.4rem 1fr auto; gap: .65rem; width: 100%; padding: .8rem; border: 0; border-radius: 14px; background: transparent; color: inherit; text-align: left; cursor: pointer; }
+  .timeline-item:hover, .timeline-item.is-current { background: #f1f7fa; }
+  .timeline-item__marker { width: .65rem; height: .65rem; margin-top: .35rem; border: 2px solid #8ebed5; border-radius: 50%; }
+  .timeline-item.is-current .timeline-item__marker { background: var(--blue); border-color: var(--blue); box-shadow: 0 0 0 4px #ddecf4; }
+  .timeline-item__content small, .timeline-item__content strong, .timeline-item__content > span { display: block; }
+  .timeline-item__content small { margin-bottom: .15rem; color: #76838e; font-size: .68rem; }
+  .timeline-item__content strong { font-size: .82rem; }
+  .timeline-item__content > span { margin-top: .2rem; color: #557081; font-size: .7rem; }
+  .history-detail { margin-top: 1rem; padding: .85rem 1rem; border-left: 3px solid #7bbbd9; background: #f7f9fa; color: #536370; font-size: .78rem; line-height: 1.5; }
+
+  .summary-layout { display: grid; grid-template-columns: minmax(0, .7fr) minmax(420px, 1fr); gap: clamp(2rem, 6vw, 5rem); align-items: center; }
+  .summary-copy p:not(.kicker) { max-width: 540px; color: var(--ink-soft); line-height: 1.65; }
+  .recipient-list { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: 1.5rem; }
+  .recipient-list span { padding: .5rem .7rem; border: 1px solid #cbd8df; border-radius: 999px; background: #fff; color: #435766; font-size: .75rem; font-weight: 600; }
+  .summary-sheet { padding: clamp(1.2rem, 3vw, 2rem); border: 1px solid #d6dde2; border-radius: 28px; background: #fff; box-shadow: var(--shadow); }
+  .summary-sheet__top { display: flex; justify-content: space-between; gap: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e4e8eb; }
+  .summary-sheet__top small { display: block; margin-bottom: .25rem; color: var(--blue-dark); font-size: .68rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; }
+  .summary-sheet__top h3 { margin: 0; }
+  .summary-sheet__top > span { color: #71808b; font-size: .7rem; }
+  .summary-sheet__intro { margin: 1rem 0 .65rem; color: var(--ink-soft); font-size: .78rem; }
+  .summary-checks { display: grid; gap: .4rem; }
+  .summary-checks label { display: grid; grid-template-columns: 1.1rem 1fr; gap: .6rem; padding: .62rem; border-radius: 12px; background: #f6f8f9; font-size: .78rem; line-height: 1.4; }
+  .summary-checks input { width: 1rem; height: 1rem; accent-color: var(--blue); }
+  .summary-note { display: block; margin-top: .9rem; }
+  .summary-note span { display: block; margin-bottom: .4rem; color: var(--ink-soft); font-size: .72rem; font-weight: 600; }
+  .summary-note textarea { width: 100%; padding: .75rem; resize: vertical; border: 1px solid #ccd5dc; border-radius: 12px; color: var(--ink); line-height: 1.45; }
+  .summary-sheet__footer { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1rem; }
+  .summary-sheet__footer > span { color: #667580; font-size: .72rem; }
+
+  .synthetic-seal { display: flex; align-items: center; gap: .7rem; padding: .8rem 1rem; border: 1px solid #c9dce7; border-radius: 18px; background: #fff; }
+  .synthetic-seal strong { color: var(--blue-dark); font: 700 1.6rem/1 "Epilogue"; }
+  .synthetic-seal span { color: #667681; font-size: .65rem; line-height: 1.25; }
+  .insight-cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 1rem; }
+  .insight-cards article { padding: 1.25rem; border: 1px solid #d7e0e5; border-radius: 22px; background: #fff; }
+  .insight-cards article > strong { display: block; margin-bottom: .8rem; color: var(--blue-dark); font: 700 2.2rem/1 "Epilogue"; }
+  .insight-cards h3 { min-height: 3.8em; margin-bottom: .75rem; font-size: .88rem; }
+  .insight-cards p { margin: 0; color: var(--ink-soft); font-size: .7rem; line-height: 1.45; }
+  .insight-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 1rem; }
+  .bars { display: grid; gap: .9rem; }
+  .bars div { display: grid; grid-template-columns: 1fr auto; gap: .3rem .8rem; color: #4b5c69; font-size: .74rem; }
+  .bars strong { color: var(--ink); }
+  .bars i { grid-column: 1 / -1; display: block; height: .55rem; border-radius: 999px; background: linear-gradient(to right, var(--blue) var(--bar), #e8edf0 var(--bar)); }
+  .action-panel__item { display: grid; grid-template-columns: 7rem 1fr; gap: .7rem; padding: .75rem 0; border-top: 1px solid #e8ecef; }
+  .action-panel__item span { color: var(--blue-dark); font-size: .7rem; font-weight: 700; }
+  .action-panel__item p { margin: 0; color: #52626e; font-size: .75rem; line-height: 1.45; }
+  .truth-card { display: flex; align-items: center; gap: 1rem; margin-top: 1rem; padding: 1rem 1.2rem; border: 1px solid #ecd699; border-radius: 18px; background: #fff9e9; }
+  .truth-card strong { flex: 0 0 33%; color: var(--amber-ink); font-size: .8rem; }
+  .truth-card p { margin: 0; color: #6b6046; font-size: .72rem; line-height: 1.45; }
+  .closing-card { display: flex; align-items: center; justify-content: space-between; gap: 2rem; margin-top: 1rem; padding: 1.3rem; border-radius: 22px; background: #142b3b; color: #fff; }
+  .closing-card .kicker { color: #85d1f3; }
+  .closing-card h3 { max-width: 760px; margin: 0; font-size: 1.05rem; }
+  .closing-card .button--primary { background: #fff; color: #142b3b; }
+
+  .toast { position: fixed; left: 50%; bottom: 1.2rem; z-index: 50; max-width: min(90vw, 540px); padding: .85rem 1rem; border-radius: 14px; background: #142b3b; color: #fff; box-shadow: 0 16px 40px -20px rgba(0,0,0,.65); font-size: .78rem; line-height: 1.45; opacity: 0; transform: translate(-50%, 1rem); pointer-events: none; transition: .2s ease; }
+  .toast.is-visible { opacity: 1; transform: translate(-50%, 0); }
+
+  :focus-visible { outline: 3px solid #f472b6; outline-offset: 3px; }
+
+  @media (max-width: 860px) {
+    .prototype-header__audience { display: none; }
+    .journey-nav { overflow-x: auto; grid-template-columns: repeat(5, minmax(145px, 1fr)); justify-content: start; }
+    .journey-nav a { justify-content: flex-start; }
+    .today-grid, .profile-grid, .summary-layout, .insight-grid { grid-template-columns: 1fr; }
+    .chat-card { max-width: 600px; }
+    .summary-layout { gap: 2rem; }
+    .insight-cards { grid-template-columns: 1fr; }
+    .insight-cards h3 { min-height: auto; }
+    .bridge-values { grid-template-columns: 1fr; }
+  }
+
+  @media (max-width: 600px) {
+    .prototype-banner { align-items: flex-start; flex-wrap: wrap; gap: .25rem .5rem; }
+    .prototype-banner span:last-child { flex-basis: 100%; }
+    .prototype-header { padding: .9rem 1rem; }
+    .prototype-header__context { display: none; }
+    .journey-nav { padding: 0 1rem; grid-template-columns: repeat(5, minmax(125px, 1fr)); }
+    .journey-nav::after { left: 1rem; right: 1rem; }
+    .journey-nav a { min-height: 58px; padding: .5rem .35rem; font-size: .7rem; }
+    .journey-nav__number { width: 1.45rem; height: 1.45rem; }
+    main { padding: 0 1rem 3rem; }
+    .scene { min-height: calc(100vh - 146px); padding: 2.2rem 0 3rem; }
+    h1 { font-size: 2.45rem; }
+    h2 { font-size: 2rem; }
+    .scene__eyebrow { align-items: flex-start; flex-direction: column; gap: .45rem; }
+    .action-row .button { width: 100%; }
+    .chat-card, .panel, .summary-sheet, .bridge-card { border-radius: 20px; }
+    .profile-heading, .insight-heading { display: block; }
+    .profile-avatar, .synthetic-seal { margin-top: 1rem; }
+    .profile-facts dl div { grid-template-columns: 1fr; gap: .2rem; }
+    .summary-sheet__top, .summary-sheet__footer { align-items: flex-start; flex-direction: column; }
+    .summary-sheet__footer .button { width: 100%; }
+    .truth-card, .closing-card { align-items: flex-start; flex-direction: column; }
+    .truth-card strong { flex-basis: auto; }
+    .closing-card .button { width: 100%; }
+    .action-panel__item { grid-template-columns: 1fr; gap: .25rem; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+  }
+</style>


### PR DESCRIPTION
## Summary

- Add an isolated, responsive concept prototype for the first Hørselsforbundet Asker dialogue.
- Show current help, an explicit concept transition, Mine sider/history, a user-controlled summary and synthetic member insight.
- Keep all prototype data local and synthetic.
- Add a six-minute facilitation script, truth map, validation questions and guardrails.

## Truth boundary

- No data is stored, copied, sent or collected.
- No database, auth, API, cookies, analytics or persistence.
- No production Composer, tokens, navigation, VIS, Backstage or current-state changes.

## Route

`/preview/viddel-concept-v01/`

The route is not linked from public navigation and is intended for branch Preview QA only until Thomas approves the visual and narrative flow.

## Verification

- `npm run build`
- Desktop QA at 1440 × 1000 and mobile QA at 390 × 844
- All five states, links and interactions verified
- No horizontal overflow, missing targets, duplicate IDs or console errors

Closes #283 only after Thomas approves and the final disposition is decided.
