### PR TITLE
Prototype: innlogget samtaleområde — Snitt A

### DIFF
--- a/src/components/conversation/ConversationContext.astro
+++ b/src/components/conversation/ConversationContext.astro
@@ -1,0 +1,102 @@
+---
+import type { ConversationPrototype } from "../../data/conversation-prototype-v01";
+
+type Props = {
+  conversations: ConversationPrototype[];
+  selectedId?: string;
+};
+
+const { conversations, selectedId } = Astro.props as Props;
+---
+
+<section class="conversation-context" aria-label="Aktiv samtale" data-conversation-context>
+  {
+    conversations.map((conversation) => (
+      <article
+        class="conversation-context__panel"
+        data-conversation-panel={conversation.id}
+        hidden={conversation.id !== selectedId}
+      >
+        <header class="conversation-context__header">
+          <button
+            type="button"
+            class="conversation-context__back"
+            data-back-to-conversations
+            aria-label="Tilbake til samtaler"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="m15 18-6-6 6-6" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <span>Samtaler</span>
+          </button>
+          <div class="conversation-context__heading">
+            <h1>{conversation.title}</h1>
+            {conversation.articleOrigin ? <p>Fra artikkelen «{conversation.articleOrigin}»</p> : null}
+          </div>
+          <button type="button" class="conversation-action conversation-action--quiet" data-new-conversation>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M12 5v14M5 12h14" stroke-linecap="round" />
+            </svg>
+            <span>Ny samtale</span>
+          </button>
+        </header>
+
+        <div class="conversation-context__body">
+          <div class="conversation-context__transcript" role="log" aria-live="polite" aria-relevant="additions text">
+            {conversation.messages.map((message) => (
+              <div class:list={["conversation-message", `conversation-message--${message.role}`]}>
+                {message.role === "assistant" ? <p class="conversation-message__speaker">Viddel</p> : null}
+                <p>{message.text}</p>
+              </div>
+            ))}
+          </div>
+          <p class="conversation-context__status" data-prototype-pending role="status">Viddel svarer …</p>
+          <div class="conversation-context__error" data-prototype-error role="alert">
+            <p>Svaret kunne ikke leveres.</p>
+            <button type="button" data-clear-demo-state>Prøv igjen</button>
+          </div>
+        </div>
+
+        <form class="conversation-composer" data-prototype-composer>
+          <label class="sr-only" for={`conversation-input-${conversation.id}`}>Skriv spørsmål til Viddel</label>
+          <textarea
+            id={`conversation-input-${conversation.id}`}
+            rows="1"
+            placeholder="Hva lurer du på?"
+            data-prototype-input
+          />
+          <button type="submit" aria-label="Send spørsmål" disabled data-prototype-send>
+            <span aria-hidden="true">↑</span>
+          </button>
+        </form>
+      </article>
+    ))
+  }
+
+  <article class="conversation-context__panel" data-conversation-panel="new" hidden>
+    <header class="conversation-context__header">
+      <button
+        type="button"
+        class="conversation-context__back"
+        data-back-to-conversations
+        aria-label="Tilbake til samtaler"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="m15 18-6-6 6-6" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        <span>Samtaler</span>
+      </button>
+      <div class="conversation-context__heading">
+        <h1>Ny samtale</h1>
+      </div>
+    </header>
+    <div class="conversation-context__body conversation-context__body--new"></div>
+    <form class="conversation-composer" data-prototype-composer>
+      <label class="sr-only" for="conversation-input-new">Skriv spørsmål til Viddel</label>
+      <textarea id="conversation-input-new" rows="1" placeholder="Hva lurer du på?" data-prototype-input />
+      <button type="submit" aria-label="Send spørsmål" disabled data-prototype-send>
+        <span aria-hidden="true">↑</span>
+      </button>
+    </form>
+  </article>
+</section>

--- a/src/components/conversation/ConversationEmptyState.astro
+++ b/src/components/conversation/ConversationEmptyState.astro
@@ -1,0 +1,6 @@
+<div class="conversation-empty-state" data-conversation-empty-state>
+  <h2>Start en samtale med Viddel</h2>
+  <button type="button" class="conversation-action conversation-action--primary" data-new-conversation>
+    Start samtale
+  </button>
+</div>

--- a/src/components/conversation/ConversationItem.astro
+++ b/src/components/conversation/ConversationItem.astro
@@ -1,0 +1,53 @@
+---
+import type { ConversationListItem } from "../../data/conversation-prototype-v01";
+
+type Props = {
+  conversation: ConversationListItem;
+  selected?: boolean;
+};
+
+const { conversation, selected = false } = Astro.props as Props;
+const titleLabel = /[.!?]$/.test(conversation.title) ? conversation.title : `${conversation.title}.`;
+const originLabel = conversation.articleOrigin
+  ? ` Fra artikkelen «${conversation.articleOrigin}».`
+  : "";
+const accessibleLabel = `${conversation.dayLabel} klokken ${conversation.timeLabel}. ${titleLabel}${originLabel}`;
+---
+
+<button
+  type="button"
+  class="conversation-item"
+  data-conversation-id={conversation.id}
+  aria-pressed={selected ? "true" : "false"}
+  aria-label={accessibleLabel}
+>
+  <span class="conversation-item__date-column" aria-hidden="true">
+    <span class:list={["conversation-item__day", !conversation.showDay && "conversation-item__day--hidden"]}>
+      {conversation.dayLabel}
+    </span>
+    <span class="conversation-item__time">{conversation.timeLabel}</span>
+  </span>
+
+  <span class="conversation-item__content">
+    <span class="conversation-item__date-inline" aria-hidden="true">
+      {conversation.showDay ? <span>{conversation.dayLabel}</span> : null}
+      <span>{conversation.timeLabel}</span>
+    </span>
+    <span class="conversation-item__heading-row">
+      <span class="conversation-item__title">{conversation.title}</span>
+      <span class="conversation-item__time-inline" aria-hidden="true">{conversation.timeLabel}</span>
+    </span>
+    {conversation.excerpt ? <span class="conversation-item__excerpt">{conversation.excerpt}</span> : null}
+    {
+      conversation.articleOrigin ? (
+        <span class="conversation-item__origin" title={`Fra artikkelen «${conversation.articleOrigin}»`}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+            <path d="M6 3h8l4 4v14H6z" stroke-linejoin="round" />
+            <path d="M14 3v5h5M9 12h6M9 16h6" stroke-linecap="round" />
+          </svg>
+          <span>Fra artikkelen «{conversation.articleOrigin}»</span>
+        </span>
+      ) : null
+    }
+  </span>
+</button>

--- a/src/components/conversation/ConversationOverview.astro
+++ b/src/components/conversation/ConversationOverview.astro
@@ -1,0 +1,40 @@
+---
+import type { ConversationDayGroup } from "../../data/conversation-prototype-v01";
+import ConversationEmptyState from "./ConversationEmptyState.astro";
+import ConversationItem from "./ConversationItem.astro";
+
+type Props = {
+  groups: ConversationDayGroup[];
+  selectedId?: string;
+};
+
+const { groups, selectedId } = Astro.props as Props;
+---
+
+<section class="conversation-overview" aria-labelledby="conversation-overview-title" data-conversation-overview>
+  <div class="conversation-overview__inner">
+    <header class="conversation-overview__header">
+      <h1 id="conversation-overview-title" data-overview-title>Samtalene dine</h1>
+      <button type="button" class="conversation-action conversation-action--primary" data-new-conversation>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M12 5v14M5 12h14" stroke-linecap="round" />
+        </svg>
+        <span>Ny samtale</span>
+      </button>
+    </header>
+
+    <div class="conversation-overview__list" data-conversation-list>
+      {
+        groups.map((group) => (
+          <div class="conversation-day-group" data-day-key={group.dayKey}>
+            {group.items.map((conversation) => (
+              <ConversationItem conversation={conversation} selected={conversation.id === selectedId} />
+            ))}
+          </div>
+        ))
+      }
+    </div>
+
+    <ConversationEmptyState />
+  </div>
+</section>

--- a/src/components/designsystem/PatternPreview.astro
+++ b/src/components/designsystem/PatternPreview.astro
@@ -128,6 +128,40 @@ const showSeeds = size === "sm" ? seeds.slice(0, 2) : seeds;
   }
 
   {
+    id === "conversation-area" && (
+      <div class="ds-preview__frame" aria-hidden="true">
+        <div class="conversation-overview__list">
+          <div class="conversation-day-group">
+            <button type="button" class="conversation-item" aria-pressed="true" tabindex="-1">
+              <span class="conversation-item__date-column">
+                <span class="conversation-item__day">I dag</span>
+                <span class="conversation-item__time">10:42</span>
+              </span>
+              <span class="conversation-item__content">
+                <span class="conversation-item__heading-row">
+                  <span class="conversation-item__title">Hva skjer på hørselstesten?</span>
+                </span>
+                <span class="conversation-item__excerpt">Jeg er usikker på hva som skjer under undersøkelsen.</span>
+              </span>
+            </button>
+            <button type="button" class="conversation-item" aria-pressed="false" tabindex="-1">
+              <span class="conversation-item__date-column">
+                <span class="conversation-item__day conversation-item__day--hidden">I dag</span>
+                <span class="conversation-item__time">09:55</span>
+              </span>
+              <span class="conversation-item__content">
+                <span class="conversation-item__heading-row">
+                  <span class="conversation-item__title">Hvordan snakke med familien om at jeg strever med å høre</span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  {
     id === "article-to-ai-transition" && (
       <div class="ds-preview__frame ds-preview__frame--article" data-r1-editorial>
         <div class="r1-editorial-container">

--- a/src/data/conversation-prototype-v01.ts
+++ b/src/data/conversation-prototype-v01.ts
@@ -1,0 +1,194 @@
+export type ConversationMessage = {
+  role: "user" | "assistant";
+  text: string;
+};
+
+export type ConversationPrototype = {
+  id: string;
+  title: string;
+  updatedAt: string;
+  excerpt?: string;
+  articleOrigin?: string;
+  messages: ConversationMessage[];
+};
+
+export type ConversationListItem = ConversationPrototype & {
+  dayKey: string;
+  dayLabel: string;
+  timeLabel: string;
+  showDay: boolean;
+};
+
+export type ConversationDayGroup = {
+  dayKey: string;
+  dayLabel: string;
+  items: ConversationListItem[];
+};
+
+export const conversationPrototypeNow = "2026-07-31T12:00:00+02:00";
+
+export const conversationPrototypeData: ConversationPrototype[] = [
+  {
+    id: "hearing-test",
+    title: "Hva skjer på hørselstesten?",
+    updatedAt: "2026-07-31T10:42:00+02:00",
+    excerpt: "Jeg er usikker på hva som skjer under undersøkelsen.",
+    messages: [
+      { role: "assistant", text: "Hva lurer du på før hørselstesten?" },
+      { role: "user", text: "Jeg er usikker på hva som skjer under undersøkelsen." },
+      {
+        role: "assistant",
+        text: "Du får vanligvis først noen spørsmål om hørselen din. Deretter måles hvordan du hører ulike toner og tale.",
+      },
+    ],
+  },
+  {
+    id: "family",
+    title: "Hvordan snakke med familien om at jeg strever med å høre",
+    updatedAt: "2026-07-31T09:55:00+02:00",
+    excerpt: "Jeg vil forklare det uten at samtalen blir for alvorlig.",
+    messages: [
+      { role: "user", text: "Jeg vil forklare det uten at samtalen blir for alvorlig." },
+      {
+        role: "assistant",
+        text: "Det kan hjelpe å beskrive konkrete situasjoner og si tydelig hva familien kan gjøre når dere snakker sammen.",
+      },
+    ],
+  },
+  {
+    id: "sharp-sound",
+    title: "Lyden blir skarp av bestikk og tallerkener",
+    updatedAt: "2026-07-31T08:15:00+02:00",
+    excerpt: "Hvorfor blir bestikk og tallerkener så høye?",
+    articleOrigin: "Lydømfintlighet",
+    messages: [
+      { role: "user", text: "Hvorfor blir bestikk og tallerkener så høye?" },
+      {
+        role: "assistant",
+        text: "Skarpe, plutselige lyder kan oppleves sterkere når hørselen er sliten eller lydnivået i høreapparatet ikke passer situasjonen.",
+      },
+    ],
+  },
+  {
+    id: "audiologist",
+    title: "Hva bør jeg ta opp med audiografen?",
+    updatedAt: "2026-07-31T07:30:00+02:00",
+    excerpt: "Jeg vil ikke glemme noe viktig på timen.",
+    articleOrigin: "Før timen",
+    messages: [
+      { role: "user", text: "Jeg vil ikke glemme noe viktig på timen." },
+      {
+        role: "assistant",
+        text: "Skriv gjerne ned situasjoner der du hører godt, og situasjoner der lyden blir vanskelig. Det gir audiografen et konkret utgangspunkt.",
+      },
+    ],
+  },
+  {
+    id: "tinnitus",
+    title: "Jeg hører en lyd som andre ikke hører",
+    updatedAt: "2026-07-28T16:20:00+02:00",
+    excerpt: "Det er en høy tone som særlig merkes om kvelden.",
+    articleOrigin: "Hva er tinnitus?",
+    messages: [
+      { role: "user", text: "Det er en høy tone som særlig merkes om kvelden." },
+      {
+        role: "assistant",
+        text: "En lyd som ikke kommer utenfra kan være tinnitus. Legg merke til når lyden er mest plagsom, og kontakt helsepersonell hvis den er ny eller bekymrer deg.",
+      },
+    ],
+  },
+  {
+    id: "work",
+    title: "Hvordan sier jeg fra på jobb?",
+    updatedAt: "2026-07-24T09:05:00+02:00",
+    excerpt: "Møter er vanskelige når flere snakker samtidig.",
+    messages: [
+      { role: "user", text: "Møter er vanskelige når flere snakker samtidig." },
+      {
+        role: "assistant",
+        text: "Du kan be om én taler om gangen, en tydelig møteagenda og en plass der du ser ansiktene til dem som snakker.",
+      },
+    ],
+  },
+  {
+    id: "devices",
+    title: "De nye apparatene høres rare ut",
+    updatedAt: "2026-07-18T13:30:00+02:00",
+    excerpt: "Musikk låter mye flatere enn før.",
+    articleOrigin: "Den første tiden med nye høreapparater og hva du kan forvente",
+    messages: [
+      { role: "user", text: "Musikk låter mye flatere enn før." },
+      {
+        role: "assistant",
+        text: "Nye innstillinger kan trenge tilvenning, men musikk bør fortsatt oppleves naturlig. Noter hva som låter annerledes og ta det med til audiografen.",
+      },
+    ],
+  },
+];
+
+const dateKey = (iso: string) => iso.slice(0, 10);
+
+const utcDayNumber = (key: string) => {
+  const [year, month, day] = key.split("-").map(Number);
+  return Date.UTC(year, month - 1, day) / 86_400_000;
+};
+
+const formatDayLabel = (key: string, nowKey: string) => {
+  const difference = utcDayNumber(nowKey) - utcDayNumber(key);
+  if (difference === 0) return "I dag";
+  if (difference === 1) return "I går";
+
+  const date = new Date(`${key}T12:00:00+02:00`);
+  if (difference > 1 && difference < 7) {
+    const weekday = new Intl.DateTimeFormat("nb-NO", { weekday: "long" }).format(date);
+    return weekday.charAt(0).toUpperCase() + weekday.slice(1);
+  }
+
+  const nowYear = Number(nowKey.slice(0, 4));
+  const dateYear = Number(key.slice(0, 4));
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+    ...(dateYear === nowYear ? {} : { year: "numeric" }),
+  }).format(date);
+};
+
+const formatTimeLabel = (iso: string) =>
+  new Intl.DateTimeFormat("nb-NO", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Europe/Oslo",
+  }).format(new Date(iso));
+
+export function groupPrototypeConversations(
+  conversations: ConversationPrototype[],
+  now = conversationPrototypeNow,
+): ConversationDayGroup[] {
+  const nowKey = dateKey(now);
+  const groups = new Map<string, ConversationPrototype[]>();
+
+  [...conversations]
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .forEach((conversation) => {
+      const key = dateKey(conversation.updatedAt);
+      const group = groups.get(key) ?? [];
+      group.push(conversation);
+      groups.set(key, group);
+    });
+
+  return [...groups.entries()].map(([key, items]) => {
+    const dayLabel = formatDayLabel(key, nowKey);
+    return {
+      dayKey: key,
+      dayLabel,
+      items: items.map((conversation, index) => ({
+        ...conversation,
+        dayKey: key,
+        dayLabel,
+        timeLabel: formatTimeLabel(conversation.updatedAt),
+        showDay: index === 0,
+      })),
+    };
+  });
+}

--- a/src/data/design-system-source-of-truth-v01.ts
+++ b/src/data/design-system-source-of-truth-v01.ts
@@ -26,8 +26,8 @@ export const designSystemMeta = {
   version: "v0.1",
   title: "Design System Source of Truth",
   canonicalPath: "/designsystem/",
-  updated: "2026-05-30",
-  issue: "#157",
+  updated: "2026-07-31",
+  issue: "#157 · #283",
   relatedDecisions: [
     "docs/project/decisions/DECISION_125M_C_STANDALONE_AI_CUSTOM_R1.md",
     "docs/project/decisions/DECISION_125M_CES_HEADLESS_INTEGRATION_CBA.md",
@@ -230,6 +230,38 @@ export const patterns: PatternRecord[] = [
     commitRef: "e896d377",
   },
   {
+    id: "conversation-area",
+    name: "Conversation Area",
+    status: "Candidate",
+    summary: "Åpen samtaleoversikt som går over i adaptiv delt flate på desktop.",
+    rule: "Samme ConversationItem skal bære full, kompakt og mobil presentasjon.",
+    purpose: "Finne igjen, åpne og starte samtaler uten dashboard- eller kortstøy.",
+    usedOn: ["/no/samtaler/ (isolert konseptprototype)"],
+    sourceFiles: [
+      "src/pages/no/samtaler.astro",
+      "src/components/conversation/ConversationOverview.astro",
+      "src/components/conversation/ConversationItem.astro",
+      "src/styles/viddel-conversation-area.css",
+    ],
+    do: [
+      "Bruk åpen liste, kronologisk gruppering og semantisk valgt state",
+      "Behold samme samtaleidentitet i full og kompakt presentasjon",
+      "Bruk eksisterende semantiske tokens i lys og mørk modus",
+    ],
+    dont: [
+      "Ikke kort rundt hvert samtaleelement",
+      "Ikke bygg auth, lagring eller samtaleadministrasjon inn i mønsteret",
+      "Ikke opprett globale state-tokens før gjenbruk er bekreftet",
+    ],
+    qaQuestions: [
+      "Er valgt samtale tydelig uten å konkurrere med tastaturfokus?",
+      "Bevares kronologi og listeposisjon på desktop og mobil?",
+      "Står 320 px, lange titler og lang artikkelopprinnelse seg?",
+    ],
+    issueRef: "#283",
+    commitRef: "—",
+  },
+  {
     id: "article-to-ai-transition",
     name: "Article-to-AI Transition",
     status: "Applied",
@@ -305,6 +337,12 @@ export const patterns: PatternRecord[] = [
 ];
 
 export const appliedSurfaces = [
+  {
+    route: "/no/samtaler/",
+    status: "Candidate" as PatternStatus,
+    patterns: ["Conversation Area", "Transcript", "AI Composer", "Loading / Error States"],
+    note: "Isolert Snitt A med syntetiske data. Visuell QA før dialogkobling.",
+  },
   {
     route: "/no/chat/",
     status: "Applied" as PatternStatus,

--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -66,7 +66,7 @@ export type ClosedSprint = {
 };
 
 export const mvpCurrentState = {
-  updatedAt: "2026-06-09",
+  updatedAt: "2026-07-31",
   currentSprint: {
     id: "2026-w21",
     label: "2026-W21",
@@ -115,6 +115,15 @@ export const mvpCurrentState = {
       visFrontpage: true,
       kind: "public",
       frontpageDescription: "Headless AI-chat — live (intern test). Public guard aktiv.",
+    },
+    {
+      id: "conversation-area-prototype",
+      label: "Innlogget samtaleområde",
+      route: "/no/samtaler/",
+      status: "Candidate",
+      note: "Isolert konseptprototype med syntetisk historikk og lokal UI-state. Ingen auth eller lagring.",
+      visFrontpage: false,
+      kind: "reference",
     },
     {
       id: "designsystem",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -23,6 +23,8 @@ const {
 };
 const isSandboxWhite = shellVariant === "sandbox-white";
 const isStandaloneChat = shellVariant === "standalone-chat";
+const isConversationArea = shellVariant === "conversation-area";
+const disablesCes = isStandaloneChat || isConversationArea;
 ---
 
 <!doctype html>
@@ -60,7 +62,7 @@ const isStandaloneChat = shellVariant === "standalone-chat";
     <InspectDrawerArmScript />
     <slot name="head" />
     {
-      !isStandaloneChat ? (
+      !disablesCes ? (
         <>
           <script defer src="https://www.gstatic.com/ces-console/fast/chat-messenger/prod/v1.15/chat-messenger.js" />
           <link
@@ -104,6 +106,7 @@ const isStandaloneChat = shellVariant === "standalone-chat";
       shellVariant === "article" && "vox-shell--article",
       isSandboxWhite && "vox-shell--sandbox-white",
       isStandaloneChat && "vox-shell--standalone-chat",
+      isConversationArea && "vox-shell--conversation-area",
     ]}
   >
     <div class="fixed inset-0 -z-10 overflow-hidden" aria-hidden="true">
@@ -168,7 +171,7 @@ const isStandaloneChat = shellVariant === "standalone-chat";
     </div>
 
     {
-      !isStandaloneChat ? (
+      !disablesCes ? (
     <script is:inline>
       const deploymentName =
         "projects/1088102295663/locations/eu/apps/1741e68d-0528-4625-8b83-99a0dbb5298f/deployments/dc1619d0-44a1-401b-92a6-1357c29274ea";

--- a/src/pages/designsystem/index.astro
+++ b/src/pages/designsystem/index.astro
@@ -5,6 +5,7 @@ import PatternPreview from "../../components/designsystem/PatternPreview.astro";
 import "../../styles/global.css";
 import "../../styles/r1-dialog-article.css";
 import "../../styles/viddel-standalone-chat.css";
+import "../../styles/viddel-conversation-area.css";
 import "../../styles/designsystem-catalog.css";
 import {
   designSystemMeta,

--- a/src/pages/no/samtaler.astro
+++ b/src/pages/no/samtaler.astro
@@ -1,0 +1,165 @@
+---
+/* CONTRACT: Isolated concept prototype for signed-in conversation history. Synthetic state only. #283 */
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import ConversationContext from "../../components/conversation/ConversationContext.astro";
+import ConversationOverview from "../../components/conversation/ConversationOverview.astro";
+import {
+  conversationPrototypeData,
+  groupPrototypeConversations,
+} from "../../data/conversation-prototype-v01";
+import "../../styles/viddel-conversation-area.css";
+
+Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
+
+const groups = groupPrototypeConversations(conversationPrototypeData);
+---
+
+<BaseLayout
+  title="Viddel - Samtalene dine"
+  currentPath="/no/samtaler"
+  shellVariant="conversation-area"
+  headerBrand="viddel"
+  showHeaderDevtoolsToggle={false}
+>
+  <meta slot="head" name="robots" content="noindex,nofollow" />
+
+  <main
+    class="conversation-area"
+    data-conversation-area
+    data-view="overview"
+    data-history="populated"
+    data-demo-state="default"
+  >
+    <div class="conversation-area__surface">
+      <ConversationOverview groups={groups} />
+      <ConversationContext conversations={conversationPrototypeData} />
+    </div>
+
+    <details class="conversation-area__demo">
+      <summary>Prototypestates</summary>
+      <div class="conversation-area__demo-controls" aria-label="Prototypestates">
+        <button type="button" data-demo-view="overview">Oversikt</button>
+        <button type="button" data-demo-history="empty">Tom historikk</button>
+        <button type="button" data-demo-state="pending">Viddel svarer</button>
+        <button type="button" data-demo-state="error">Feil</button>
+        <button type="button" data-demo-reset>Nullstill</button>
+      </div>
+    </details>
+  </main>
+
+  <script>
+    (() => {
+      const root = document.querySelector<HTMLElement>("[data-conversation-area]");
+      if (!root) return;
+
+      const items = Array.from(root.querySelectorAll<HTMLButtonElement>("[data-conversation-id]"));
+      const panels = Array.from(root.querySelectorAll<HTMLElement>("[data-conversation-panel]"));
+      const list = root.querySelector<HTMLElement>("[data-conversation-list]");
+      const overviewTitle = root.querySelector<HTMLElement>("[data-overview-title]");
+      let selectedId = "";
+      let listScrollTop = 0;
+      let pageScrollTop = 0;
+
+      const showPanel = (id: string) => {
+        panels.forEach((panel) => {
+          panel.hidden = panel.dataset.conversationPanel !== id;
+        });
+      };
+
+      const selectConversation = (id: string) => {
+        selectedId = id;
+        listScrollTop = list?.scrollTop ?? 0;
+        pageScrollTop = window.scrollY;
+        items.forEach((item) => item.setAttribute("aria-pressed", String(item.dataset.conversationId === id)));
+        showPanel(id);
+        root.dataset.view = "active";
+        root.dataset.demoState = "default";
+        if (overviewTitle) overviewTitle.textContent = "Samtaler";
+      };
+
+      const startNewConversation = () => {
+        items.forEach((item) => item.setAttribute("aria-pressed", "false"));
+        showPanel("new");
+        root.dataset.view = "new";
+        root.dataset.demoState = "default";
+        if (overviewTitle) overviewTitle.textContent = "Samtaler";
+      };
+
+      const returnToOverview = () => {
+        root.dataset.view = "overview";
+        root.dataset.demoState = "default";
+        if (overviewTitle) overviewTitle.textContent = "Samtalene dine";
+        if (list) list.scrollTop = listScrollTop;
+        window.requestAnimationFrame(() => window.scrollTo({ top: pageScrollTop, behavior: "auto" }));
+        if (selectedId) {
+          items.forEach((item) => item.setAttribute("aria-pressed", String(item.dataset.conversationId === selectedId)));
+        }
+      };
+
+      items.forEach((item) => {
+        item.addEventListener("click", () => {
+          const id = item.dataset.conversationId;
+          if (id) selectConversation(id);
+        });
+      });
+
+      root.querySelectorAll<HTMLButtonElement>("[data-new-conversation]").forEach((button) => {
+        button.addEventListener("click", startNewConversation);
+      });
+
+      root.querySelectorAll<HTMLButtonElement>("[data-back-to-conversations]").forEach((button) => {
+        button.addEventListener("click", returnToOverview);
+      });
+
+      root.querySelectorAll<HTMLFormElement>("[data-prototype-composer]").forEach((form) => {
+        const input = form.querySelector<HTMLTextAreaElement>("[data-prototype-input]");
+        const send = form.querySelector<HTMLButtonElement>("[data-prototype-send]");
+        input?.addEventListener("input", () => {
+          if (send) send.disabled = !input.value.trim();
+        });
+        form.addEventListener("submit", (event) => {
+          event.preventDefault();
+          if (!input?.value.trim()) return;
+          root.dataset.demoState = "pending";
+          input.value = "";
+          if (send) send.disabled = true;
+        });
+      });
+
+      root.querySelectorAll<HTMLButtonElement>("[data-clear-demo-state]").forEach((button) => {
+        button.addEventListener("click", () => {
+          root.dataset.demoState = "default";
+        });
+      });
+
+      root.querySelector<HTMLButtonElement>("[data-demo-view='overview']")?.addEventListener("click", () => {
+        root.dataset.history = "populated";
+        returnToOverview();
+      });
+
+      root.querySelector<HTMLButtonElement>("[data-demo-history='empty']")?.addEventListener("click", () => {
+        root.dataset.history = "empty";
+        root.dataset.view = "overview";
+        root.dataset.demoState = "default";
+        if (overviewTitle) overviewTitle.textContent = "Samtalene dine";
+      });
+
+      root.querySelectorAll<HTMLButtonElement>("[data-demo-state]").forEach((button) => {
+        button.addEventListener("click", () => {
+          root.dataset.history = "populated";
+          if (root.dataset.view === "overview") {
+            selectConversation(selectedId || items[0]?.dataset.conversationId || "");
+          }
+          root.dataset.demoState = button.dataset.demoState || "default";
+        });
+      });
+
+      root.querySelector<HTMLButtonElement>("[data-demo-reset]")?.addEventListener("click", () => {
+        selectedId = "";
+        items.forEach((item) => item.setAttribute("aria-pressed", "false"));
+        root.dataset.history = "populated";
+        returnToOverview();
+      });
+    })();
+  </script>
+</BaseLayout>

--- a/src/styles/viddel-conversation-area.css
+++ b/src/styles/viddel-conversation-area.css
@@ -1,0 +1,642 @@
+body.vox-shell--conversation-area {
+  min-height: 100dvh;
+}
+
+.conversation-area {
+  width: 100%;
+  padding-bottom: 3rem;
+}
+
+.conversation-area__surface {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 0;
+  min-height: min(70dvh, 760px);
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  background: rgb(var(--surface) / 0.78);
+  box-shadow: var(--shadow-sm);
+  transition: grid-template-columns 220ms ease;
+}
+
+.conversation-area[data-view="active"] .conversation-area__surface,
+.conversation-area[data-view="new"] .conversation-area__surface {
+  grid-template-columns: minmax(17rem, 34%) minmax(0, 66%);
+}
+
+.conversation-overview {
+  min-width: 0;
+  padding: clamp(1.25rem, 3vw, 2.5rem);
+  transition: padding 220ms ease, background-color 180ms ease;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-overview {
+  padding: 1.125rem;
+  background: rgb(var(--surface-subtle) / 0.72);
+  box-shadow: inset -1px 0 0 rgb(var(--border) / 0.38);
+}
+
+.conversation-overview__inner {
+  width: min(100%, 48rem);
+  margin-inline: auto;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-overview__inner {
+  width: 100%;
+}
+
+.conversation-overview__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.conversation-overview__header h1,
+.conversation-context__heading h1,
+.conversation-empty-state h2 {
+  margin: 0;
+  color: rgb(var(--text));
+}
+
+.conversation-overview__header h1 {
+  font-size: clamp(1.45rem, 3vw, 2rem);
+  line-height: 1.2;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-overview__header h1 {
+  font-size: 1.1rem;
+}
+
+.conversation-action {
+  display: inline-flex;
+  min-height: 2.65rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border: 0;
+  border-radius: var(--radius-md);
+  padding: 0.65rem 0.85rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.conversation-action svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.conversation-action--primary {
+  color: rgb(var(--primary-contrast));
+  background: rgb(var(--accent-primary));
+}
+
+.conversation-action--primary:hover {
+  background: color-mix(in srgb, rgb(var(--accent-primary)) 88%, rgb(var(--text)) 12%);
+}
+
+.conversation-action--quiet {
+  color: rgb(var(--text));
+  background: transparent;
+}
+
+.conversation-action--quiet:hover {
+  background: rgb(var(--surface-subtle));
+}
+
+.conversation-action:focus-visible,
+.conversation-item:focus-visible,
+.conversation-context__back:focus-visible,
+.conversation-composer :is(textarea, button):focus-visible,
+.conversation-area__demo button:focus-visible {
+  outline: 2px solid rgb(var(--focus-ring));
+  outline-offset: 2px;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"])
+  .conversation-overview__header
+  .conversation-action {
+  min-width: 2.65rem;
+  padding-inline: 0.7rem;
+  color: rgb(var(--text));
+  background: transparent;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"])
+  .conversation-overview__header
+  .conversation-action span {
+  display: none;
+}
+
+.conversation-overview__list {
+  display: grid;
+}
+
+.conversation-day-group {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.conversation-day-group + .conversation-day-group {
+  margin-top: 1.75rem;
+}
+
+.conversation-item {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr);
+  gap: 1rem;
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+  color: rgb(var(--text));
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.conversation-item:hover {
+  background: rgb(var(--surface-subtle) / 0.86);
+}
+
+.conversation-item[aria-pressed="true"] {
+  background: color-mix(in srgb, rgb(var(--surface-subtle)) 88%, rgb(var(--accent-primary)) 12%);
+  box-shadow: inset 3px 0 0 rgb(var(--accent-primary) / 0.78);
+}
+
+.conversation-item__date-column,
+.conversation-item__content,
+.conversation-item__heading-row {
+  min-width: 0;
+}
+
+.conversation-item__date-column {
+  display: grid;
+  align-content: start;
+  gap: 0.1rem;
+  color: rgb(var(--text-secondary));
+  font-size: 0.78rem;
+}
+
+.conversation-item__day--hidden {
+  visibility: hidden;
+}
+
+.conversation-item__content {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.conversation-item__date-inline {
+  display: none;
+  gap: 0.4rem;
+  color: rgb(var(--text-secondary));
+  font-size: 0.78rem;
+}
+
+.conversation-item__date-inline span + span::before {
+  content: "·";
+  margin-right: 0.4rem;
+}
+
+.conversation-item__heading-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.conversation-item__title {
+  display: -webkit-box;
+  min-width: 0;
+  overflow: hidden;
+  font-weight: 600;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.conversation-item__time-inline {
+  display: none;
+  flex: 0 0 auto;
+  color: rgb(var(--text-secondary));
+  font-size: 0.78rem;
+}
+
+.conversation-item__excerpt {
+  overflow: hidden;
+  color: rgb(var(--text-secondary));
+  font-size: 0.9rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-item__origin {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  align-items: center;
+  gap: 0.35rem;
+  overflow: hidden;
+  color: rgb(var(--text-secondary));
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.conversation-item__origin svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: 0 0 auto;
+}
+
+.conversation-item__origin span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-item {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  padding: 0.65rem;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-item__date-column,
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-item__excerpt,
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-item__time-inline {
+  display: none;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-item__date-inline {
+  display: flex;
+}
+
+.conversation-empty-state {
+  display: none;
+  min-height: 24rem;
+  place-content: center;
+  justify-items: center;
+  gap: 1.15rem;
+  text-align: center;
+}
+
+.conversation-empty-state h2 {
+  font-size: clamp(1.35rem, 3vw, 1.8rem);
+}
+
+.conversation-area[data-history="empty"] .conversation-overview__list,
+.conversation-area[data-history="empty"] .conversation-overview__header .conversation-action {
+  display: none;
+}
+
+.conversation-area[data-history="empty"] .conversation-empty-state {
+  display: grid;
+}
+
+.conversation-context {
+  min-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  background: rgb(var(--surface));
+  transform: translateX(0.8rem);
+  transition: opacity 160ms ease 60ms, transform 200ms ease 40ms;
+}
+
+.conversation-area:is([data-view="active"], [data-view="new"]) .conversation-context {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+}
+
+.conversation-context__panel {
+  display: flex;
+  min-height: min(70dvh, 760px);
+  flex-direction: column;
+}
+
+.conversation-context__panel[hidden] {
+  display: none;
+}
+
+.conversation-context__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow: inset 0 -1px 0 rgb(var(--border) / 0.34);
+}
+
+.conversation-context__heading {
+  min-width: 0;
+}
+
+.conversation-context__heading h1 {
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+  line-height: 1.3;
+}
+
+.conversation-context__heading p {
+  overflow: hidden;
+  margin: 0.3rem 0 0;
+  color: rgb(var(--text-secondary));
+  font-size: 0.8rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-context__back {
+  display: none;
+  align-items: center;
+  gap: 0.25rem;
+  border: 0;
+  padding: 0;
+  color: rgb(var(--text));
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
+.conversation-context__back svg {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.conversation-context__body {
+  display: flex;
+  min-height: 20rem;
+  flex: 1;
+  flex-direction: column;
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.conversation-context__body--new {
+  place-content: center;
+}
+
+.conversation-context__transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.conversation-message {
+  max-width: 42rem;
+  color: rgb(var(--text));
+  line-height: 1.6;
+}
+
+.conversation-message--user {
+  align-self: flex-end;
+  max-width: min(82%, 32rem);
+  border-radius: var(--radius-md);
+  padding: 0.8rem 1rem;
+  background: rgb(var(--surface-subtle));
+}
+
+.conversation-message p {
+  margin: 0;
+}
+
+.conversation-message__speaker {
+  margin-bottom: 0.25rem !important;
+  color: rgb(var(--text-secondary));
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.conversation-context__status,
+.conversation-context__error {
+  display: none;
+  margin: auto 0 0;
+  padding-top: 1.25rem;
+  color: rgb(var(--text-secondary));
+}
+
+.conversation-area[data-demo-state="pending"] [data-prototype-pending] {
+  display: block;
+}
+
+.conversation-area[data-demo-state="error"] [data-prototype-error] {
+  display: block;
+}
+
+.conversation-context__error p {
+  margin: 0 0 0.5rem;
+  color: rgb(var(--text));
+}
+
+.conversation-context__error button {
+  border: 0;
+  padding: 0;
+  color: rgb(var(--accent-primary));
+  background: transparent;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.conversation-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.55rem;
+  margin: 0 1.5rem 1.35rem;
+  border-radius: var(--radius-md);
+  padding: 0.45rem;
+  background: rgb(var(--surface-subtle));
+  box-shadow: inset 0 0 0 1px rgb(var(--border) / 0.28), var(--shadow-sm);
+}
+
+.conversation-composer:focus-within {
+  box-shadow: inset 0 0 0 1px rgb(var(--focus-ring) / 0.55), var(--shadow-sm);
+}
+
+.conversation-composer textarea {
+  min-height: 2.8rem;
+  flex: 1;
+  resize: none;
+  border: 0;
+  padding: 0.75rem;
+  color: rgb(var(--text));
+  background: transparent;
+  font: inherit;
+  outline: 0;
+}
+
+.conversation-composer textarea::placeholder {
+  color: rgb(var(--text-secondary));
+}
+
+.conversation-composer button {
+  width: 2.65rem;
+  height: 2.65rem;
+  border: 0;
+  border-radius: var(--radius-md);
+  color: rgb(var(--primary-contrast));
+  background: rgb(var(--accent-primary));
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.conversation-composer button:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.conversation-area__demo {
+  margin-top: 0.8rem;
+  color: rgb(var(--text-secondary));
+  font-size: 0.78rem;
+}
+
+.conversation-area__demo summary {
+  width: fit-content;
+  cursor: pointer;
+}
+
+.conversation-area__demo-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.55rem;
+}
+
+.conversation-area__demo button {
+  border: 1px solid rgb(var(--border) / 0.5);
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.55rem;
+  color: rgb(var(--text));
+  background: rgb(var(--surface) / 0.78);
+  font: inherit;
+  cursor: pointer;
+}
+
+.conversation-area[data-history="empty"]:is([data-view="active"], [data-view="new"])
+  .conversation-area__surface {
+  grid-template-columns: 0 minmax(0, 1fr);
+}
+
+.conversation-area[data-history="empty"]:is([data-view="active"], [data-view="new"])
+  .conversation-overview {
+  overflow: hidden;
+  padding: 0;
+}
+
+@media (max-width: 760px) {
+  .conversation-area__surface,
+  .conversation-area[data-view="active"] .conversation-area__surface,
+  .conversation-area[data-view="new"] .conversation-area__surface {
+    display: block;
+    min-height: calc(100dvh - 9.5rem);
+    border-radius: var(--radius-md);
+  }
+
+  .conversation-overview,
+  .conversation-area:is([data-view="active"], [data-view="new"]) .conversation-overview {
+    padding: 1rem;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .conversation-area:is([data-view="active"], [data-view="new"]) .conversation-overview {
+    display: none;
+  }
+
+  .conversation-overview__header h1,
+  .conversation-area:is([data-view="active"], [data-view="new"]) .conversation-overview__header h1 {
+    font-size: 1.45rem;
+  }
+
+  .conversation-overview__header .conversation-action span {
+    display: none;
+  }
+
+  .conversation-overview__header .conversation-action {
+    min-width: 2.65rem;
+    padding-inline: 0.7rem;
+  }
+
+  .conversation-item,
+  .conversation-area:is([data-view="active"], [data-view="new"]) .conversation-item {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0;
+    padding: 0.72rem;
+  }
+
+  .conversation-item__date-column,
+  .conversation-item__excerpt,
+  .conversation-item__time-inline {
+    display: none;
+  }
+
+  .conversation-item__date-inline,
+  .conversation-area:is([data-view="active"], [data-view="new"]) .conversation-item__date-inline {
+    display: flex;
+  }
+
+  .conversation-context {
+    display: none;
+    min-height: calc(100dvh - 9.5rem);
+    opacity: 1;
+    transform: none;
+  }
+
+  .conversation-area:is([data-view="active"], [data-view="new"]) .conversation-context {
+    display: block;
+  }
+
+  .conversation-context__panel {
+    min-height: calc(100dvh - 9.5rem);
+  }
+
+  .conversation-context__header {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    padding: 1rem;
+  }
+
+  .conversation-context__back {
+    display: inline-flex;
+  }
+
+  .conversation-context__header .conversation-action {
+    display: none;
+  }
+
+  .conversation-context__body {
+    padding: 1.25rem 1rem;
+  }
+
+  .conversation-composer {
+    margin: 0 1rem 1rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .conversation-area {
+    margin-inline: -0.25rem;
+    width: calc(100% + 0.5rem);
+  }
+
+  .conversation-overview,
+  .conversation-context__header,
+  .conversation-context__body {
+    padding-inline: 0.8rem;
+  }
+
+  .conversation-composer {
+    margin-inline: 0.8rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .conversation-area__surface,
+  .conversation-overview,
+  .conversation-context {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Formål

Implementerer kun Snitt A fra den godkjente implementeringsbriefen for innlogget samtaleområde.

## Levert

- isolert noindex-route /no/samtaler/
- syntetisk, typet samtaledata og daggruppering
- ConversationOverview, ConversationItem, ConversationContext og ConversationEmptyState
- full desktopoversikt og adaptiv delt desktopflate
- mobiloversikt, aktiv samtale, ny samtale og tilbake
- tom historikk, pending og feil som kontrollerte prototypestates
- semantisk tokenkobling uten nye globale tokenverdier
- kandidatregistrering i current-state og /designsystem/

## Vernet

- /no/chat er urørt
- ArticleInlineChatShell er urørt
- ingen auth, lagring, datalag eller API-integrasjon
- ingen global Composer- eller chat-CSS-endring

## Verifikasjon

- npm run build ✅
- VIS sprint guard ✅
- Backstage guard ✅
- VIS runtime feed guard ✅
- Lab gate ✅
- syntetisk daggruppering kontrollert ✅
- bygget HTML inneholder ikke CES/chat-messenger på /no/samtaler/ ✅

## Review

Stopp etter Snitt A. Kontroller preview på desktop, 390 px, 320 px, lys og mørk før eventuell dialogkobling.

Relatert: #283