### PR TITLE
Snitt B: produksjonsnær Composer i samtaleområdet

### DIFF
--- a/src/components/conversation/ConversationComposer.astro
+++ b/src/components/conversation/ConversationComposer.astro
@@ -1,0 +1,144 @@
+---
+type Props = {
+  id: string;
+};
+
+const { id } = Astro.props as Props;
+const inputId = `conversation-input-${id}`;
+const fileId = `conversation-file-${id}`;
+const menuId = `conversation-attach-menu-${id}`;
+---
+
+<div
+  class="conversation-composer inline-chat-shell"
+  data-conversation-composer
+  data-viddel-chat
+  data-inline-chat-mode="progressive"
+  data-inline-chat-conversation="active"
+>
+  <div class="inline-chat-shell__compose-stack" data-conversation-compose-stack>
+    <p class="inline-chat-shell__status inline-chat-shell__status--dock" data-prototype-pending role="status">
+      Viddel svarer …
+    </p>
+    <div class="conversation-composer__error" data-prototype-error role="alert">
+      <p data-conversation-composer-error>Svaret kunne ikke leveres.</p>
+      <button type="button" data-clear-demo-state>Prøv igjen</button>
+    </div>
+
+    <div class="viddel-chat-attach__attach-layer hidden" data-conversation-attach-layer>
+      <div
+        class="viddel-chat-attach__attach-menu-backdrop hidden"
+        data-conversation-attach-backdrop
+        aria-hidden="true"
+      ></div>
+      <div
+        id={menuId}
+        class="viddel-chat-attach__attach-menu hidden"
+        data-conversation-attach-menu
+        role="menu"
+        aria-label="Legg til bilde"
+      >
+        <button
+          type="button"
+          class="viddel-chat-attach__attach-menu-item viddel-chat-attach__attach-menu-item--camera"
+          data-conversation-attach-camera
+          role="menuitem"
+        >
+          <span class="viddel-chat-attach__attach-menu-item-content">
+            <svg
+              class="viddel-chat-attach__attach-menu-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.85"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 8h3l2-2h6l2 2h3v11H4V8z"></path>
+              <circle cx="12" cy="13" r="3.25"></circle>
+            </svg>
+            <span>Ta bilde</span>
+          </span>
+        </button>
+        <button
+          type="button"
+          class="viddel-chat-attach__attach-menu-item"
+          data-conversation-attach-pick
+          role="menuitem"
+        >
+          <span class="viddel-chat-attach__attach-menu-item-content">
+            <svg
+              class="viddel-chat-attach__attach-menu-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.85"
+              aria-hidden="true"
+            >
+              <rect x="4" y="5" width="16" height="14" rx="2"></rect>
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.5 14.5 11 11.5l2.5 3 2-1.5L18 15"></path>
+              <circle cx="9" cy="9" r="1"></circle>
+            </svg>
+            <span class="viddel-chat-attach__attach-menu-label--mobile">Velg bilde</span>
+            <span class="viddel-chat-attach__attach-menu-label--desktop">Last opp bilde</span>
+          </span>
+        </button>
+      </div>
+    </div>
+
+    <form class="inline-chat-shell__compose viddel-chat-attach__compose" data-prototype-composer>
+      <input id={fileId} type="file" accept="image/*" class="sr-only" data-conversation-file />
+      <div class="viddel-chat-attach__attachment-strip hidden" data-conversation-attachment-strip>
+        <div class="viddel-chat-attach__attachment-list">
+          <div class="viddel-chat-attach__attachment">
+            <img class="viddel-chat-attach__thumb" data-conversation-thumb alt="Valgt utstyr-bilde" />
+            <button
+              type="button"
+              class="viddel-chat-attach__remove-attachment"
+              data-conversation-remove
+              aria-label="Fjern bilde"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="viddel-chat-attach__compose-row">
+        <div class="viddel-chat-attach__attach-wrap">
+          <button
+            type="button"
+            class="viddel-chat-attach__attach"
+            data-conversation-attach
+            aria-label="Legg til bilde"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-controls={menuId}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" aria-hidden="true">
+              <path stroke-linecap="round" d="M12 5v14M5 12h14"></path>
+            </svg>
+          </button>
+        </div>
+        <div class="inline-chat-shell__compose-input-wrap viddel-chat-attach__compose-input-wrap">
+          <label class="sr-only" for={inputId}>Skriv spørsmål til Viddel</label>
+          <textarea
+            id={inputId}
+            class="inline-chat-shell__compose-input"
+            rows="1"
+            enterkeyhint="send"
+            placeholder="Hva lurer du på?"
+            data-prototype-input
+          ></textarea>
+        </div>
+        <button
+          type="submit"
+          class="inline-chat-shell__compose-send"
+          aria-label="Send spørsmål"
+          disabled
+          data-prototype-send
+        >
+          <span aria-hidden="true">↑</span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/components/conversation/ConversationContext.astro
+++ b/src/components/conversation/ConversationContext.astro
@@ -1,5 +1,6 @@
 ---
 import type { ConversationPrototype } from "../../data/conversation-prototype-v01";
+import ConversationComposer from "./ConversationComposer.astro";
 
 type Props = {
   conversations: ConversationPrototype[];
@@ -50,25 +51,8 @@ const { conversations, selectedId } = Astro.props as Props;
               </div>
             ))}
           </div>
-          <p class="conversation-context__status" data-prototype-pending role="status">Viddel svarer …</p>
-          <div class="conversation-context__error" data-prototype-error role="alert">
-            <p>Svaret kunne ikke leveres.</p>
-            <button type="button" data-clear-demo-state>Prøv igjen</button>
-          </div>
         </div>
-
-        <form class="conversation-composer" data-prototype-composer>
-          <label class="sr-only" for={`conversation-input-${conversation.id}`}>Skriv spørsmål til Viddel</label>
-          <textarea
-            id={`conversation-input-${conversation.id}`}
-            rows="1"
-            placeholder="Hva lurer du på?"
-            data-prototype-input
-          />
-          <button type="submit" aria-label="Send spørsmål" disabled data-prototype-send>
-            <span aria-hidden="true">↑</span>
-          </button>
-        </form>
+        <ConversationComposer id={conversation.id} />
       </article>
     ))
   }
@@ -91,12 +75,6 @@ const { conversations, selectedId } = Astro.props as Props;
       </div>
     </header>
     <div class="conversation-context__body conversation-context__body--new"></div>
-    <form class="conversation-composer" data-prototype-composer>
-      <label class="sr-only" for="conversation-input-new">Skriv spørsmål til Viddel</label>
-      <textarea id="conversation-input-new" rows="1" placeholder="Hva lurer du på?" data-prototype-input />
-      <button type="submit" aria-label="Send spørsmål" disabled data-prototype-send>
-        <span aria-hidden="true">↑</span>
-      </button>
-    </form>
+    <ConversationComposer id="new" />
   </article>
 </section>

--- a/src/components/nav/Header.astro
+++ b/src/components/nav/Header.astro
@@ -10,9 +10,10 @@ type Props = {
   brand?: "default" | "klarlyd" | "viddel";
   /** Midlertidig intern devtools (#81) — vis diskret toggle etter «Om». */
   showDevtoolsToggle?: boolean;
+  showChatEntry?: boolean;
 };
 
-const { currentPath = "", brand = "default", showDevtoolsToggle = false } = Astro.props as Props;
+const { currentPath = "", brand = "default", showDevtoolsToggle = false, showChatEntry = true } = Astro.props as Props;
 const base = import.meta.env.BASE_URL;
 const homeHref = `${base}no`;
 const chatHref = `${base}${NO_NAV_CHAT_HREF.replace(/^\//, "")}`;
@@ -98,7 +99,7 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
       }
     </nav>
     {
-      chatActive ? (
+      !showChatEntry || chatActive ? (
         <div class="pointer-events-none hidden w-[8.75rem] lg:block" aria-hidden="true"></div>
       ) : (
         <a

--- a/src/components/nav/MobileMenuSheet.astro
+++ b/src/components/nav/MobileMenuSheet.astro
@@ -7,9 +7,10 @@ type Props = {
   currentPath?: string;
   brand?: "default" | "klarlyd" | "viddel";
   showDevtoolsToggle?: boolean;
+  showChatEntry?: boolean;
 };
 
-const { currentPath = "", brand = "default", showDevtoolsToggle = false } = Astro.props as Props;
+const { currentPath = "", brand = "default", showDevtoolsToggle = false, showChatEntry = true } = Astro.props as Props;
 const menuTitle =
   brand === "klarlyd" ? "KLARLYD meny" : brand === "viddel" ? "Viddel meny" : "VOX meny";
 const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
@@ -57,7 +58,7 @@ const chatActive = isNavActive(NO_NAV_CHAT_HREF, currentPath);
       }
     </nav>
     {
-      !chatActive ? (
+      showChatEntry && !chatActive ? (
         <a
           href={NO_NAV_CHAT_HREF}
           class="mt-4 flex w-full items-center justify-center rounded-full border border-[rgb(var(--border))/0.7] bg-[rgb(var(--surface-subtle))] px-5 py-3 text-sm font-semibold text-[rgb(var(--text))] transition-colors"

--- a/src/data/design-system-source-of-truth-v01.ts
+++ b/src/data/design-system-source-of-truth-v01.ts
@@ -241,11 +241,14 @@ export const patterns: PatternRecord[] = [
       "src/pages/no/samtaler.astro",
       "src/components/conversation/ConversationOverview.astro",
       "src/components/conversation/ConversationItem.astro",
+      "src/components/conversation/ConversationContext.astro",
+      "src/components/conversation/ConversationComposer.astro",
       "src/styles/viddel-conversation-area.css",
     ],
     do: [
       "Bruk åpen liste, kronologisk gruppering og semantisk valgt state",
       "Behold samme samtaleidentitet i full og kompakt presentasjon",
+      "La Composer følge produksjonskontrakten uten å trekke inn rutens faste posisjonering",
       "Bruk eksisterende semantiske tokens i lys og mørk modus",
     ],
     dont: [

--- a/src/data/design-system-source-of-truth-v01.ts
+++ b/src/data/design-system-source-of-truth-v01.ts
@@ -248,7 +248,7 @@ export const patterns: PatternRecord[] = [
     do: [
       "Bruk åpen liste, kronologisk gruppering og semantisk valgt state",
       "Behold samme samtaleidentitet i full og kompakt presentasjon",
-      "La Composer følge produksjonskontrakten uten å trekke inn rutens faste posisjonering",
+      "Behold Composer-adapteren lokal; produksjons-Composer er canonical til en eksplisitt harmoniseringsbeslutning",
       "Bruk eksisterende semantiske tokens i lys og mørk modus",
     ],
     dont: [

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,7 @@ const {
   shellVariant = "default",
   headerBrand = "viddel",
   showHeaderDevtoolsToggle = true,
+  showHeaderChatEntry = true,
 } = Astro.props as {
   title?: string;
   currentPath?: string;
@@ -20,6 +21,8 @@ const {
   headerBrand?: "default" | "klarlyd" | "viddel";
   /** Midlertidig intern devtools (#81) — kun der det eksplisitt slås på (f.eks. r1-spoke-v03). */
   showHeaderDevtoolsToggle?: boolean;
+  /** Global samtaleinngang skjules når den lokale flaten allerede eier samtalehandlingen. */
+  showHeaderChatEntry?: boolean;
 };
 const isSandboxWhite = shellVariant === "sandbox-white";
 const isStandaloneChat = shellVariant === "standalone-chat";
@@ -153,12 +156,22 @@ const disablesCes = isStandaloneChat || isConversationArea;
         style="box-shadow: var(--shadow-header);"
       >
         <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-          <Header currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
+          <Header
+            currentPath={currentPath}
+            brand={headerBrand}
+            showDevtoolsToggle={showHeaderDevtoolsToggle}
+            showChatEntry={showHeaderChatEntry}
+          />
         </div>
       </div>
     </header>
 
-    <MobileMenuSheet currentPath={currentPath} brand={headerBrand} showDevtoolsToggle={showHeaderDevtoolsToggle} />
+    <MobileMenuSheet
+      currentPath={currentPath}
+      brand={headerBrand}
+      showDevtoolsToggle={showHeaderDevtoolsToggle}
+      showChatEntry={showHeaderChatEntry}
+    />
 
     <div
       class:list={[

--- a/src/pages/no/samtaler.astro
+++ b/src/pages/no/samtaler.astro
@@ -21,6 +21,7 @@ const groups = groupPrototypeConversations(conversationPrototypeData);
   shellVariant="conversation-area"
   headerBrand="viddel"
   showHeaderDevtoolsToggle={false}
+  showHeaderChatEntry={false}
 >
   <meta slot="head" name="robots" content="noindex,nofollow" />
 

--- a/src/pages/no/samtaler.astro
+++ b/src/pages/no/samtaler.astro
@@ -7,6 +7,7 @@ import {
   conversationPrototypeData,
   groupPrototypeConversations,
 } from "../../data/conversation-prototype-v01";
+import "../../styles/viddel-chat-attachment.css";
 import "../../styles/viddel-conversation-area.css";
 
 Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
@@ -48,6 +49,9 @@ const groups = groupPrototypeConversations(conversationPrototypeData);
   </main>
 
   <script>
+    import { initChatAttachmentMenu } from "../../lib/chat-image-attachment-menu-v01";
+    import { validateChatImageFile } from "../../lib/chat-image-file-v01";
+
     (() => {
       const root = document.querySelector<HTMLElement>("[data-conversation-area]");
       if (!root) return;
@@ -112,17 +116,90 @@ const groups = groupPrototypeConversations(conversationPrototypeData);
       });
 
       root.querySelectorAll<HTMLFormElement>("[data-prototype-composer]").forEach((form) => {
+        const composer = form.closest<HTMLElement>("[data-conversation-composer]");
+        const composeStack = composer?.querySelector<HTMLElement>("[data-conversation-compose-stack]");
         const input = form.querySelector<HTMLTextAreaElement>("[data-prototype-input]");
         const send = form.querySelector<HTMLButtonElement>("[data-prototype-send]");
+        const fileInput = form.querySelector<HTMLInputElement>("[data-conversation-file]");
+        const attachmentStrip = form.querySelector<HTMLElement>("[data-conversation-attachment-strip]");
+        const thumb = form.querySelector<HTMLImageElement>("[data-conversation-thumb]");
+        const remove = form.querySelector<HTMLButtonElement>("[data-conversation-remove]");
+        const attachLayer = composer?.querySelector<HTMLElement>("[data-conversation-attach-layer]");
+        const attachBtn = composer?.querySelector<HTMLButtonElement>("[data-conversation-attach]");
+        const attachMenu = composer?.querySelector<HTMLElement>("[data-conversation-attach-menu]");
+        const attachBackdrop = composer?.querySelector<HTMLElement>("[data-conversation-attach-backdrop]");
+        const attachCameraBtn = composer?.querySelector<HTMLButtonElement>("[data-conversation-attach-camera]");
+        const attachPickBtn = composer?.querySelector<HTMLButtonElement>("[data-conversation-attach-pick]");
+        const error = composer?.querySelector<HTMLElement>("[data-conversation-composer-error]");
+        let selectedFile: File | null = null;
+        let objectUrl = "";
+
+        const syncSend = () => {
+          if (send) send.disabled = !input?.value.trim() && !selectedFile;
+        };
+
+        const clearAttachment = () => {
+          selectedFile = null;
+          if (objectUrl) URL.revokeObjectURL(objectUrl);
+          objectUrl = "";
+          if (thumb) thumb.removeAttribute("src");
+          attachmentStrip?.classList.add("hidden");
+          if (fileInput) fileInput.value = "";
+          syncSend();
+        };
+
+        if (
+          composeStack &&
+          fileInput &&
+          attachLayer &&
+          attachBtn &&
+          attachMenu &&
+          attachBackdrop &&
+          attachCameraBtn &&
+          attachPickBtn
+        ) {
+          initChatAttachmentMenu(
+            {
+              attachLayer,
+              attachBtn,
+              attachMenu,
+              attachBackdrop,
+              attachCameraBtn,
+              attachPickBtn,
+              fileInput,
+              composeStack,
+            },
+            {
+              onFileSelected: (file) => {
+                const validation = validateChatImageFile(file);
+                if (!validation.ok) {
+                  if (error) error.textContent = validation.message;
+                  root.dataset.demoState = "error";
+                  clearAttachment();
+                  return;
+                }
+                root.dataset.demoState = "default";
+                selectedFile = file;
+                if (objectUrl) URL.revokeObjectURL(objectUrl);
+                objectUrl = URL.createObjectURL(file);
+                if (thumb) thumb.src = objectUrl;
+                attachmentStrip?.classList.remove("hidden");
+                syncSend();
+              },
+            },
+          );
+        }
+
         input?.addEventListener("input", () => {
-          if (send) send.disabled = !input.value.trim();
+          syncSend();
         });
+        remove?.addEventListener("click", clearAttachment);
         form.addEventListener("submit", (event) => {
           event.preventDefault();
-          if (!input?.value.trim()) return;
+          if (!input?.value.trim() && !selectedFile) return;
           root.dataset.demoState = "pending";
-          input.value = "";
-          if (send) send.disabled = true;
+          if (input) input.value = "";
+          clearAttachment();
         });
       });
 

--- a/src/styles/viddel-conversation-area.css
+++ b/src/styles/viddel-conversation-area.css
@@ -117,15 +117,6 @@ body.vox-shell--conversation-area {
 .conversation-area:is([data-view="active"], [data-view="new"])
   .conversation-overview__header
   .conversation-action {
-  min-width: 2.65rem;
-  padding-inline: 0.7rem;
-  color: rgb(var(--text));
-  background: transparent;
-}
-
-.conversation-area:is([data-view="active"], [data-view="new"])
-  .conversation-overview__header
-  .conversation-action span {
   display: none;
 }
 
@@ -661,17 +652,25 @@ body.vox-shell--conversation-area .viddel-chat-attach__attach-menu-item:focus-vi
   }
 
   .conversation-context__header {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.75rem;
     padding: 1rem;
   }
 
   .conversation-context__back {
     display: inline-flex;
+    grid-column: 1 / -1;
+  }
+
+  .conversation-context__heading {
+    grid-column: 1;
   }
 
   .conversation-context__header .conversation-action {
-    display: none;
+    display: inline-flex;
+    grid-column: 2;
+    grid-row: 2;
+    align-self: start;
   }
 
   .conversation-context__body {

--- a/src/styles/viddel-conversation-area.css
+++ b/src/styles/viddel-conversation-area.css
@@ -408,12 +408,12 @@ body.vox-shell--conversation-area {
   font-weight: 600;
 }
 
-.conversation-context__status,
-.conversation-context__error {
+.conversation-composer [data-prototype-pending],
+.conversation-composer [data-prototype-error] {
   display: none;
-  margin: auto 0 0;
-  padding-top: 1.25rem;
+  margin: 0 0 0.55rem;
   color: rgb(var(--text-secondary));
+  font-size: 0.86rem;
 }
 
 .conversation-area[data-demo-state="pending"] [data-prototype-pending] {
@@ -424,12 +424,12 @@ body.vox-shell--conversation-area {
   display: block;
 }
 
-.conversation-context__error p {
+.conversation-composer__error p {
   margin: 0 0 0.5rem;
   color: rgb(var(--text));
 }
 
-.conversation-context__error button {
+.conversation-composer__error button {
   border: 0;
   padding: 0;
   color: rgb(var(--accent-primary));
@@ -440,51 +440,118 @@ body.vox-shell--conversation-area {
 }
 
 .conversation-composer {
-  display: flex;
-  align-items: flex-end;
-  gap: 0.55rem;
   margin: 0 1.5rem 1.35rem;
-  border-radius: var(--radius-md);
-  padding: 0.45rem;
-  background: rgb(var(--surface-subtle));
-  box-shadow: inset 0 0 0 1px rgb(var(--border) / 0.28), var(--shadow-sm);
+  color: rgb(var(--text));
 }
 
-.conversation-composer:focus-within {
-  box-shadow: inset 0 0 0 1px rgb(var(--focus-ring) / 0.55), var(--shadow-sm);
+.conversation-composer .inline-chat-shell__compose-stack {
+  width: min(100%, 46rem);
+  margin-inline: auto;
 }
 
-.conversation-composer textarea {
-  min-height: 2.8rem;
-  flex: 1;
+.conversation-composer .inline-chat-shell__compose {
+  display: flex;
+  min-height: 3.4rem;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.5rem 0.58rem;
+  background: rgb(var(--surface));
+  box-shadow: var(--shadow-md);
+  transition: border-radius 160ms ease, box-shadow 160ms ease;
+}
+
+.conversation-composer .inline-chat-shell__compose:focus-within {
+  box-shadow: 0 0 0 2px rgb(var(--focus-ring) / 0.38), var(--shadow-md);
+}
+
+.conversation-composer
+  .inline-chat-shell__compose:has(.viddel-chat-attach__attachment-strip:not(.hidden)),
+.conversation-composer .inline-chat-shell__compose:has(.inline-chat-shell__compose-input[data-chat-input-expanded]) {
+  border-radius: 1.65rem;
+}
+
+.conversation-composer .viddel-chat-attach__compose-row {
+  align-items: center;
+}
+
+.conversation-composer .inline-chat-shell__compose-input-wrap {
+  display: grid;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.conversation-composer .inline-chat-shell__compose-input {
+  width: 100%;
+  min-height: 2.75rem;
+  max-height: min(9rem, 32vh);
   resize: none;
   border: 0;
-  padding: 0.75rem;
+  padding: 0.58rem 0.15rem 0.58rem 0;
   color: rgb(var(--text));
   background: transparent;
   font: inherit;
+  font-size: 1.02rem;
+  line-height: 1.4;
   outline: 0;
 }
 
-.conversation-composer textarea::placeholder {
-  color: rgb(var(--text-secondary));
+.conversation-composer .inline-chat-shell__compose-input::placeholder {
+  color: rgb(var(--text-secondary) / 0.72);
 }
 
-.conversation-composer button {
-  width: 2.65rem;
-  height: 2.65rem;
+.conversation-composer .inline-chat-shell__compose-send {
+  display: inline-flex;
+  width: 2.85rem;
+  min-width: 2.85rem;
+  height: 2.85rem;
+  min-height: 2.85rem;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
   border: 0;
-  border-radius: var(--radius-md);
-  color: rgb(var(--primary-contrast));
-  background: rgb(var(--accent-primary));
+  border-radius: 999px;
+  padding: 0;
+  color: rgb(var(--surface));
+  background: rgb(var(--text));
   font: inherit;
+  font-size: 1.05rem;
   font-weight: 700;
   cursor: pointer;
 }
 
-.conversation-composer button:disabled {
-  cursor: default;
-  opacity: 0.4;
+.conversation-composer .inline-chat-shell__compose-send:disabled {
+  cursor: not-allowed;
+  opacity: 0.46;
+}
+
+.conversation-composer .inline-chat-shell__compose-send:focus-visible,
+.conversation-composer .viddel-chat-attach__attach:focus-visible {
+  outline: 2px solid rgb(var(--focus-ring) / 0.52);
+  outline-offset: 2px;
+}
+
+.conversation-composer .viddel-chat-attach__attach {
+  color: rgb(var(--text-secondary));
+}
+
+body.vox-shell--conversation-area .viddel-chat-attach__attach-menu {
+  color: rgb(var(--text));
+  background: rgb(var(--surface));
+  box-shadow: var(--shadow-md);
+}
+
+body.vox-shell--conversation-area .viddel-chat-attach__attach-menu-item {
+  color: rgb(var(--text));
+}
+
+body.vox-shell--conversation-area .viddel-chat-attach__attach-menu-icon {
+  color: rgb(var(--text-secondary));
+}
+
+body.vox-shell--conversation-area .viddel-chat-attach__attach-menu-item:focus-visible {
+  outline-color: rgb(var(--focus-ring) / 0.52);
 }
 
 .conversation-area__demo {


### PR DESCRIPTION
## Omfang\n- erstatter den enkle prototype-Composer med en isolert adapter som følger produksjons-Composerens form, mål og copy\n- gjenbruker eksisterende vedleggsmeny og bildevalidering\n- beholder send, venter og feil som lokal prototypestate; ingen API-, auth- eller lagringskobling\n- mapper samtaleområdet til eksisterende semantiske tokens og registrerer de nye kildefilene i designsystemet\n\n## Guardrails\n- ingen endringer i /no/chat\n- ingen endringer i produksjons-Composerens stilark eller tokens\n- ingen fast posisjonering importert fra produksjonsruten\n\n## Verifisering\n- npm run build ✅\n- git diff --check ✅\n- visuell kontroll kreves på Vercel-preview: /no/samtaler/\n\nParent: #283