### PR TITLE
Offentlig rotforside for viddel.no

### DIFF
--- a/src/data/mvp-current-state.ts
+++ b/src/data/mvp-current-state.ts
@@ -66,7 +66,7 @@ export type ClosedSprint = {
 };
 
 export const mvpCurrentState = {
-  updatedAt: "2026-07-31",
+  updatedAt: "2026-08-02",
   currentSprint: {
     id: "2026-w21",
     label: "2026-W21",
@@ -80,8 +80,18 @@ export const mvpCurrentState = {
     "Monitoring levert (#188). Reliability-test via Vercel guard-limits (100/500 midlertidig) — ikke lokal token. Fallback ved behov.",
   mvpSurfaces: [
     {
+      id: "public-root",
+      label: "Viddel.no",
+      route: "/",
+      status: "Applied",
+      note: "Kort offentlig presentasjon av Viddel. Produkt-MVP-en ligger fortsatt separat under /no/.",
+      visFrontpage: true,
+      kind: "public",
+      frontpageDescription: "Offentlig presentasjon og kontaktpunkt for Viddel AS.",
+    },
+    {
       id: "frontpage",
-      label: "Forside",
+      label: "Produktforside",
       route: "/no/",
       status: "Applied",
       visFrontpage: true,
@@ -214,6 +224,11 @@ export const mvpCurrentState = {
   ] satisfies NextRisk[],
   recentChanges: [
     {
+      date: "2026-08-02",
+      summary: "Ny offentlig rotforside på / med kort Viddel-presentasjon og kontaktadresse; produkt-MVP-en beholdes under /no/.",
+      commit: "—",
+    },
+    {
       date: "2026-06-09",
       summary: "Needs-to-source coverage matrix v0.1 — P0/P1/P2 behov mappet mot full Drive inventory; 'Ingen lyd / svak lyd' anbefalt som første canonical guidance asset (#243)",
       issue: "#243",
@@ -277,7 +292,7 @@ export type VisFrontpageEntry = {
 export function getVisFrontpageEntries(baseUrl: string): VisFrontpageEntry[] {
   const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
 
-  const surfaceOrder = ["chat", "designsystem", "frontpage", "hjelp", "bedre-lyd"];
+  const surfaceOrder = ["public-root", "chat", "designsystem", "frontpage", "hjelp", "bedre-lyd"];
   const surfaces = surfaceOrder
     .map((id) => mvpCurrentState.mvpSurfaces.find((s) => s.id === id))
     .filter((s): s is MvpSurface => !!s && s.visFrontpage);

--- a/src/layouts/PublicHoldingLayout.astro
+++ b/src/layouts/PublicHoldingLayout.astro
@@ -1,0 +1,44 @@
+---
+/* CONTRACT: Minimal public company shell for viddel.no. Reuses production tokens without product navigation, CES or internal tools. */
+import "../styles/global.css";
+
+const {
+  title = "Viddel",
+  description = "Viddel utvikler en produsentuavhengig digital tjeneste for høreapparatbrukere.",
+  canonical = "https://www.viddel.no/",
+} = Astro.props as {
+  title?: string;
+  description?: string;
+  canonical?: string;
+};
+---
+
+<!doctype html>
+<html lang="no" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content={description} />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href={canonical} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Epilogue:wght@500;600;700&family=Inter:wght@400;500;600&display=swap"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="nb_NO" />
+    <meta property="og:site_name" content="Viddel" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonical} />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ const pageDescription =
 
       <article class="holding-page__content" aria-labelledby="holding-title">
         <span class="holding-page__signal" aria-hidden="true"></span>
-        <h1 id="holding-title">Viddel – hjelp med lyd i hverdagen</h1>
+        <h1 id="holding-title">Hjelp med lyd i hverdagen</h1>
 
         <div class="holding-page__copy">
           <p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,161 @@
 ---
-return Astro.redirect("/no");
+/* CONTRACT: Public company landing at viddel.no. Product MVP remains available separately under /no. */
+import PublicHoldingLayout from "../layouts/PublicHoldingLayout.astro";
+
+const pageTitle = "Viddel – hjelp med lyd i hverdagen";
+const pageDescription =
+  "Viddel utvikler en produsentuavhengig digital tjeneste som samler praktisk hjelp om høreapparat, mobil og lyd.";
 ---
+
+<PublicHoldingLayout title={pageTitle} description={pageDescription}>
+  <main class="holding-page">
+    <div class="holding-page__frame">
+      <header class="holding-page__brand">
+        <img src="/brand/viddel-wordmark.svg" alt="Viddel" width="172" height="48" />
+      </header>
+
+      <article class="holding-page__content" aria-labelledby="holding-title">
+        <span class="holding-page__signal" aria-hidden="true"></span>
+        <h1 id="holding-title">Viddel – hjelp med lyd i hverdagen</h1>
+
+        <div class="holding-page__copy">
+          <p>
+            Viddel utvikler en produsentuavhengig digital tjeneste for høreapparatbrukere. Den samler praktisk
+            hjelp om høreapparat, mobil og lyd, og forklarer hvordan ting henger sammen når spørsmålene oppstår
+            i hverdagen.
+          </p>
+          <p>
+            Vi arbeider nå med en avgrenset førsteversjon og forbereder brukertesting. Tjenesten er foreløpig
+            ikke åpen for allmenn bruk.
+          </p>
+        </div>
+
+        <p class="holding-page__contact">
+          Spørsmål? Skriv til <a href="mailto:kontakt@viddel.no">kontakt@viddel.no</a>.
+        </p>
+      </article>
+
+      <footer class="holding-page__footer">Viddel AS</footer>
+    </div>
+  </main>
+</PublicHoldingLayout>
+
+<style>
+  .holding-page {
+    min-height: 100svh;
+    background:
+      linear-gradient(180deg, rgb(var(--article-page-canvas)) 0%, rgb(var(--article-page-canvas)) 72%, rgb(var(--surface-subtle)) 100%);
+    color: rgb(var(--reading-ink));
+  }
+
+  .holding-page__frame {
+    display: grid;
+    min-height: 100svh;
+    grid-template-rows: auto 1fr auto;
+    width: min(100%, 72rem);
+    margin: 0 auto;
+    padding: clamp(1.5rem, 4vw, 3rem) clamp(1.25rem, 6vw, 4.5rem) clamp(1.25rem, 3vw, 2.25rem);
+  }
+
+  .holding-page__brand img {
+    display: block;
+    width: clamp(7.5rem, 14vw, 9.5rem);
+    height: auto;
+    color: rgb(var(--reading-ink));
+  }
+
+  .holding-page__content {
+    align-self: center;
+    max-width: 45rem;
+    padding: clamp(4rem, 10vh, 7.5rem) 0 clamp(5rem, 12vh, 8rem);
+  }
+
+  .holding-page__signal {
+    display: block;
+    width: 3.25rem;
+    height: 0.25rem;
+    margin-bottom: clamp(1.4rem, 3vw, 2rem);
+    border-radius: 999px;
+    background: rgb(var(--accent-primary));
+  }
+
+  .holding-page h1 {
+    max-width: 42rem;
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(2.4rem, 6vw, 4.6rem);
+    font-weight: 600;
+    line-height: 1.04;
+    letter-spacing: -0.055em;
+    text-wrap: balance;
+  }
+
+  .holding-page__copy {
+    display: grid;
+    gap: 1rem;
+    max-width: 42rem;
+    margin-top: clamp(1.7rem, 4vw, 2.6rem);
+    color: rgb(var(--reading-ink-secondary));
+    font-size: clamp(1.05rem, 2vw, 1.2rem);
+    line-height: 1.65;
+  }
+
+  .holding-page__copy p,
+  .holding-page__contact {
+    margin: 0;
+  }
+
+  .holding-page__contact {
+    max-width: 42rem;
+    margin-top: clamp(2rem, 5vw, 3rem);
+    padding-top: 1.25rem;
+    border-top: 1px solid rgb(var(--border) / 0.72);
+    font-size: clamp(1rem, 1.8vw, 1.1rem);
+    line-height: 1.6;
+  }
+
+  .holding-page__contact a {
+    color: rgb(var(--reading-ink));
+    font-weight: 600;
+    text-decoration-color: rgb(var(--accent-primary) / 0.65);
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.2em;
+  }
+
+  .holding-page__contact a:hover {
+    text-decoration-color: rgb(var(--accent-primary));
+  }
+
+  .holding-page__contact a:focus-visible {
+    border-radius: 2px;
+    outline: 3px solid rgb(var(--focus-ring) / 0.38);
+    outline-offset: 4px;
+  }
+
+  .holding-page__footer {
+    padding-top: 1rem;
+    border-top: 1px solid rgb(var(--border) / 0.5);
+    color: rgb(var(--reading-ink-secondary));
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  @media (max-width: 639px) {
+    .holding-page__frame {
+      padding-top: 1.4rem;
+    }
+
+    .holding-page__content {
+      align-self: start;
+      padding-top: clamp(4.5rem, 14vh, 7rem);
+    }
+
+    .holding-page h1 {
+      font-size: clamp(2.25rem, 11vw, 3.25rem);
+      line-height: 1.07;
+    }
+  }
+
+</style>


### PR DESCRIPTION
## Hva\n- erstatter redirecten fra / til /no med en kort offentlig Viddel-presentasjon\n- gjenbruker produksjonstokens, Epilogue/Inter og godkjent Viddel-wordmark\n- holder produktnavigasjon, CES, utviklerverktøy og lenker til /no utenfor rotforsiden\n- legger inn kontakt@viddel.no, metadata og canonical\n- oppdaterer VIS current-state med den nye offentlige flaten\n\n## Verifisering\n- npm run build\n- lokal HTTP-kontroll: 200 OK, ingen redirect\n- responsiv layout kontrollert ved mobil- og desktopmål\n\n## Avgrensning\n- /no og øvrige produktruter er uendret\n- ingen backend-, miljø- eller analyseendringer