### PR TITLE
Min status til audiograf — deterministisk syntetisk datakontrakt

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs && node --experimental-strip-types scripts/verify-backstage-guard.mjs && node --experimental-strip-types scripts/verify-vis-runtime-feed.mjs && node --experimental-strip-types scripts/verify-lab-gate.mjs && astro build",
+    "build": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs && node --experimental-strip-types scripts/verify-backstage-guard.mjs && node --experimental-strip-types scripts/verify-vis-runtime-feed.mjs && node --experimental-strip-types scripts/verify-lab-gate.mjs && node --experimental-strip-types scripts/verify-status-audiologist-prototype.mjs && astro build",
     "verify:vis-sprint-guard": "node --experimental-strip-types scripts/verify-vis-sprint-guard.mjs",
     "verify:backstage-guard": "node --experimental-strip-types scripts/verify-backstage-guard.mjs",
     "verify:vis-runtime-feed": "node --experimental-strip-types scripts/verify-vis-runtime-feed.mjs",
+    "verify:status-audiologist": "node --experimental-strip-types scripts/verify-status-audiologist-prototype.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "storyblok:bootstrap:slice01": "node scripts/storyblok-bootstrap-slice-01.mjs",

--- a/scripts/verify-status-audiologist-prototype.mjs
+++ b/scripts/verify-status-audiologist-prototype.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { conversationPrototypeData } from "../src/data/conversation-prototype-v01.ts";
+import {
+  countStatusPointsInRange,
+  getStatusPeriodRange,
+  getStatusPointSources,
+  statusDraftGroups,
+} from "../src/data/status-audiologist-prototype-v01.ts";
+
+const conversationsById = new Map(conversationPrototypeData.map((conversation) => [conversation.id, conversation]));
+const points = statusDraftGroups.flatMap((group) => group.points);
+
+for (const point of points) {
+  assert.ok(point.sourceConversationIds.length, `${point.id} mangler kildesamtale`);
+  for (const sourceId of point.sourceConversationIds) {
+    assert.ok(conversationsById.has(sourceId), `${point.id} peker til ukjent samtale ${sourceId}`);
+  }
+}
+
+const defaultRange = getStatusPeriodRange("30-days");
+assert.equal(countStatusPointsInRange(defaultRange), 6, "Standardperioden skal gi seks statuspunkter");
+
+const narrowRange = getStatusPeriodRange("custom", "2026-07-24", "2026-07-31");
+assert.equal(countStatusPointsInRange(narrowRange), 5, "Smal periode skal filtrere bort musikkpunktet");
+
+const settings = points.find((point) => point.id === "settings");
+assert.ok(settings, "Innstillingspunktet mangler");
+assert.deepEqual(
+  getStatusPointSources(settings, narrowRange).map((source) => source.id),
+  ["sharp-sound"],
+  "Et punkt med flere kilder skal bare vise kilder innenfor valgt periode",
+);
+
+console.log("Status til audiograf datakontrakt OK");

--- a/src/components/conversation/StatusToAudiologist.astro
+++ b/src/components/conversation/StatusToAudiologist.astro
@@ -1,51 +1,13 @@
 ---
-const groups = [
-  {
-    title: "Dette har vært vanskelig",
-    points: [
-      {
-        id: "sharp-sounds",
-        text: "Bestikk og tallerkener oppleves skarpe og ubehagelige.",
-        source: "Fra «Lyden blir skarp av bestikk og tallerkener» · 31. juli",
-      },
-      {
-        id: "meetings",
-        text: "Møter blir krevende når flere snakker samtidig.",
-        source: "Fra «Hvordan sier jeg fra på jobb?» · 24. juli",
-      },
-      {
-        id: "music",
-        text: "Musikk låter flatere med de nye høreapparatene.",
-        source: "Fra «De nye apparatene høres rare ut» · 18. juli",
-      },
-    ],
-  },
-  {
-    title: "Dette har jeg prøvd",
-    points: [
-      {
-        id: "meeting-position",
-        text: "Jeg har forsøkt å sitte nærmere dem som snakker i møter.",
-        source: "Fra «Hvordan sier jeg fra på jobb?» · 24. juli",
-      },
-    ],
-  },
-  {
-    title: "Dette vil jeg ta opp",
-    points: [
-      {
-        id: "settings",
-        text: "Om innstillingene kan justeres for musikk og skarpe hverdagslyder.",
-        source: "Fra to samtaler · 18. og 31. juli",
-      },
-      {
-        id: "next-appointment",
-        text: "Hva jeg bør følge med på før neste time.",
-        source: "Fra «Hva bør jeg ta opp med audiografen?» · 31. juli",
-      },
-    ],
-  },
-];
+import { conversationPrototypeData } from "../../data/conversation-prototype-v01";
+import {
+  formatStatusPointSource,
+  getStatusPeriodRange,
+  getStatusPointSources,
+  statusDraftGroups,
+} from "../../data/status-audiologist-prototype-v01";
+
+const initialRange = getStatusPeriodRange("30-days");
 ---
 
 <section class="status-workspace" data-status-workspace aria-labelledby="status-workspace-title">
@@ -85,15 +47,15 @@ const groups = [
         <legend>Periode</legend>
         <div class="status-period-options">
           <label>
-            <input type="radio" name="status-period" value="Siste 30 dager" checked />
+            <input type="radio" name="status-period" value="30-days" checked />
             <span>Siste 30 dager</span>
           </label>
           <label>
-            <input type="radio" name="status-period" value="Siste 3 måneder" />
+            <input type="radio" name="status-period" value="90-days" />
             <span>Siste 3 måneder</span>
           </label>
           <label>
-            <input type="radio" name="status-period" value="Egendefinert periode" />
+            <input type="radio" name="status-period" value="custom" />
             <span>Velg datoer</span>
           </label>
         </div>
@@ -112,17 +74,24 @@ const groups = [
     <section class="status-panel" data-status-panel="2" aria-labelledby="status-draft-title" hidden>
       <div class="status-panel__intro">
         <h2 id="status-draft-title">Se gjennom utkastet</h2>
-        <p><span data-status-period-label>Siste 30 dager</span> · 6 foreslåtte punkter</p>
+        <p><span data-status-period-label>Siste 30 dager</span> · <span data-status-point-count>6</span> foreslåtte punkter</p>
         <p>Alt er valgt nå. Fjern det som ikke passer, og skriv om resten.</p>
       </div>
 
       {
-        groups.map((group) => (
+        statusDraftGroups.map((group) => (
           <fieldset class="status-section" data-status-group={group.title}>
             <legend>{group.title}</legend>
             <div class="status-points">
-              {group.points.map((point) => (
-                <div class="status-point" data-status-point>
+              {group.points.map((point) => {
+                const sources = getStatusPointSources(point, initialRange, conversationPrototypeData);
+                return (
+                <div
+                  class="status-point"
+                  data-status-point
+                  data-status-point-id={point.id}
+                  data-status-source-ids={point.sourceConversationIds.join(",")}
+                >
                   <label class="status-point__include">
                     <input type="checkbox" checked data-status-include />
                     <span>Ta med</span>
@@ -131,9 +100,10 @@ const groups = [
                     Rediger statuspunkt
                   </label>
                   <textarea id={`status-${point.id}`} rows="2" data-status-text>{point.text}</textarea>
-                  <p>{point.source}</p>
+                  <p data-status-source>{formatStatusPointSource(sources)}</p>
                 </div>
-              ))}
+                );
+              })}
             </div>
           </fieldset>
         ))

--- a/src/data/status-audiologist-prototype-v01.ts
+++ b/src/data/status-audiologist-prototype-v01.ts
@@ -1,0 +1,130 @@
+import {
+  conversationPrototypeData,
+  conversationPrototypeNow,
+  type ConversationPrototype,
+} from "./conversation-prototype-v01.ts";
+
+export type StatusDraftPoint = {
+  id: string;
+  text: string;
+  sourceConversationIds: string[];
+};
+
+export type StatusDraftGroup = {
+  title: string;
+  points: StatusDraftPoint[];
+};
+
+export type StatusPeriodMode = "30-days" | "90-days" | "custom";
+
+export type StatusPeriodRange = {
+  from: string;
+  to: string;
+};
+
+export const statusDraftGroups: StatusDraftGroup[] = [
+  {
+    title: "Dette har vært vanskelig",
+    points: [
+      {
+        id: "sharp-sounds",
+        text: "Bestikk og tallerkener oppleves skarpe og ubehagelige.",
+        sourceConversationIds: ["sharp-sound"],
+      },
+      {
+        id: "meetings",
+        text: "Møter blir krevende når flere snakker samtidig.",
+        sourceConversationIds: ["work"],
+      },
+      {
+        id: "music",
+        text: "Musikk låter flatere med de nye høreapparatene.",
+        sourceConversationIds: ["devices"],
+      },
+    ],
+  },
+  {
+    title: "Dette har jeg prøvd",
+    points: [
+      {
+        id: "meeting-position",
+        text: "Jeg har forsøkt å sitte nærmere dem som snakker i møter.",
+        sourceConversationIds: ["work"],
+      },
+    ],
+  },
+  {
+    title: "Dette vil jeg ta opp",
+    points: [
+      {
+        id: "settings",
+        text: "Om innstillingene kan justeres for musikk og skarpe hverdagslyder.",
+        sourceConversationIds: ["devices", "sharp-sound"],
+      },
+      {
+        id: "next-appointment",
+        text: "Hva jeg bør følge med på før neste time.",
+        sourceConversationIds: ["audiologist"],
+      },
+    ],
+  },
+];
+
+const dateKey = (iso: string) => iso.slice(0, 10);
+
+const shiftDateKey = (key: string, days: number) => {
+  const [year, month, day] = key.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return date.toISOString().slice(0, 10);
+};
+
+export function getStatusPeriodRange(
+  mode: StatusPeriodMode,
+  customFrom = "2026-07-01",
+  customTo = "2026-07-31",
+  now = conversationPrototypeNow,
+): StatusPeriodRange {
+  if (mode === "custom") return { from: customFrom, to: customTo };
+  const to = dateKey(now);
+  return { from: shiftDateKey(to, mode === "30-days" ? -29 : -89), to };
+}
+
+export function getStatusPointSources(
+  point: StatusDraftPoint,
+  range: StatusPeriodRange,
+  conversations: ConversationPrototype[] = conversationPrototypeData,
+) {
+  const sourceIds = new Set(point.sourceConversationIds);
+  return conversations
+    .filter((conversation) => sourceIds.has(conversation.id))
+    .filter((conversation) => {
+      const key = dateKey(conversation.updatedAt);
+      return key >= range.from && key <= range.to;
+    })
+    .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+}
+
+const formatSourceDate = (iso: string) =>
+  new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+    timeZone: "Europe/Oslo",
+  }).format(new Date(iso));
+
+export function formatStatusPointSource(sources: ConversationPrototype[]) {
+  if (sources.length === 1) {
+    return `Fra «${sources[0].title}» · ${formatSourceDate(sources[0].updatedAt)}`;
+  }
+  const dates = sources.map((source) => formatSourceDate(source.updatedAt));
+  const dateList = dates.length === 2 ? dates.join(" og ") : `${dates.slice(0, -1).join(", ")} og ${dates.at(-1)}`;
+  return `Fra ${sources.length === 2 ? "to" : sources.length} samtaler · ${dateList}`;
+}
+
+export function countStatusPointsInRange(
+  range: StatusPeriodRange,
+  groups: StatusDraftGroup[] = statusDraftGroups,
+  conversations: ConversationPrototype[] = conversationPrototypeData,
+) {
+  return groups.flatMap((group) => group.points).filter((point) => getStatusPointSources(point, range, conversations).length)
+    .length;
+}

--- a/src/pages/no/samtaler.astro
+++ b/src/pages/no/samtaler.astro
@@ -54,6 +54,14 @@ const groups = groupPrototypeConversations(conversationPrototypeData);
   <script>
     import { initChatAttachmentMenu } from "../../lib/chat-image-attachment-menu-v01";
     import { validateChatImageFile } from "../../lib/chat-image-file-v01";
+    import { conversationPrototypeData } from "../../data/conversation-prototype-v01";
+    import {
+      formatStatusPointSource,
+      getStatusPeriodRange,
+      getStatusPointSources,
+      type StatusDraftPoint,
+      type StatusPeriodMode,
+    } from "../../data/status-audiologist-prototype-v01";
 
     (() => {
       const root = document.querySelector<HTMLElement>("[data-conversation-area]");
@@ -144,23 +152,52 @@ const groups = groupPrototypeConversations(conversationPrototypeData);
         const customPeriod = statusWorkspace.querySelector<HTMLElement>("[data-status-custom-period]");
         const preview = statusWorkspace.querySelector<HTMLElement>("[data-status-preview]");
 
-        const periodText = () => {
+        const selectedPeriodMode = () => {
           const selected = statusWorkspace.querySelector<HTMLInputElement>('input[name="status-period"]:checked');
-          if (!selected || selected.value !== "Egendefinert periode") return selected?.value || "Siste 30 dager";
+          return (selected?.value || "30-days") as StatusPeriodMode;
+        };
+
+        const periodText = () => {
+          const mode = selectedPeriodMode();
+          if (mode !== "custom") return mode === "90-days" ? "Siste 3 måneder" : "Siste 30 dager";
           const from = statusWorkspace.querySelector<HTMLInputElement>("[data-status-from]");
           const to = statusWorkspace.querySelector<HTMLInputElement>("[data-status-to]");
           return `${from?.value || "Fra dato"}–${to?.value || "til dato"}`;
         };
 
         const syncPeriod = () => {
-          const selected = statusWorkspace.querySelector<HTMLInputElement>('input[name="status-period"]:checked');
-          if (customPeriod) customPeriod.hidden = selected?.value !== "Egendefinert periode";
+          const mode = selectedPeriodMode();
+          if (customPeriod) customPeriod.hidden = mode !== "custom";
+          const from = statusWorkspace.querySelector<HTMLInputElement>("[data-status-from]")?.value;
+          const to = statusWorkspace.querySelector<HTMLInputElement>("[data-status-to]")?.value;
+          const range = getStatusPeriodRange(mode, from, to);
           const label = periodText();
           statusWorkspace.querySelectorAll<HTMLElement>("[data-status-period-label]").forEach((node) => {
             node.textContent = label;
           });
           const previewPeriod = statusWorkspace.querySelector<HTMLElement>("[data-status-preview-period]");
           if (previewPeriod) previewPeriod.textContent = label;
+
+          let pointCount = 0;
+          statusWorkspace.querySelectorAll<HTMLElement>("[data-status-point]").forEach((point) => {
+            const sourceConversationIds = (point.dataset.statusSourceIds || "").split(",").filter(Boolean);
+            const pointContract: StatusDraftPoint = {
+              id: point.dataset.statusPointId || "",
+              text: "",
+              sourceConversationIds,
+            };
+            const sources = getStatusPointSources(pointContract, range, conversationPrototypeData);
+            point.hidden = !sources.length;
+            if (sources.length) pointCount += 1;
+            const source = point.querySelector<HTMLElement>("[data-status-source]");
+            if (source && sources.length) source.textContent = formatStatusPointSource(sources);
+          });
+          statusWorkspace.querySelectorAll<HTMLElement>("[data-status-group]").forEach((group) => {
+            group.hidden = !group.querySelector<HTMLElement>("[data-status-point]:not([hidden])");
+          });
+          statusWorkspace.querySelectorAll<HTMLElement>("[data-status-point-count]").forEach((node) => {
+            node.textContent = String(pointCount);
+          });
         };
 
         const renderPreview = () => {
@@ -170,6 +207,7 @@ const groups = groupPrototypeConversations(conversationPrototypeData);
 
           statusWorkspace.querySelectorAll<HTMLElement>("[data-status-group]").forEach((group) => {
             const texts = Array.from(group.querySelectorAll<HTMLElement>("[data-status-point]")).flatMap((point) => {
+              if (point.hidden) return [];
               const include = point.querySelector<HTMLInputElement>("[data-status-include]");
               const text = point.querySelector<HTMLTextAreaElement>("[data-status-text]");
               return include?.checked && text?.value.trim() ? [text.value.trim()] : [];


### PR DESCRIPTION
## Hva

Gjør den godkjente statusflyten teknisk etterprøvbar uten backend eller persistens.

- statuspunkter peker eksplisitt til syntetiske samtale-ID-er
- valgt periode filtrerer både punkter og kildesamtaler deterministisk
- antall foreslåtte punkter og kildetekst kommer fra samme datagrunnlag
- lokale valg og redigeringer beholdes som før
- en liten byggsjekk hindrer ukjente kilde-ID-er og brudd i standardperioden

## Avgrensning

Ingen database, autentisering, reell samtalehistorikk, lagring, eksport, deling eller visuell redesign.

## Verifisert

- egen datakontraktsjekk er grønn
- full bygg er grønn
- lokal nettleserkontroll: 24.–31. juli gir fem punkter; musikkpunktet faller ut; fler-kildepunktet viser bare kilden innenfor perioden
- layout og eksisterende semantiske tokens er uendret

Closes #301
Relatert: #283, #299, #105

Stoppunkt: Thomas vurderer preview før merge.